### PR TITLE
Provide Package Data when updating version

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -161,7 +161,7 @@ async function insertNewPackage(pack) {
  * @param {string|null} oldName - If provided, the old name to be replaced for the renaming of the package.
  * @returns {object} A server status object.
  */
-async function insertNewPackageVersion(packJSON, oldName = null) {
+async function insertNewPackageVersion(packJSON, packageData, oldName = null) {
   sqlStorage ??= setupSQL();
 
   // We are expected to receive a standard `package.json` file.
@@ -257,7 +257,7 @@ async function insertNewPackageVersion(packJSON, oldName = null) {
       // Then update the package object in the related column of packages table.
       const updatePackageData = await sqlTrans`
         UPDATE packages
-        SET data = ${packJSON}
+        SET data = ${packageData}
         WHERE pointer = ${pointer}
         RETURNING *;
       `;
@@ -294,7 +294,7 @@ async function insertNewPackageVersion(packJSON, oldName = null) {
       const msg =
         typeof err === "string"
           ? err
-          : `A generic error occured while inserting the new package version ${packName}`;
+          : `A generic error occured while inserting the new package version ${packJSON.name}`;
 
       return { ok: false, content: msg, short: "Server Error" };
     });

--- a/src/git.js
+++ b/src/git.js
@@ -619,4 +619,6 @@ module.exports = {
   getPackageJSON,
   setGHAPIURL,
   setGHWebURL,
+  selectPackageRepository,
+  getRepoReadMe,
 };

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -200,7 +200,7 @@ describe("Package Lifecycle Tests", () => {
 
     // === Now let's add a version
     const v1_0_1 = pack.addVersion("1.0.1");
-    const addNextVersion = await database.insertNewPackageVersion(v1_0_1);
+    const addNextVersion = await database.insertNewPackageVersion(v1_0_1, pack.packageDataForVersion(v1_0_1));
     if (!addNextVersion.ok) {
       console.log(addNextVersion);
     }
@@ -227,7 +227,7 @@ describe("Package Lifecycle Tests", () => {
     );
 
     // === Can we publish a duplicate or a lower version?
-    const dupVer = await database.insertNewPackageVersion(v1_0_1);
+    const dupVer = await database.insertNewPackageVersion(v1_0_1, pack.packageDataForVersion(v1_0_1));
     expect(dupVer.ok).toBeFalsy();
     expect(dupVer.content).toEqual(
       "Cannot publish a new version with semver lower or equal than the current latest one."
@@ -310,7 +310,7 @@ describe("Package Lifecycle Tests", () => {
     // === Can we reinsert a previous deleted version?
     // This is intentionally unsupported because we want a new package to be always
     // higher than the previous latest one in order to trigger an update to the user.
-    const reAddNextVersion = await database.insertNewPackageVersion(v1_0_1);
+    const reAddNextVersion = await database.insertNewPackageVersion(v1_0_1, pack.packageDataForVersion(v1_0_1));
     const latestVer = await database.getPackageByName(NEW_NAME);
     expect(reAddNextVersion.ok).toBeFalsy();
     expect(reAddNextVersion.content).toEqual(
@@ -321,7 +321,7 @@ describe("Package Lifecycle Tests", () => {
     // First let's push a new version.
     const newSemver = "1.1.0";
     const newVersion = pack.addVersion(newSemver);
-    const addNewVersion = await database.insertNewPackageVersion(newVersion);
+    const addNewVersion = await database.insertNewPackageVersion(newVersion, pack.packageDataForVersion(newVersion));
     expect(addNewVersion.ok).toBeTruthy();
     expect(addNewVersion.content).toEqual(
       `Successfully added new version: ${newVersion.name}@${newVersion.version}`
@@ -348,7 +348,7 @@ describe("Package Lifecycle Tests", () => {
 
     // === Can we add an odd yet valid semver?
     const oddVer = pack.addVersion("1.2.3-beta.0");
-    const oddNewVer = await database.insertNewPackageVersion(oddVer);
+    const oddNewVer = await database.insertNewPackageVersion(oddVer, pack.packageDataForVersion(oddVer));
     expect(oddNewVer.ok).toBeTruthy();
     expect(oddNewVer.content).toEqual(
       `Successfully added new version: ${oddVer.name}@${oddVer.version}`
@@ -356,7 +356,7 @@ describe("Package Lifecycle Tests", () => {
 
     // === What about another Odd yet valid semver?
     const oddVer2 = pack.addVersion("1.2.4-alpha1");
-    const oddNewVer2 = await database.insertNewPackageVersion(oddVer2);
+    const oddNewVer2 = await database.insertNewPackageVersion(oddVer2, pack.createPack);
     expect(oddNewVer2.ok).toBeTruthy();
     expect(oddNewVer2.content).toEqual(
       `Successfully added new version: ${oddVer2.name}@${oddVer2.version}`

--- a/src/tests_integration/fixtures/lifetime/package-a.js
+++ b/src/tests_integration/fixtures/lifetime/package-a.js
@@ -33,7 +33,20 @@ const addVersion = (v) => {
   };
 };
 
+const packageDataForVersion = (v) => {
+  return {
+    name: "package-a-lifetime",
+    repository: {
+      type: "git",
+      url: "https://github.com/pulsar-edit/package-a-lifetime"
+    },
+    readme: "This is a readme!",
+    metadata: v
+  };
+};
+
 module.exports = {
   createPack,
   addVersion,
+  packageDataForVersion,
 };


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This should resolve an issue currently effecting production.

Currently when the version is updated, we thought it would be helpful to update the Main Packages `data` field at the same time to include any new changes to the `package.json` there, but because generally this field is populated with other custom values that include `readme`, `name`, `repository`, `metadata` those fields were ignored during the update, and not populated.

Causing a big data mismatch between what's expected and what's now in the database.

This update restores this functionality, now by instead creating this object again and passing it to the version update, which then uses this value only to update the Packages `data` field.

This has additional benefits to include updates to the readme on package version update.

Lastly some tests needed to be modified to work with these changes as well.
