### PR TITLE
More robust owner/repo retrieving + SQL query optimization

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -418,15 +418,6 @@ async function getPackageByName(name, user = false) {
   try {
     sqlStorage ??= setupSQL();
 
-    // While this query achieves the same as the one below it, there is about .1ms saved.
-    //const command = await sqlStorage`
-    //  SELECT p.*, JSON_AGG(v.*) FROM packages p JOIN versions v ON p.pointer = v.package
-    //  WHERE pointer IN (
-    //    SELECT pointer FROM names WHERE name = ${name}
-    //  )
-    //  GROUP BY p.pointer, v.package;
-    //`;
-
     const command = await sqlStorage`
       SELECT
         ${
@@ -505,14 +496,9 @@ async function getPackageVersionByNameAndVersion(name, version) {
     sqlStorage ??= setupSQL();
 
     const command = await sqlStorage`
-      SELECT semver, status, license, engine, meta
-      FROM versions
-      WHERE package IN (
-        SELECT pointer
-        FROM names
-        WHERE name = ${name}
-      )
-      AND semver = ${version} AND status != 'removed';
+      SELECT v.semver, v.status, v.license, v.engine, v.meta
+      FROM packages p INNER JOIN names n ON (p.pointer = n.pointer AND n.name = ${name})
+        INNER JOIN versions v ON (p.pointer = v.package AND semver = ${version} AND status != 'removed');
     `;
 
     return command.count !== 0
@@ -543,12 +529,9 @@ async function getPackageCollectionByName(packArray) {
     // which process the returned content with constructPackageObjectShort(),
     // we select only the needed columns.
     const command = await sqlStorage`
-      SELECT p.data, p.downloads, (p.stargazers_count + p.original_stargazers) AS stargazers_count, v.semver
-      FROM packages AS p INNER JOIN versions AS v ON (p.pointer = v.package) AND (v.status = 'latest')
-      WHERE pointer IN (
-        SELECT pointer FROM names
-        WHERE name IN ${sqlStorage(packArray)}
-      )
+    SELECT p.data, p.downloads, (p.stargazers_count + p.original_stargazers) AS stargazers_count, v.semver
+    FROM packages p INNER JOIN names n ON (p.pointer = n.pointer AND n.name IN ${sqlStorage(packArray)})
+      INNER JOIN versions v ON (p.pointer = v.package AND v.status = 'latest');
     `;
 
     return command.count !== 0

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -889,7 +889,7 @@ async function deletePackageVersion(req, res) {
 
   const gitowner = await git.ownership(
     user.content,
-    utils.getOwnerRepoFromUrlString(packageExists.content.data.repository.url)
+    utils.getOwnerRepoFromPackage(packageExists.content.data)
   );
 
   if (!gitowner.ok) {

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -889,7 +889,7 @@ async function deletePackageVersion(req, res) {
 
   const gitowner = await git.ownership(
     user.content,
-    utils.getOwnerRepoFromURL(packageExists.content.data.repository.url)
+    utils.getOwnerRepoFromUrlString(packageExists.content.data.repository.url)
   );
 
   if (!gitowner.ok) {

--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -6,18 +6,18 @@ const utils = require("../utils.js");
 describe("isPackageNameBanned Tests", () => {
   test("Returns true correctly for banned item", async () => {
     getBanList.mockResolvedValue({ ok: true, content: ["banned-item"] });
-    let name = "banned-item";
+    const name = "banned-item";
 
-    let isBanned = await utils.isPackageNameBanned(name);
+    const isBanned = await utils.isPackageNameBanned(name);
 
     expect(isBanned.ok).toBeTruthy();
   });
 
   test("Returns false correctly for non-banned item", async () => {
     getBanList.mockResolvedValue({ ok: true, content: ["banned-item"] });
-    let name = "not-banned-item";
+    const name = "not-banned-item";
 
-    let isBanned = await utils.isPackageNameBanned(name);
+    const isBanned = await utils.isPackageNameBanned(name);
 
     expect(isBanned.ok).toBeFalsy();
   });
@@ -25,7 +25,7 @@ describe("isPackageNameBanned Tests", () => {
   test("Returns true if no banned list can be retrieved", async () => {
     getBanList.mockResolvedValue({ ok: false });
 
-    let isBanned = await utils.isPackageNameBanned("any");
+    const isBanned = await utils.isPackageNameBanned("any");
 
     expect(isBanned.ok).toBeTruthy();
   });
@@ -33,7 +33,7 @@ describe("isPackageNameBanned Tests", () => {
 
 describe("engineFilter returns version expected.", () => {
   test("Returns First Position when given multiple valid positions.", async () => {
-    let pack = {
+    const pack = {
       versions: {
         "2.0.0": {
           version: "2.0.0",
@@ -50,14 +50,14 @@ describe("engineFilter returns version expected.", () => {
       },
     };
 
-    let engine = "1.5.0";
+    const engine = "1.5.0";
 
-    let res = await utils.engineFilter(pack, engine);
+    const res = await utils.engineFilter(pack, engine);
     expect(res.metadata.version == "2.0.0");
   });
 
   test("Returns Matching version when given an equal upper bound.", async () => {
-    let pack = {
+    const pack = {
       versions: {
         "2.0.0": {
           version: "2.0.0",
@@ -74,14 +74,14 @@ describe("engineFilter returns version expected.", () => {
       },
     };
 
-    let engine = "1.4.9";
+    const engine = "1.4.9";
 
-    let res = await utils.engineFilter(pack, engine);
+    const res = await utils.engineFilter(pack, engine);
     expect(res.metadata.version == "1.9.9");
   });
 
   test("Returns First Matching version on lower bond equal.", async () => {
-    let pack = {
+    const pack = {
       versions: {
         "2.0.0": {
           version: "2.0.0",
@@ -98,22 +98,22 @@ describe("engineFilter returns version expected.", () => {
       },
     };
 
-    let engine = "1.2.3";
+    const engine = "1.2.3";
 
-    let res = await utils.engineFilter(pack, engine);
+    const res = await utils.engineFilter(pack, engine);
     expect(res.metadata.version == "2.0.0");
   });
 
   test("Catches non String correctly", async () => {
-    let pack = {
+    const pack = {
       versions: {
         "1.0.0": {
           version: "1.0.0",
         },
       },
     };
-    let engine = { bad: "engine" };
-    let res = await utils.engineFilter(pack, engine);
+    const engine = { bad: "engine" };
+    const res = await utils.engineFilter(pack, engine);
     expect(res.versions["1.0.0"]).toBeDefined();
     expect(res.versions["1.0.0"].version).toEqual("1.0.0");
   });
@@ -245,68 +245,70 @@ describe("Tests against semverLt", () => {
 
 describe("Tests for getOwnerRepoFromURL", () => {
   test("Returns Owner/repo for valid string", () => {
-    let string = "https://github.com/pulsar-edit/package-backend";
-    let res = utils.getOwnerRepoFromURL(string);
+    const string = "https://github.com/pulsar-edit/package-backend";
+    const res = utils.getOwnerRepoFromURL(string);
     expect(res).toEqual("pulsar-edit/package-backend");
   });
   test("Returns owner/repo for valid string with ending .git", () => {
-    let string = "https://github.com/pulsar-edit/package-frontend.git";
-    let res = utils.getOwnerRepoFromURL(string);
+    const string = "https://github.com/pulsar-edit/package-frontend.git";
+    const res = utils.getOwnerRepoFromURL(string);
     expect(res).toEqual("pulsar-edit/package-frontend");
   });
   test("Returns empty string for invalid repo", () => {
-    let string = "https://github.com/pulsar-edit-I-Am-Not-Valid";
-    let res = utils.getOwnerRepoFromURL(string);
+    const string = "https://github.com/pulsar-edit-I-Am-Not-Valid";
+    const res = utils.getOwnerRepoFromURL(string);
     expect(res).toEqual("");
   });
   test("Returns owner/repo for another valid string", () => {
-    let string = "https://github.com/confused-Techie/atom-backend";
-    let res = utils.getOwnerRepoFromURL(string);
+    const string = "https://github.com/confused-Techie/atom-backend";
+    const res = utils.getOwnerRepoFromURL(string);
     expect(res).toEqual("confused-Techie/atom-backend");
   });
   test("Returns owner/repo for valid string with special characters", () => {
-    let string = "https://github.com/confused-Techi_e/atom_-.backend";
-    let res = utils.getOwnerRepoFromURL(string);
+    const string = "https://github.com/confused-Techi_e/atom_-.backend";
+    const res = utils.getOwnerRepoFromURL(string);
     expect(res).toEqual("confused-Techi_e/atom_-.backend");
   });
 });
 
-//describe("Tests against StateStore", () => {
-//  test("Returns a State when handed an IP", () => {
-//    let stateStore = new utils.StateStore();/
+/*
+describe("Tests against StateStore", () => {
+  test("Returns a State when handed an IP", () => {
+    const stateStore = new utils.StateStore();/
 
-//  return stateStore.setState("8.8.8.8").then((res) => {
-//    expect(res.ok).toBeTruthy();
-//    expect(res.content).toBeDefined();
-//  });
-//});
-//test("Returns Bad OK When no IP is in Hashmap", () => {
-//  let stateStore = new utils.StateStore();
-//  let res = stateStore.getState("8.8.8.8", "1234");
-//expect(res.ok).toBeFalsy(); //TODO
-//});
-//test("Returns Good OK When Same state is passed to Hashmap", () => {
-//  let stateStore = new utils.StateStore();/
+  return stateStore.setState("8.8.8.8").then((res) => {
+    expect(res.ok).toBeTruthy();
+    expect(res.content).toBeDefined();
+  });
+});
+test("Returns Bad OK When no IP is in Hashmap", () => {
+  const stateStore = new utils.StateStore();
+  const res = stateStore.getState("8.8.8.8", "1234");
+expect(res.ok).toBeFalsy(); //TODO
+});
+test("Returns Good OK When Same state is passed to Hashmap", () => {
+  const stateStore = new utils.StateStore();/
 
-//    return stateStore.setState("8.8.8.8").then((res) => {
-//      expect(res.ok).toBeTruthy();
-//      expect(res.content).toBeDefined();/
-//
-//      let valid = stateStore.getState("8.8.8.8", res.content);
+    return stateStore.setState("8.8.8.8").then((res) => {
+      expect(res.ok).toBeTruthy();
+      expect(res.content).toBeDefined();/
 
-//      expect(valid.ok).toBeTruthy();
-//    });
-//  });
-//  test("Returns Bad OK When invalid State is passed to Hashmap", () => {
-//    let stateStore = new utils.StateStore();
+      const valid = stateStore.getState("8.8.8.8", res.content);
 
-//    return stateStore.setState("8.8.8.8").then((res) => {
-//      expect(res.ok).toBeTruthy();
-//      expect(res.content).toBeDefined();
+      expect(valid.ok).toBeTruthy();
+    });
+  });
+  test("Returns Bad OK When invalid State is passed to Hashmap", () => {
+    const stateStore = new utils.StateStore();
 
-//      let valid = stateStore.getState("8.8.8.8", "invalid-state");
+    return stateStore.setState("8.8.8.8").then((res) => {
+      expect(res.ok).toBeTruthy();
+      expect(res.content).toBeDefined();
 
-//expect(valid.ok).toBeFalsy(); //TODO
-//    });
-//  });
-//});
+      const valid = stateStore.getState("8.8.8.8", "invalid-state");
+
+expect(valid.ok).toBeFalsy(); //TODO
+    });
+  });
+});
+*/

--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -243,10 +243,35 @@ describe("Tests against semverLt", () => {
   });
 });
 
+describe("Tests for getOwnerRepoFromPackage", () => {
+  test("Returns Owner/repo for repository.url set into the package", () => {
+    const repo = "pulsar-edit/package-backend";
+    const url = `https://github.com/${repo}.git`;
+    const res = utils.getOwnerRepoFromPackage({
+      "repository": { "url": url }
+    });
+    expect(res).toEqual(repo);
+  });
+  test("Returns Owner/repo even when repository.url is not set into the package", () => {
+    const repo = "pulsar-edit/package-backend";
+    const url = `git@github.com:${repo}.git`;
+    const res = utils.getOwnerRepoFromPackage({
+      "metadata": { "repository": url }
+    });
+    expect(res).toEqual(repo);
+  });
+});
+
 describe("Tests for getOwnerRepoFromUrlString", () => {
   test("Returns Owner/repo for valid string", () => {
     const repo = "pulsar-edit/package-backend";
     const url = `https://github.com/${repo}.git`;
+    const res = utils.getOwnerRepoFromUrlString(url);
+    expect(res).toEqual(repo);
+  });
+  test("Returns Owner/repo for valid string in the 'git@' format", () => {
+    const repo = "pulsar-edit/package-backend";
+    const url = `git@github.com:${repo}.git`;
     const res = utils.getOwnerRepoFromUrlString(url);
     expect(res).toEqual(repo);
   });

--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -243,31 +243,35 @@ describe("Tests against semverLt", () => {
   });
 });
 
-describe("Tests for getOwnerRepoFromURL", () => {
+describe("Tests for getOwnerRepoFromUrlString", () => {
   test("Returns Owner/repo for valid string", () => {
-    const string = "https://github.com/pulsar-edit/package-backend";
-    const res = utils.getOwnerRepoFromURL(string);
-    expect(res).toEqual("pulsar-edit/package-backend");
+    const repo = "pulsar-edit/package-backend";
+    const url = `https://github.com/${repo}.git`;
+    const res = utils.getOwnerRepoFromUrlString(url);
+    expect(res).toEqual(repo);
   });
-  test("Returns owner/repo for valid string with ending .git", () => {
-    const string = "https://github.com/pulsar-edit/package-frontend.git";
-    const res = utils.getOwnerRepoFromURL(string);
-    expect(res).toEqual("pulsar-edit/package-frontend");
+  test("Returns owner/repo for valid string even when final .git is missing", () => {
+    const repo = "pulsar-edit/package-frontend";
+    const url = `https://github.com/${repo}`;
+    const res = utils.getOwnerRepoFromUrlString(url);
+    expect(res).toEqual(repo);
   });
   test("Returns empty string for invalid repo", () => {
-    const string = "https://github.com/pulsar-edit-I-Am-Not-Valid";
-    const res = utils.getOwnerRepoFromURL(string);
+    const url = "https://github.com/pulsar-edit-I-Am-Not-Valid.git";
+    const res = utils.getOwnerRepoFromUrlString(url);
     expect(res).toEqual("");
   });
   test("Returns owner/repo for another valid string", () => {
-    const string = "https://github.com/confused-Techie/atom-backend";
-    const res = utils.getOwnerRepoFromURL(string);
-    expect(res).toEqual("confused-Techie/atom-backend");
+    const repo = "confused-Techie/atom-backend";
+    const url = `https://github.com/${repo}.git`;
+    const res = utils.getOwnerRepoFromUrlString(url);
+    expect(res).toEqual(repo);
   });
   test("Returns owner/repo for valid string with special characters", () => {
-    const string = "https://github.com/confused-Techi_e/atom_-.backend";
-    const res = utils.getOwnerRepoFromURL(string);
-    expect(res).toEqual("confused-Techi_e/atom_-.backend");
+    const repo = "confused-Techi_e/atom_-.backend";
+    const url = `https://github.com/${repo}.git`;
+    const res = utils.getOwnerRepoFromUrlString(url);
+    expect(res).toEqual(repo);
   });
 });
 

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -82,17 +82,6 @@ describe("getPackageByName", () => {
   });
 });
 
-describe("getTotalPackageEstimate", () => {
-  test("Should return a successful Server Status Object", async () => {
-    const obj = await database.getTotalPackageEstimate();
-    expect(obj.ok).toBeTruthy();
-  });
-  test.failing("Should return an expected-ish value", async () => {
-    const obj = await database.getTotalPackageEstimate();
-    expect(obj.content.total).toBeGreaterThan(0);
-  });
-});
-
 describe("Package Lifecycle Tests", () => {
   // Below are what we will call lifecycle tests.
   // That is tests that will test multiple actions against the same package,

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -159,7 +159,7 @@ describe("Package Lifecycle Tests", () => {
     expect(
       getByNewName.content.updated >= getAfterPublish.content.updated
     ).toBeTruthy();
-    // For the above expect().getGreaterThan() doesn't support dates.
+    // For the above expect().toBeGreaterThan() doesn't support dates.
 
     // === Can we still get the package by it's old name?
     const getByOldName = await database.getPackageByName(pack.createPack.name);

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -172,6 +172,19 @@ describe("Package Lifecycle Tests", () => {
       `Unable to add the new name: ${pack.createPack.name} is already used.`
     );
 
+    // === Can we get the package collection specifying the old name?
+    const packCollection = await database.getPackageCollectionByName([pack.createPack.name]);
+    expect(packCollection.ok).toBeTruthy();
+    expect(Array.isArray(packCollection.content)).toBeTruthy();
+    for (const p of packCollection.content) {
+      expect(typeof p.data.name === "string").toBeTruthy();
+      // PostgreSQL numeric types are not fully compatible with js Number type
+      expect(`${p.stargazers_count}`.match(/^\d+$/) === null).toBeFalsy();
+      expect(`${p.downloads}`.match(/^\d+$/) === null).toBeFalsy();
+      expect(typeof p.semver === "string").toBeTruthy();
+    }
+
+
     // === Now let's try to delete the only version available.
     // This should fail because the package needs to have at least
     // one published (latest) version.
@@ -229,7 +242,7 @@ describe("Package Lifecycle Tests", () => {
     expect(getNewVerOnly.content.semver).toEqual(v1_0_1.version);
     expect(getNewVerOnly.content.meta.name).toEqual(pack.createPack.name);
 
-    // === Can we get the first verison published still?
+    // === Can we get the first version published still?
     const getOldVerOnly = await database.getPackageVersionByNameAndVersion(
       NEW_NAME,
       pack.createPack.metadata.version

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -116,9 +116,10 @@ describe("Get /api/oauth", () => {
 });
 
 describe("Get /api/packages", () => {
-  test("Should respond with an array of packages.", async () => {
+  test("Should respond with a non empty array of packages.", async () => {
     const res = await request(app).get("/api/packages");
     expect(res.body).toBeArray();
+    expect(res.body.length).toBeGreaterThan(0);
   });
   test("Should return valid Status Code", async () => {
     const res = await request(app).get("/api/packages");
@@ -273,9 +274,10 @@ describe("GET /api/packages/featured", () => {
 });
 
 describe("GET /api/packages/search", () => {
-  test("Valid Search Returns Array", async () => {
+  test("Valid Search Returns Non Empty Array", async () => {
     const res = await request(app).get("/api/packages/search?q=language");
     expect(res.body).toBeArray();
+    expect(res.body.length).toBeGreaterThan(0);
   });
   test("Valid Search Returns Success Status Code", async () => {
     const res = await request(app).get("/api/packages/search?q=language");
@@ -836,16 +838,39 @@ describe("GET /api/themes", () => {
     const res = await request(app).get("/api/themes");
     expect(res).toHaveHTTPCode(200);
   });
-  test("Returns Array", async () => {
+  test("Returns a Non Empty Array", async () => {
     const res = await request(app).get("/api/themes");
     expect(res.body).toBeArray();
+    expect(res.body.length).toBeGreaterThan(0);
+  });
+  test("Should respond with an array containing valid data", async () => {
+    const res = await request(app).get("/api/themes");
+    for (const p of res.body) {
+      expect(typeof p.name === "string").toBeTruthy();
+      // PostgreSQL numeric types are not fully compatible with js Number type
+      expect(`${p.stargazers_count}`.match(/^\d+$/) === null).toBeFalsy();
+      expect(`${p.downloads}`.match(/^\d+$/) === null).toBeFalsy();
+      expect(typeof p.releases.latest === "string").toBeTruthy();
+    }
+  });
+  test("Should respond with an array not containing sensible data", async () => {
+    const res = await request(app).get("/api/themes");
+    for (const p of res.body) {
+      // Use type coercion to catch also undefined
+      expect(p.pointer == null).toBeTruthy();
+    }
+  });
+  test("Should 404 on invalid Method", async () => {
+    const res = await request(app).patch("/api/themes");
+    expect(res).toHaveHTTPCode(404);
   });
 });
 
 describe("GET /api/themes/search", () => {
-  test("Valid search returns array", async () => {
+  test("Valid Search Returns a Non Empty Array", async () => {
     const res = await request(app).get("/api/themes/search?q=syntax");
     expect(res.body).toBeArray();
+    expect(res.body.length).toBeGreaterThan(0);
   });
   test("Valid Search Returns Success Status Code", async () => {
     const res = await request(app).get("/api/themes/search?q=syntax");
@@ -857,7 +882,7 @@ describe("GET /api/themes/search", () => {
       expect(p.pointer == null).toBeTruthy();
     }
   });
-  test("Valid Search returns valid data", async () => {
+  test("Valid Search Returns Valid Ddata", async () => {
     const res = await request(app).get("/api/themes/search?q=syntax");
     for (const p of res.body) {
       expect(typeof p.name === "string").toBeTruthy();

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -142,6 +142,11 @@ describe("Get /api/packages", () => {
       expect(p.pointer == null).toBeTruthy();
     }
   });
+  test("Should respond with the expected headers", async () => {
+    const res = await request(app).get("/api/packages");
+    expect(res.headers["link"].length).toBeGreaterThan(0);
+    expect(res.headers["query-total"].match(/^\d+$/) === null).toBeFalsy();
+  });
   test("Should 404 on invalid Method", async () => {
     const res = await request(app).patch("/api/packages");
     expect(res).toHaveHTTPCode(404);
@@ -299,6 +304,11 @@ describe("GET /api/packages/search", () => {
       // Use type coercion to catch also undefined
       expect(p.pointer == null).toBeTruthy();
     }
+  });
+  test("Valid Search Returns Expected Headers", async () => {
+    const res = await request(app).get("/api/packages/search?q=language");
+    expect(res.headers["link"].length).toBeGreaterThan(0);
+    expect(res.headers["query-total"].match(/^\d+$/) === null).toBeFalsy();
   });
   test("Invalid Search Returns Array", async () => {
     const res = await request(app).get("/api/packages/search?q=not-one-match");
@@ -860,6 +870,11 @@ describe("GET /api/themes", () => {
       expect(p.pointer == null).toBeTruthy();
     }
   });
+  test("Should respond with the expected headers", async () => {
+    const res = await request(app).get("/api/themes");
+    expect(res.headers["link"].length).toBeGreaterThan(0);
+    expect(res.headers["query-total"].match(/^\d+$/) === null).toBeFalsy();
+  });
   test("Should 404 on invalid Method", async () => {
     const res = await request(app).patch("/api/themes");
     expect(res).toHaveHTTPCode(404);
@@ -882,7 +897,7 @@ describe("GET /api/themes/search", () => {
       expect(p.pointer == null).toBeTruthy();
     }
   });
-  test("Valid Search Returns Valid Ddata", async () => {
+  test("Valid Search Returns Valid Data", async () => {
     const res = await request(app).get("/api/themes/search?q=syntax");
     for (const p of res.body) {
       expect(typeof p.name === "string").toBeTruthy();
@@ -890,6 +905,11 @@ describe("GET /api/themes/search", () => {
       expect(`${p.downloads}`.match(/^\d+$/) === null).toBeFalsy();
       expect(typeof p.releases.latest === "string").toBeTruthy();
     }
+  });
+  test("Valid Search Returns Expected Headers", async () => {
+    const res = await request(app).get("/api/themes/search?q=syntax");
+    expect(res.headers["link"].length).toBeGreaterThan(0);
+    expect(res.headers["query-total"].match(/^\d+$/) === null).toBeFalsy();
   });
   test("Invalid Search Returns Array", async () => {
     const res = await request(app).get("/api/themes/search?q=not-one-match");

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -146,6 +146,7 @@ describe("Get /api/packages", () => {
     const res = await request(app).get("/api/packages");
     expect(res.headers["link"].length).toBeGreaterThan(0);
     expect(res.headers["query-total"].match(/^\d+$/) === null).toBeFalsy();
+    expect(res.headers["query-limit"].match(/^\d+$/) === null).toBeFalsy();
   });
   test("Should 404 on invalid Method", async () => {
     const res = await request(app).patch("/api/packages");
@@ -309,6 +310,7 @@ describe("GET /api/packages/search", () => {
     const res = await request(app).get("/api/packages/search?q=language");
     expect(res.headers["link"].length).toBeGreaterThan(0);
     expect(res.headers["query-total"].match(/^\d+$/) === null).toBeFalsy();
+    expect(res.headers["query-limit"].match(/^\d+$/) === null).toBeFalsy();
   });
   test("Invalid Search Returns Array", async () => {
     const res = await request(app).get("/api/packages/search?q=not-one-match");
@@ -874,6 +876,7 @@ describe("GET /api/themes", () => {
     const res = await request(app).get("/api/themes");
     expect(res.headers["link"].length).toBeGreaterThan(0);
     expect(res.headers["query-total"].match(/^\d+$/) === null).toBeFalsy();
+    expect(res.headers["query-limit"].match(/^\d+$/) === null).toBeFalsy();
   });
   test("Should 404 on invalid Method", async () => {
     const res = await request(app).patch("/api/themes");
@@ -910,6 +913,7 @@ describe("GET /api/themes/search", () => {
     const res = await request(app).get("/api/themes/search?q=syntax");
     expect(res.headers["link"].length).toBeGreaterThan(0);
     expect(res.headers["query-total"].match(/^\d+$/) === null).toBeFalsy();
+    expect(res.headers["query-limit"].match(/^\d+$/) === null).toBeFalsy();
   });
   test("Invalid Search Returns Array", async () => {
     const res = await request(app).get("/api/themes/search?q=not-one-match");

--- a/src/utils.js
+++ b/src/utils.js
@@ -433,23 +433,32 @@ function semverLt(a1, a2) {
 }
 
 /**
- * @function getOwnerRepoFromURL
- * @desc A function to take the URL of a GitHub repo and return the `owner/repo`
+ * @function getOwnerRepoFromUrlString
+ * @desc A function that takes the URL string of a GitHub repo and return the `owner/repo`
  * string for the repo. Intended to be used from a packages entry `data.repository.url`
  * @param {string} url - The URL for the Repo.
- * @returns {string} The `owner/repo` string from the URL. Or an empty string of unable to parse.
+ * @returns {string} The `owner/repo` string from the URL. Or an empty string if unable to parse.
  */
-function getOwnerRepoFromURL(url) {
-  const reg =
-    /(?=(https:\/\/github\.com\/|git@github\.com:))\1(?=((?:[\w\-\.]+)\/(?:[\w\.\-]+)))\2/;
-
-  const res = url.match(reg);
-
-  if (res === null || res?.length < 3) {
-    logger.generic(3, `getOwnerRepoFromURL Unable to parse: ${url}`);
+function getOwnerRepoFromUrlString(url) {
+  if (typeof url !== "string") {
     return "";
   }
 
+  // Simplified version of the regex here: https://regex101.com/r/3OMBy2/3
+  // The following is the optimized version using the positive lookaheads, atomic groups and
+  // capturing groups to avoid backtracking: https://regex101.com/r/I5p3OT/2
+  const reg =
+    /(?=(https:\/\/(?:www\.)?github\.com\/|git@github\.com:))\1(?=((?:[\w\-\.]+)\/(?:[\w\-\.]+)))\2/;
+
+  const res = url.match(reg);
+
+  if (res === null || res?.length !== 3) {
+    logger.generic(3, `getOwnerRepoFromUrlString Unable to parse: ${url}`);
+    return "";
+  }
+
+  // Since backtracking is not allowed, the final ".git" is captured if present,
+  // so we remove it before return.
   return res[2].replace(/\.git$/, "");
 }
 
@@ -580,5 +589,5 @@ module.exports = {
   semverLt,
   semverEq,
   StateStore,
-  getOwnerRepoFromURL,
+  getOwnerRepoFromUrlString,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -433,6 +433,32 @@ function semverLt(a1, a2) {
 }
 
 /**
+ * @function getOwnerRepoFromPackage
+ * @desc A function that takes a package and tries to extract `owner/repo` string from it
+ * relying on getOwnerRepoFromUrlString util.
+ * @param {object} pack - The Github package.
+ * @returns {string} The `owner/repo` string from the URL. Or an empty string if unable to parse.
+ */
+function getOwnerRepoFromPackage(pack) {
+  // pack.repository.url should be enough, but in case GitHub in the future decides to change it,
+  // we use other properties to have chances to still extract the owner/repo string.
+  const props = [
+    pack?.repository?.url,
+    pack?.metadata?.repository,
+  ];
+
+  let repo = "";
+  for (const p of props) {
+    repo = getOwnerRepoFromUrlString(p);
+    if (repo !== "") {
+      break;
+    }
+  }
+
+  return repo;
+}
+
+/**
  * @function getOwnerRepoFromUrlString
  * @desc A function that takes the URL string of a GitHub repo and return the `owner/repo`
  * string for the repo. Intended to be used from a packages entry `data.repository.url`
@@ -589,5 +615,6 @@ module.exports = {
   semverLt,
   semverEq,
   StateStore,
+  getOwnerRepoFromPackage,
   getOwnerRepoFromUrlString,
 };


### PR DESCRIPTION
### Requirements 

* [x] Have you ran tests against this code?

### Description of the Change

As the title says, a more robust version for getting the `owner/repo` string. We pass the package and extract the string making an attempt on multiple properties (more can be added in the future in case GitHub changes the package format).

The regex has been slightly fixed to allow the same characters on both owner and repo. More tests have been added.

For an easier reviewing, it's recommended to push #19 before.