### PR TITLE
Protect `sanitizeLogs`

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -40,6 +40,10 @@ function httpLog(req, res) {
 function sanitizeLogs(val) {
   // Removes New Line, Carriage Return, Tabs,
   // TODO: Should probably also defend against links within this.
+  if (typeof val === "number") {
+    // Don't try to preform string methods on number
+    return val;
+  }
   return val?.replace(/\n|\r/g, "")?.replace(/\t/g, "");
 }
 


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This was an issue experienced in production.

The update has already been pushed to production, but in keeping good form creating a PR.

This helps protect `logger.sanitizeLogs()` against executing String based methods on non-string parameters.

Likely a true fix would be to check for any type that's not a string, or provide proper handling for any type it may be provided. Otherwise as a quick and dirty, single issue solution this should do the trick.