### PR TITLE
Dynamic Mock Limits in Dev Server

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -79,6 +79,7 @@ Below are the available scripts:
   - Uses mocked responses for all functions in `./src/storage.js` to avoid having to contact Google Storage APIs.
   - Spins up a mock GitHub API Server to respond to requests from `git.js` (Only when running tests located in `./src/tests_integration/git.js`).
 * `start:dev`: This can be used for local development of the backend if you don't have access to the production database. This will spin up a local Database using Docker and will mock external requests for all other services such as GitHub and Google Storage.
+  - When using `start:dev` you have additional options available to limit what is mocked, available [below](#limitingwhatsmockedinthedevserver).
   - Sets `PULSAR_STATUS=dev`
   - Starts up the server using `./src/dev_server.js` instead of `./src/server.js`
   - Requires the ability to spin up a local Database that it will connect to, ignoring the values in your `app.yaml`
@@ -94,6 +95,21 @@ There are some additional scripts that you likely won't encounter or need during
 * `contributors:add`: Uses `all-contributors` to add a new contributor to the README.md
 * `test_search`: Uses the `./scripts/tools/search.js` to run the different search methods against a pre-set amount of data, and return the scores. It's important to note, that these search algorithms are no longer used within the backend in favour of natively supported Fuzzy Matching.
 * `migrations`: This is used by `@database/pg-migrations` to run the SQL scripts found in `./src/dev-runner/migrations/001-initial-migration.sql` to populate the local database when in use by certain scripts mentioned above.
+
+#### Limiting what's mocked in the dev server
+
+No additionally, when working locally if you need to test a feature where you have no option but to query the remote service (This is not recommended) you do have the option to enable some remote services as needed.
+
+Again setting any of the below values will contact remote services, meaning you must have the proper Configuration Values set to do so, and you become at risk of causing damage to external data, any deletions that occur here will cause permanent data loss to these services. Or may get you blocked by remote services if there is abuse.
+
+The following values can only ever be started when using `npm run start:dev` and will be ignored in all other instances.
+
+To use any of the following you need to ensure they are passed through the `npm run ...` script by using `npm run start:dev -- YOUR_ARG`
+
+* `--gh`: This will set the environment variable `MOCK_GH` to false, ensuring any requests made in the dev server actually reach out to GitHub ignoring all local development data and logic.
+* `--google`: This will set the environment variable `MOCK_GOOGLE` to false, ensuring any requests made in the dev server actually reach out to Google, ignoring all local development data and logic.
+* `--db`: This will set the environment variable `MOCK_DB` to false, ensuring any requests made in the dev server actually reach out to your DB instance, ignoring all local development data and logic.
+* `--auth`: This will set the environment variable `MOCK_AUTH` to false, ensuring any requests made in the dev server for authentication actually rely on the user within the database (dev or otherwise) and actually reach out to GitHub (dev or otherwise).
 
 ## Development with a Local Database
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -27,7 +27,7 @@ async function verifyAuth(token) {
   try {
     let user_data;
 
-    if (process.env.PULSAR_STATUS == "dev") {
+    if (process.env.PULSAR_STATUS == "dev" && process.env.MOCK_AUTH != 'false') {
       // Server is in developer mode.
       logger.generic(3, "auth.verifyAuth() is returning Dev Only Permissions!");
 

--- a/src/database.js
+++ b/src/database.js
@@ -32,7 +32,7 @@ let sqlStorage; // SQL object, to interact with the DB.
  * @returns {object} PostgreSQL connection object.
  */
 function setupSQL() {
-  return process.env.PULSAR_STATUS === "dev"
+  return process.env.PULSAR_STATUS === "dev" && process.env.MOCK_DB != 'false'
     ? postgres({
         host: DB_HOST,
         username: DB_USER,

--- a/src/dev_server.js
+++ b/src/dev_server.js
@@ -13,44 +13,53 @@ const dbSetup = require("../node_modules/@databases/pg-test/jest/globalSetup");
 const dbTeardown = require("../node_modules/@databases/pg-test/jest/globalTeardown");
 
 async function test() {
-  await dbSetup();
+  await processArgs();
 
-  // lets take the value made by the test runner database, and put it where the api server expects.
-  let db_url = process.env.DATABASE_URL;
-  // this gives us something like postgres://test-user@localhost:5432/test-db
-  // We then need to map these values to where the API server expects,
-  let db_url_reg = /postgres:\/\/([\/\S]+)@([\/\S]+):(\d+)\/([\/\S]+)/;
-  let db_url_parsed = db_url_reg.exec(db_url);
+  if (process.env.MOCK_DB != 'false') {
+    // We only Mock the Database if our argument flags permit.
+    console.log("Setting up Database Mock");
 
-  // set the parsed URL as proper env
-  process.env.DB_HOST = db_url_parsed[2];
-  process.env.DB_USER = db_url_parsed[1];
-  process.env.DB_DB = db_url_parsed[4];
-  process.env.DB_PORT = db_url_parsed[3];
+    await dbSetup();
 
-  // Then since we want to make sure we don't initialize the config module, before we have set our values,
-  // we will define our own port to use here.
-  process.env.PORT = 8080;
+    // lets take the value made by the test runner database, and put it where the api server expects.
+    let db_url = process.env.DATABASE_URL;
+    // this gives us something like postgres://test-user@localhost:5432/test-db
+    // We then need to map these values to where the API server expects,
+    let db_url_reg = /postgres:\/\/([\/\S]+)@([\/\S]+):(\d+)\/([\/\S]+)/;
+    let db_url_parsed = db_url_reg.exec(db_url);
+
+    // set the parsed URL as proper env
+    process.env.DB_HOST = db_url_parsed[2];
+    process.env.DB_USER = db_url_parsed[1];
+    process.env.DB_DB = db_url_parsed[4];
+    process.env.DB_PORT = db_url_parsed[3];
+
+    // Then since we want to make sure we don't initialize the config module, before we have set our values,
+    // we will define our own port to use here.
+    process.env.PORT = 8080;
+  }
 
   const app = require("./main.js");
   const logger = require("./logger.js");
   const database = require("./database.js");
   // We can only require these items after we have set our env variables
 
-  logger.generic(
-    3,
-    "Pulsar Server is in Development Mode with a Local Database!"
-  );
+  if (process.env.MOCK_DB != 'false') {
+    logger.generic(
+      3,
+      "Pulsar Server is in Development Mode with a Local Database!"
+    );
 
-  logger.generic(6, "Dev DB Configured Environment Variables.", {
-    type: "object",
-    obj: {
-      host: process.env.DB_HOST,
-      user: process.env.DB_USER,
-      database: process.env.DB_DB,
-      port: process.env.DB_PORT,
-    },
-  });
+    logger.generic(6, "Dev DB Configured Environment Variables.", {
+      type: "object",
+      obj: {
+        host: process.env.DB_HOST,
+        user: process.env.DB_USER,
+        database: process.env.DB_DB,
+        port: process.env.DB_PORT,
+      },
+    });
+  }
 
   const serve = app.listen(process.env.PORT, () => {
     logger.generic(3, `Pulsar Server Listening on port ${process.env.PORT}`);
@@ -82,6 +91,31 @@ async function localExterminate(callee, serve, db) {
   serve.close(() => {
     console.log("HTTP Server Closed.");
   });
+}
+
+async function processArgs() {
+  let rawArgs = process.argv.slice(2);
+
+  for (let i = 0; i < rawArgs.length; i++) {
+    if (rawArgs[i] == "--gh") {
+      console.log("Setting No Mock GitHub");
+      process.env.MOCK_GH = 'false';
+    }
+    if (rawArgs[i] == "--google") {
+      console.log("Setting No Mock Google");
+      process.env.MOCK_GOOGLE = 'false';
+    }
+    if (rawArgs[i] == "--db") {
+      console.log("Setting No Mock Database");
+      process.env.MOCK_DB = 'false';
+    }
+    if (rawArgs[i] == "--auth") {
+      console.log("Setting No Mock Authentication");
+      process.env.MOCK_AUTH = 'false';
+    }
+  }
+
+  return;
 }
 
 test();

--- a/src/git.js
+++ b/src/git.js
@@ -48,7 +48,7 @@ function setGHAPIURL(val) {
 async function ownership(user, repo, dev_override = false) {
   // user here is a full fledged user object. And repo is a text representation of the repository.
   // Since git auth is not setup, this will return positive.
-  if (process.env.PULSAR_STATUS == "dev" && !dev_override) {
+  if (process.env.PULSAR_STATUS == "dev" && !dev_override && process.env.MOCK_GH != 'false') {
     console.log(
       `git.js.Ownership() Is returning Dev Only Permissions for ${logger.sanitizeLogs(
         user.username

--- a/src/storage.js
+++ b/src/storage.js
@@ -42,7 +42,8 @@ async function getBanList() {
     if (
       GCLOUD_STORAGE_BUCKET === undefined ||
       GOOGLE_APPLICATION_CREDENTIALS === undefined ||
-      process.env.PULSAR_STATUS == "dev"
+      process.env.PULSAR_STATUS == "dev" &&
+      process.env.MOCK_GOOGLE != 'false'
     ) {
       // This catches the instance when tests are being run, without access
       // or good reason to reach to 3rd party servers.
@@ -95,7 +96,8 @@ async function getFeaturedPackages() {
     if (
       GCLOUD_STORAGE_BUCKET === undefined ||
       GOOGLE_APPLICATION_CREDENTIALS === undefined ||
-      process.env.PULSAR_STATUS == "dev"
+      process.env.PULSAR_STATUS == "dev" &&
+      process.env.MOCK_GOOGLE != 'false'
     ) {
       // This catches the instance when tests are being run, without access
       // or good reason to reach to 3rd party servers.
@@ -149,7 +151,8 @@ async function getFeaturedThemes() {
     if (
       GCLOUD_STORAGE_BUCKET === undefined ||
       GOOGLE_APPLICATION_CREDENTIALS === undefined ||
-      process.env.PULSAR_STATUS == "dev"
+      process.env.PULSAR_STATUS == "dev" &&
+      process.env.MOCK_GOOGLE != 'false'
     ) {
       // This catches the instance when tests are being run, without access
       // or good reason to reach to 3rd party servers.


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This PR adds new features to the dev instance of the server. Allowing the developer to limit what's mocked during the dev server being run.

This can be extremely useful when testing new features or code that has no other option but to reach out to remote services. This is not recommended and should be avoided at all costs, but if you must, then now it's possible.

When using `npm run start:dev` the server used to force mocks of all external systems, never letting a network request leave your system, but now you are able to disable some mocks as needed with the following flags.

* `--gh`: Disables Mocks to GitHub Services.
* `--db`: Disables Mocks to the Database
* `--auth`: Disables Mocks relating to authentication
* `--google`: Disables Mocks to Google.

All the above can be used like so:

```bash
npm run start:dev -- --gh
npm run start:dev -- --google
npm run start:dev -- --google --gh --db
```

Using these will assume you have the proper access to resources and proper configuration values set in your `app.yaml`, if you use these you are at risk for causing permanent damage to remote services data, being blocked by remote services for abuse, and anything else that comes with programmatically calling out to remote services.

I'll say again this is not recommended and should only be used by those very familiar with the full workings of the backend, but they are available.