### PR TITLE
Retrieve metadata info on new package version

### DIFF
--- a/docs/reference/Source_Documentation.md
+++ b/docs/reference/Source_Documentation.md
@@ -596,6 +596,7 @@ Assists in interactions between the backend and GitHub.
     * [~setGHAPIURL(val)](#module_git..setGHAPIURL)
     * [~ownership(user, repo, [dev_override])](#module_git..ownership)
     * [~createPackage(repo)](#module_git..createPackage) ⇒ <code>object</code>
+    * [~metadataAppendTarballInfo(pack, repo, user)](#module_git..metadataAppendTarballInfo) ⇒ <code>object</code> \| <code>undefined</code>
     * [~selectPackageRepository(repo)](#module_git..selectPackageRepository) ⇒ <code>object</code>
     * [~doesUserHaveRepo(user, repo, [page])](#module_git..doesUserHaveRepo) ⇒ <code>object</code>
     * [~getRepoExistance(repo)](#module_git..getRepoExistance) ⇒ <code>boolean</code>
@@ -657,6 +658,21 @@ return back a proper `Server Object Full` object within a `Server Status`.conten
 | Param | Type | Description |
 | --- | --- | --- |
 | repo | <code>string</code> | The Repo to use in the form `owner/repo`. |
+
+<a name="module_git..metadataAppendTarballInfo"></a>
+
+### git~metadataAppendTarballInfo(pack, repo, user) ⇒ <code>object</code> \| <code>undefined</code>
+Get the version metadata package object and append tarball and hash.
+
+**Kind**: inner method of [<code>git</code>](#module_git)  
+**Returns**: <code>object</code> \| <code>undefined</code> - The metadata object with tarball URL and sha hash code
+appended, or undefined or error.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| pack | <code>object</code> | The metadata package object. |
+| repo | <code>object</code> \| <code>string</code> | The repo object provided by GitHub or the tag string to retrieve the repo tag from getRepoTags(). |
+| user | <code>object</code> | The user object in case the repo tag has to be retrieved. |
 
 <a name="module_git..selectPackageRepository"></a>
 

--- a/docs/reference/Source_Documentation.md
+++ b/docs/reference/Source_Documentation.md
@@ -947,7 +947,7 @@ Parses the 'engine' query parameter to ensure it's valid, otherwise returning fa
 <a name="module_query..auth"></a>
 
 ### query~auth(req) ⇒ <code>string</code>
-retrieves Authorization Headers from Request, and Checks for Undefined.
+Retrieves Authorization Headers from Request, and Checks for Undefined.
 
 **Kind**: inner method of [<code>query</code>](#module_query)  
 **Returns**: <code>string</code> - Returning a valid Authorization Token, or '' if invalid/not found.  
@@ -1182,7 +1182,7 @@ construction of package object shorts
 
 ### utils~constructPackageObjectJSON(pack) ⇒ <code>object</code>
 Takes the return of getPackageVersionByNameAndVersion and returns
-a recreation of the package.json with a modified dist.tarball key, poionting
+a recreation of the package.json with a modified dist.tarball key, pointing
 to this server for download.
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  

--- a/docs/reference/Source_Documentation.md
+++ b/docs/reference/Source_Documentation.md
@@ -12,7 +12,7 @@ But this does provide an opportunity to allow multiple caching systems.</p>
 </dd>
 <dt><a href="#module_database">database</a></dt>
 <dd><p>Provides an interface of a large collection of functions to interact
-with and retreive data from the cloud hosted database instance.</p>
+with and retrieve data from the cloud hosted database instance.</p>
 </dd>
 <dt><a href="#module_debug_util">debug_util</a></dt>
 <dd><p>A collection of simple functions to help devs debug the application during runtime,
@@ -153,7 +153,7 @@ const { search_algorithm } = require("./config.js").getConfig();
 
 ## database
 Provides an interface of a large collection of functions to interact
-with and retreive data from the cloud hosted database instance.
+with and retrieve data from the cloud hosted database instance.
 
 
 * [database](#module_database)
@@ -394,7 +394,7 @@ This also makes sure that a new latest version is selected in case the previous 
 
 ### database~getFeaturedPackages() ⇒ <code>object</code>
 Collects the hardcoded featured packages array from the storage.js
-module. Then uses this.getPackageCollectionByName to retreive details of the
+module. Then uses this.getPackageCollectionByName to retrieve details of the
 package.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
@@ -403,7 +403,7 @@ package.
 
 ### database~getFeaturedThemes() ⇒ <code>object</code>
 Collects the hardcoded featured themes array from the storage.js module.
-Then uses this.getPackageCollectionByName to retreive details of the package.
+Then uses this.getPackageCollectionByName to retrieve details of the package.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object.  
@@ -720,7 +720,7 @@ on GitHub.
 <a name="module_git..getPackageJSON"></a>
 
 ### git~getPackageJSON(repo) ⇒ <code>string</code> \| <code>undefined</code>
-Intends to retreive the raw text of the GitHub repo package.
+Intends to retrieve the raw text of the GitHub repo package.
 
 **Kind**: inner method of [<code>git</code>](#module_git)  
 **Returns**: <code>string</code> \| <code>undefined</code> - Returns a proper string of the readme if successful.
@@ -733,7 +733,7 @@ And returns `undefined` otherwise.
 <a name="module_git..getRepoReadMe"></a>
 
 ### git~getRepoReadMe(repo) ⇒ <code>string</code> \| <code>undefined</code>
-Intends to retreive the GitHub repo readme file. Will look for both
+Intends to retrieve the GitHub repo readme file. Will look for both
 `readme.md` and `README.md` just in case.
 
 **Kind**: inner method of [<code>git</code>](#module_git)  
@@ -947,7 +947,7 @@ Parses the 'engine' query parameter to ensure it's valid, otherwise returning fa
 <a name="module_query..auth"></a>
 
 ### query~auth(req) ⇒ <code>string</code>
-Retreives Authorization Headers from Request, and Checks for Undefined.
+retrieves Authorization Headers from Request, and Checks for Undefined.
 
 **Kind**: inner method of [<code>query</code>](#module_query)  
 **Returns**: <code>string</code> - Returning a valid Authorization Token, or '' if invalid/not found.  
@@ -1091,7 +1091,7 @@ Caching the object once read for this instance of the server run.
 <a name="module_storage..getFeaturedThemes"></a>
 
 ### storage~getFeaturedThemes() ⇒ <code>Array</code>
-Used to retreive Google Cloud Storage Object for featured themes.
+Used to retrieve Google Cloud Storage Object for featured themes.
 
 **Kind**: inner method of [<code>storage</code>](#module_storage)  
 **Returns**: <code>Array</code> - JSON Parsed Array of Featured Theme Names.  
@@ -1128,7 +1128,7 @@ These states are used during the authentication flow to help ensure against mali
 <a name="module_utils..isPackageNameBanned"></a>
 
 ### utils~isPackageNameBanned(name) ⇒ <code>object</code>
-This uses the `storage.js` to retreive a banlist. And then simply
+This uses the `storage.js` to retrieve a banlist. And then simply
 iterates through the banList array, until it finds a match to the name
 it was given. If no match is found then it returns false.
 
@@ -1197,7 +1197,7 @@ to this server for download.
 
 ### utils~engineFilter() ⇒ <code>object</code>
 A complex function that provides filtering by Atom engine version.
-This should take a package with it's versions and retreive whatever matches
+This should take a package with it's versions and retrieve whatever matches
 that engine version as provided.
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
@@ -1644,7 +1644,7 @@ sensitive informations like primary and foreign keys.
 <a name="module_package_handler..getPackagesFeatured"></a>
 
 ### package_handler~getPackagesFeatured(req, res)
-Allows the user to retreive the featured packages, as package object shorts.
+Allows the user to retrieve the featured packages, as package object shorts.
 This endpoint was originally undocumented. The decision to return 200 is based off similar endpoints.
 Additionally for the time being this list is created manually, the same method used
 on Atom.io for now. Although there are plans to have this become automatic later on.
@@ -1814,7 +1814,7 @@ a user to rename their application during this process.
 <a name="module_package_handler..getPackagesVersion"></a>
 
 ### package_handler~getPackagesVersion(req, res)
-Used to retreive a specific version from a package.
+Used to retrieve a specific version from a package.
 
 **Kind**: inner method of [<code>package\_handler</code>](#module_package_handler)  
 
@@ -1932,7 +1932,7 @@ Endpoint Handlers relating to themes only.
 <a name="module_theme_handler..getThemeFeatured"></a>
 
 ### theme_handler~getThemeFeatured(req, res)
-Used to retreive all Featured Packages that are Themes. Originally an undocumented
+Used to retrieve all Featured Packages that are Themes. Originally an undocumented
 endpoint. Returns a 200 response based on other similar responses.
 Additionally for the time being this list is created manually, the same method used
 on Atom.io for now. Although there are plans to have this become automatic later on.
@@ -2004,7 +2004,7 @@ Endpoint Handlers relating to updating the editor.
 <a name="module_update_handler..getUpdates"></a>
 
 ### update_handler~getUpdates(req, res)
-Used to retreive new editor update information.
+Used to retrieve new editor update information.
 
 **Kind**: inner method of [<code>update\_handler</code>](#module_update_handler)  
 **Todo**

--- a/docs/resources/ORIGINAL_README.md
+++ b/docs/resources/ORIGINAL_README.md
@@ -166,7 +166,7 @@ These JSON files will be saved under a UUID like so `UUIDv4.json` allowing any c
 while always pointing to the same file.
 This UUIDv4.json will also be the location the package_pointer.json index will refer to.
 
-Within each package file will be additional data not retreived in the API. Including a list of all users
+Within each package file will be additional data not retrieved in the API. Including a list of all users
 that have stared the package, listed by their username.
 Additionally will list the creation date, and last modified date.
 But these values will be removed before returning via the API.

--- a/docs/resources/complexity-report.md
+++ b/docs/resources/complexity-report.md
@@ -1,4 +1,4 @@
-# Complexity report, 1/1/2023
+# Complexity report, 1/2/2023
 
 * Mean per-function logical LOC: 17.307692307692307
 * Mean per-function parameter count: 0.36538461538461536

--- a/docs/resources/complexity-report.md
+++ b/docs/resources/complexity-report.md
@@ -1,4 +1,4 @@
-# Complexity report, 12/31/2022
+# Complexity report, 1/1/2023
 
 * Mean per-function logical LOC: 17.307692307692307
 * Mean per-function parameter count: 0.36538461538461536
@@ -9,7 +9,7 @@
 * Change cost: 8.284023668639055%
 * Core size: 100%
 
-## /home/runner/work/package-backend/package-backend/jest.config.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/jest.config.js
 
 * Physical LOC: 23
 * Logical LOC: 12
@@ -19,7 +19,7 @@
 * Maintainability index: 62.36361563140606
 * Dependency count: 0
 
-## /home/runner/work/package-backend/package-backend/src/cache.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/cache.js
 
 * Physical LOC: 28
 * Logical LOC: 3
@@ -29,7 +29,7 @@
 * Maintainability index: 78.8444767459975
 * Dependency count: 1
 
-## /home/runner/work/package-backend/package-backend/src/debug_utils.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/debug_utils.js
 
 * Physical LOC: 30
 * Logical LOC: 22
@@ -49,7 +49,7 @@
     * Halstead volume: 475.6861996976024
     * Halstead effort: 8970.082622869073
 
-## /home/runner/work/package-backend/package-backend/scripts/deprecated/search.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/deprecated/search.js
 
 * Physical LOC: 176
 * Logical LOC: 73
@@ -119,7 +119,7 @@
     * Halstead volume: 380.3296723500879
     * Halstead effort: 12318.455498894515
 
-## /home/runner/work/package-backend/package-backend/scripts/tools/genBadges.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/scripts/tools/genBadges.js
 
 * Physical LOC: 90
 * Logical LOC: 50
@@ -169,7 +169,7 @@
     * Halstead volume: 91.37651812938249
     * Halstead effort: 186.9065143555551
 
-## /home/runner/work/package-backend/package-backend/src/tests/config.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/config.test.js
 
 * Physical LOC: 63
 * Logical LOC: 2
@@ -179,7 +179,7 @@
 * Maintainability index: 86.03073855173344
 * Dependency count: 1
 
-## /home/runner/work/package-backend/package-backend/src/tests/debug_utils.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/debug_utils.test.js
 
 * Physical LOC: 31
 * Logical LOC: 2
@@ -189,7 +189,7 @@
 * Maintainability index: 86.03073855173344
 * Dependency count: 1
 
-## /home/runner/work/package-backend/package-backend/src/tests/logger.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/logger.test.js
 
 * Physical LOC: 95
 * Logical LOC: 4
@@ -199,7 +199,7 @@
 * Maintainability index: 76.39879935103494
 * Dependency count: 1
 
-## /home/runner/work/package-backend/package-backend/src/tests/query.test.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests/query.test.js
 
 * Physical LOC: 143
 * Logical LOC: 78
@@ -209,7 +209,7 @@
 * Maintainability index: 37.68731830500316
 * Dependency count: 1
 
-## /home/runner/work/package-backend/package-backend/src/tests_integration/fixtures/git.createPackage_returns/valid_multi_version.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/git.createPackage_returns/valid_multi_version.js
 
 * Physical LOC: 43
 * Logical LOC: 34
@@ -219,7 +219,7 @@
 * Maintainability index: 50.83192723928399
 * Dependency count: 0
 
-## /home/runner/work/package-backend/package-backend/src/tests_integration/fixtures/git.createPackage_returns/valid_one_version.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/git.createPackage_returns/valid_one_version.js
 
 * Physical LOC: 25
 * Logical LOC: 19
@@ -229,7 +229,7 @@
 * Maintainability index: 58.378034894518755
 * Dependency count: 0
 
-## /home/runner/work/package-backend/package-backend/src/tests_integration/fixtures/lifetime/package-a.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/lifetime/package-a.js
 
 * Physical LOC: 52
 * Logical LOC: 25
@@ -239,7 +239,7 @@
 * Maintainability index: 54.4848955157022
 * Dependency count: 0
 
-## /home/runner/work/package-backend/package-backend/src/tests_integration/fixtures/lifetime/user-a.js
+## /home/runner/work/atom-community-server-backend-JS/atom-community-server-backend-JS/src/tests_integration/fixtures/lifetime/user-a.js
 
 * Physical LOC: 9
 * Logical LOC: 6

--- a/src/database.js
+++ b/src/database.js
@@ -95,9 +95,9 @@ async function insertNewPackage(pack) {
 
       // No need to specify downloads and stargazers. They default at 0 on creation.
       let command = await sqlTrans`
-      INSERT INTO packages (name, creation_method, data, package_type)
-      VALUES (${pack.name}, ${pack.creation_method}, ${packData}, ${packageType})
-      RETURNING pointer;
+        INSERT INTO packages (name, creation_method, data, package_type)
+        VALUES (${pack.name}, ${pack.creation_method}, ${packData}, ${packageType})
+        RETURNING pointer;
     `;
 
       const pointer = command[0].pointer;
@@ -107,8 +107,8 @@ async function insertNewPackage(pack) {
 
       // Populate names table
       command = await sqlTrans`
-      INSERT INTO names (name, pointer)
-      VALUES (${pack.name}, ${pointer});
+        INSERT INTO names (name, pointer)
+        VALUES (${pack.name}, ${pointer});
     `;
 
       if (command.count === 0) {
@@ -134,9 +134,9 @@ async function insertNewPackage(pack) {
         const license = pv[ver].license ?? defaultLicense;
 
         command = await sqlTrans`
-        INSERT INTO versions (package, status, semver, license, engine, meta)
-        VALUES (${pointer}, ${status}, ${ver}, ${license}, ${engine}, ${pv[ver]})
-        RETURNING id;
+          INSERT INTO versions (package, status, semver, license, engine, meta)
+          VALUES (${pointer}, ${status}, ${ver}, ${license}, ${engine}, ${pv[ver]})
+          RETURNING id;
       `;
 
         if (command[0].id === undefined) {
@@ -192,10 +192,10 @@ async function insertNewPackageVersion(packJSON, packageData, oldName = null) {
         // since we want that column to contain the current name.
         try {
           const updateNewName = await sqlTrans`
-          UPDATE packages
-          SET name = ${packJSON.name}
-          WHERE pointer = ${pointer}
-          RETURNING *;
+            UPDATE packages
+            SET name = ${packJSON.name}
+            WHERE pointer = ${pointer}
+            RETURNING *;
           `;
 
           if (updateNewName.count === 0) {
@@ -208,10 +208,10 @@ async function insertNewPackageVersion(packJSON, packageData, oldName = null) {
         // Now we can finally insert the new name inside the `names` table.
         try {
           const newInsertedName = await sqlTrans`
-          INSERT INTO names
-          (name, pointer) VALUES
-          (${packJSON.name}, ${pointer})
-          RETURNING *;
+            INSERT INTO names
+            (name, pointer) VALUES
+            (${packJSON.name}, ${pointer})
+            RETURNING *;
           `;
 
           if (newInsertedName.count === 0) {
@@ -275,9 +275,9 @@ async function insertNewPackageVersion(packJSON, packageData, oldName = null) {
 
       try {
         const addVer = await sqlTrans`
-        INSERT INTO versions (package, status, semver, license, engine, meta)
-        VALUES(${pointer}, 'latest', ${packJSON.version}, ${license}, ${engine}, ${packJSON})
-        RETURNING *;
+          INSERT INTO versions (package, status, semver, license, engine, meta)
+          VALUES(${pointer}, 'latest', ${packJSON.version}, ${license}, ${engine}, ${packJSON})
+          RETURNING *;
         `;
 
         if (addVer.count === 0) {
@@ -333,10 +333,10 @@ async function insertNewPackageName(newName, oldName) {
       // since we want that column to contain the current name.
       try {
         const updateNewName = await sqlTrans`
-        UPDATE packages
-        SET name = ${newName}
-        WHERE pointer = ${pointer}
-        RETURNING *;
+          UPDATE packages
+          SET name = ${newName}
+          WHERE pointer = ${pointer}
+          RETURNING *;
         `;
 
         if (updateNewName.count === 0) {
@@ -349,10 +349,10 @@ async function insertNewPackageName(newName, oldName) {
       // Now we can finally insert the new name inside the `names` table.
       try {
         const newInsertedName = await sqlTrans`
-        INSERT INTO names
-        (name, pointer) VALUES
-        (${newName}, ${pointer})
-        RETURNING *;
+          INSERT INTO names
+          (name, pointer) VALUES
+          (${newName}, ${pointer})
+          RETURNING *;
         `;
 
         if (newInsertedName.count === 0) {
@@ -532,12 +532,12 @@ async function getPackageCollectionByName(packArray) {
     // which process the returned content with constructPackageObjectShort(),
     // we select only the needed columns.
     const command = await sqlStorage`
-    SELECT p.data, p.downloads, (p.stargazers_count + p.original_stargazers) AS stargazers_count, v.semver
-    FROM packages p
-      INNER JOIN names n ON (p.pointer = n.pointer AND n.name IN ${sqlStorage(
-        packArray
-      )})
-      INNER JOIN versions v ON (p.pointer = v.package AND v.status = 'latest');
+      SELECT p.data, p.downloads, (p.stargazers_count + p.original_stargazers) AS stargazers_count, v.semver
+      FROM packages p
+        INNER JOIN names n ON (p.pointer = n.pointer AND n.name IN ${sqlStorage(
+          packArray
+        )})
+        INNER JOIN versions v ON (p.pointer = v.package AND v.status = 'latest');
     `;
 
     return command.count !== 0

--- a/src/database.js
+++ b/src/database.js
@@ -1,7 +1,7 @@
 /**
  * @module database
  * @desc Provides an interface of a large collection of functions to interact
- * with and retreive data from the cloud hosted database instance.
+ * with and retrieve data from the cloud hosted database instance.
  */
 
 const fs = require("fs");
@@ -926,7 +926,7 @@ async function removePackageVersion(packName, semVer) {
  * @async
  * @function getFeaturedPackages
  * @desc Collects the hardcoded featured packages array from the storage.js
- * module. Then uses this.getPackageCollectionByName to retreive details of the
+ * module. Then uses this.getPackageCollectionByName to retrieve details of the
  * package.
  * @returns {object} A server status object.
  */
@@ -944,7 +944,7 @@ async function getFeaturedPackages() {
  * @async
  * @function getFeaturedThemes
  * @desc Collects the hardcoded featured themes array from the storage.js module.
- * Then uses this.getPackageCollectionByName to retreive details of the package.
+ * Then uses this.getPackageCollectionByName to retrieve details of the package.
  * @returns {object} A server status object.
  */
 async function getFeaturedThemes() {

--- a/src/database.js
+++ b/src/database.js
@@ -19,6 +19,9 @@ const {
   paginated_amount,
 } = require("./config.js").getConfig();
 
+const defaultEngine = { atom: "*" };
+const defaultLicense = "NONE";
+
 let sqlStorage; // SQL object, to interact with the DB.
 // It is set after the first call with logical nullish assignment
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment
@@ -124,11 +127,11 @@ async function insertNewPackage(pack) {
         // Since many packages don't define an engine field,
         // we will do it for them if not present,
         // following suit with what Atom internal packages do.
-        const engine = pv[ver].engines ?? { atom: "*" };
+        const engine = pv[ver].engines ?? defaultEngine;
 
         // It's common practice for packages to not specify license,
         // therefore set it as NONE if undefined.
-        const license = pv[ver].license ?? "NONE";
+        const license = pv[ver].license ?? defaultLicense;
 
         command = await sqlTrans`
         INSERT INTO versions (package, status, semver, license, engine, meta)
@@ -267,8 +270,8 @@ async function insertNewPackageVersion(packJSON, packageData, oldName = null) {
       }
 
       // We can finally insert the new latest version.
-      const license = packJSON.license ?? "NONE";
-      const engine = packJSON.engines ?? { atom: "*" };
+      const license = packJSON.license ?? defaultLicense;
+      const engine = packJSON.engines ?? defaultEngine;
 
       try {
         const addVer = await sqlTrans`

--- a/src/git.js
+++ b/src/git.js
@@ -268,6 +268,10 @@ async function createPackage(repo, user) {
       // would have the correct download URL. So the error would only be visual when browsing
       // the packages details.
       if (!versionMetadata) {
+        logger.generic(
+          3,
+          `Cannot retrieve metadata info for version ${ver} of packName`
+        );
         continue;
       }
 

--- a/src/git.js
+++ b/src/git.js
@@ -268,7 +268,7 @@ async function createPackage(repo, user) {
       // would have the correct download URL. So the error would only be visual when browsing
       // the packages details.
       if (!versionMetadata) {
-        continue
+        continue;
       }
 
       newPack.versions[ver] = versionMetadata;
@@ -386,9 +386,7 @@ function selectPackageRepository(repo) {
       case "object":
         // If not null, it's likely a first party package
         // with an already valid package object that can just be added over.
-        return repo !== null
-          ? repo
-          : { type: "na", url: "" };
+        return repo !== null ? repo : { type: "na", url: "" };
 
       case "string": {
         const lcRepo = repo.toLowerCase();

--- a/src/git.js
+++ b/src/git.js
@@ -538,7 +538,7 @@ async function getRepoExistance(repo, user) {
 /**
  * @async
  * @function getPackageJSON
- * @desc Intends to retreive the raw text of the GitHub repo package.
+ * @desc Intends to retrieve the raw text of the GitHub repo package.
  * @param {string} repo - The string of the repo in format `owner/repo`.
  * @returns {string|undefined} Returns a proper string of the readme if successful.
  * And returns `undefined` otherwise.
@@ -575,7 +575,7 @@ async function getPackageJSON(repo, user) {
 /**
  * @async
  * @function getRepoReadMe
- * @desc Intends to retreive the GitHub repo readme file. Will look for both
+ * @desc Intends to retrieve the GitHub repo readme file. Will look for both
  * `readme.md` and `README.md` just in case.
  * @param {string} repo - A valid repo in format `owner/repo`.
  * @returns {string|undefined} Returns the raw string of the readme if available,
@@ -595,7 +595,7 @@ async function getRepoReadMe(repo, user) {
       default:
         logger.generic(
           3,
-          `Unexpected Status Code during README.md retrevial: ${res}`
+          `Unexpected Status Code during README.md retrieval: ${res}`
         );
         return undefined;
     }
@@ -633,7 +633,7 @@ async function getRepoReadMe(repo, user) {
           // it returned, but not the error code we expect.
           logger.generic(
             3,
-            `Unexpected Status code during readme.md retrevial: ${resLower}`
+            `Unexpected Status code during readme.md retrieval: ${resLower}`
           );
           return undefined;
       }

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -861,8 +861,8 @@ async function getPackagesVersionTarball(req, res) {
 
   // Try to extract the hostname
   try {
-    const url = new URL(tarballURL);
-    hostname = url.hostname;
+    const tbUrl = new URL(tarballURL);
+    hostname = tbUrl.hostname;
   } catch (e) {
     logger.generic(
       3,

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -220,7 +220,7 @@ async function postPackages(req, res) {
 /**
  * @async
  * @function getPackagesFeatured
- * @desc Allows the user to retreive the featured packages, as package object shorts.
+ * @desc Allows the user to retrieve the featured packages, as package object shorts.
  * This endpoint was originally undocumented. The decision to return 200 is based off similar endpoints.
  * Additionally for the time being this list is created manually, the same method used
  * on Atom.io for now. Although there are plans to have this become automatic later on.
@@ -763,7 +763,7 @@ async function postPackagesVersion(req, res) {
 /**
  * @async
  * @function getPackagesVersion
- * @desc Used to retreive a specific version from a package.
+ * @desc Used to retrieve a specific version from a package.
  * @param {object} req - The `Request` object inherited from the Express endpoint.
  * @param {object} res - The `Response` object inherited from the Express endpoint.
  * @property {http_method} - GET

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -675,7 +675,7 @@ async function postPackagesVersion(req, res) {
   const packMetadata = await git.metadataAppendTarballInfo(
     packJSON,
     packJSON.version,
-    user.content,
+    user.content
   );
   if (packMetadata === undefined) {
     await common.handleError(req, res, {
@@ -877,7 +877,10 @@ async function getPackagesVersionTarball(req, res) {
     "raw.githubusercontent.com",
   ];
 
-  if (!allowedHostnames.includes(hostname) && process.env.PULSAR_STATUS !== "dev") {
+  if (
+    !allowedHostnames.includes(hostname) &&
+    process.env.PULSAR_STATUS !== "dev"
+  ) {
     await common.handleError(req, res, {
       ok: false,
       short: "Server Error",

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -577,7 +577,7 @@ async function getPackagesStargazers(req, res) {
  */
 async function postPackagesVersion(req, res) {
   const params = {
-    tag: query.tag(req),
+    // tag: query.tag(req), // unused parameter
     rename: query.rename(req),
     auth: query.auth(req),
     packageName: query.packageName(req),
@@ -588,7 +588,7 @@ async function postPackagesVersion(req, res) {
     await common.handleError(req, res, {
       ok: false,
       short: "Bad Repo",
-      content: "The tag parameter is not correctly specified",
+      content: "The tag parameter is not specified correctly",
     });
     return;
   }*/
@@ -672,15 +672,28 @@ async function postPackagesVersion(req, res) {
     });
   }
 
+  const packMetadata = await git.metadataAppendTarballInfo(
+    packJSON,
+    packJSON.version,
+    user.content,
+  );
+  if (packMetadata === undefined) {
+    await common.handleError(req, res, {
+      ok: false,
+      short: "Bad Package",
+      content: `Failed to get Package metadata info: ${ownerRepo}`,
+    });
+  }
+
   // Now construct the object that will be used to update the `data` column.
   const packageData = {
-    name: packJSON.name.toLowerCase(),
-    repository: git.selectPackageRepository(packJSON.repository),
+    name: packMetadata.name.toLowerCase(),
+    repository: git.selectPackageRepository(packMetadata.repository),
     readme: packReadme,
-    metadata: packJSON,
+    metadata: packMetadata,
   };
 
-  const newName = packJSON.name;
+  const newName = packMetadata.name;
   const currentName = packExists.content.name;
   if (newName !== currentName && !params.rename) {
     logger.generic(
@@ -732,7 +745,7 @@ async function postPackagesVersion(req, res) {
   // Now add the new Version key.
 
   const addVer = await database.insertNewPackageVersion(
-    packJSON,
+    packMetadata,
     packageData,
     rename ? currentName : null
   );
@@ -843,31 +856,34 @@ async function getPackagesVersionTarball(req, res) {
   // the download to take place from their servers.
 
   // But right before, lets do a couple simple checks to make sure we are sending to a legit site.
-  //let tarballURL = new url((pack.content.meta.tarball_url ? pack.content.meta.tarball_url : ""));
-  let tarballURL = pack.content.meta.tarball_url;
+  const tarballURL = pack.content.meta.tarball_url ?? "";
+  let hostname = "";
 
-  if (tarballURL !== undefined && false) {
-    // todo the url feature doesn't work the way we would expect in production
-    tarballURL = url.parse(pack.content.meta.tarball_url);
+  // Try to extract the hostname
+  try {
+    const url = new URL(tarballURL);
+    hostname = url.hostname;
+  } catch (e) {
+    logger.generic(
+      3,
+      `Malformed tarball URL for version ${params.versionName} of ${params.packageName}`
+    );
+  }
 
-    if (
-      url.hostname != "codeload.github.com" ||
-      url.hostname != "api.github.com" ||
-      url.hostname != "github.com" ||
-      url.hostname != "raw.githubusercontent.com"
-    ) {
-      await common.handleError(req, res, {
-        ok: false,
-        short: "Server Error",
-        content: `Invalid Domain for Download Redirect: ${url.toString()}`,
-      });
-      return;
-    }
+  const allowedHostnames = [
+    "codeload.github.com",
+    "api.github.com",
+    "github.com",
+    "raw.githubusercontent.com",
+  ];
 
-    tarballURL = tarballURL.toString();
-  } else {
-    // we are likely in a test environment. And will just leave this blank to error out on the client side.
-    //tarballURL = "";
+  if (!allowedHostnames.includes(hostname) && process.env.PULSAR_STATUS !== "dev") {
+    await common.handleError(req, res, {
+      ok: false,
+      short: "Server Error",
+      content: `Invalid Domain for Download Redirect: ${hostname}`,
+    });
+    return;
   }
 
   res.redirect(tarballURL);

--- a/src/handlers/theme_handler.js
+++ b/src/handlers/theme_handler.js
@@ -17,7 +17,7 @@ const { server_url } = require("../config.js").getConfig();
 /**
  * @async
  * @function getThemeFeatured
- * @desc Used to retreive all Featured Packages that are Themes. Originally an undocumented
+ * @desc Used to retrieve all Featured Packages that are Themes. Originally an undocumented
  * endpoint. Returns a 200 response based on other similar responses.
  * Additionally for the time being this list is created manually, the same method used
  * on Atom.io for now. Although there are plans to have this become automatic later on.

--- a/src/handlers/update_handler.js
+++ b/src/handlers/update_handler.js
@@ -9,7 +9,7 @@ const common = require("./common_handler.js");
 /**
  * @async
  * @function getUpdates
- * @desc Used to retreive new editor update information.
+ * @desc Used to retrieve new editor update information.
  * @param {object} req - The `Request` object inherited from the Express endpoint.
  * @param {object} res - The `Response` object inherited from the Express endpoint.
  * @property {http_method} - GET

--- a/src/query.js
+++ b/src/query.js
@@ -115,7 +115,7 @@ function engine(semver) {
 
 /**
  * @function auth
- * @desc Retreives Authorization Headers from Request, and Checks for Undefined.
+ * @desc Retrieves Authorization Headers from Request, and Checks for Undefined.
  * @param {object} req = The `Request` object inherited from the Express endpoint.
  * @returns {string} Returning a valid Authorization Token, or '' if invalid/not found.
  */

--- a/src/storage.js
+++ b/src/storage.js
@@ -139,7 +139,7 @@ async function getFeaturedPackages() {
 /**
  * @async
  * @function getFeaturedThemes
- * @desc Used to retreive Google Cloud Storage Object for featured themes.
+ * @desc Used to retrieve Google Cloud Storage Object for featured themes.
  * @returns {Array} JSON Parsed Array of Featured Theme Names.
  */
 async function getFeaturedThemes() {

--- a/src/tests/query.test.js
+++ b/src/tests/query.test.js
@@ -95,7 +95,7 @@ describe("Verify Auth Query Returns", () => {
     }
   }
 
-  test("Properly Retreives Value", () => {
+  test("Properly Retrieves Value", () => {
     const req = new SimpleReq("ValidHeader");
     const res = query.auth(req);
     expect(res).toEqual("ValidHeader");

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -363,7 +363,9 @@ describe("GET /api/packages/:packageName", () => {
     expect(typeof res.body.releases.latest === "string").toBeTruthy();
     for (const v of Object.keys(res.body.versions)) {
       expect(typeof res.body.versions[v].license === "string").toBeTruthy();
-      expect(typeof res.body.versions[v].dist.tarball === "string").toBeTruthy();
+      expect(
+        typeof res.body.versions[v].dist.tarball === "string"
+      ).toBeTruthy();
     }
   });
   test("Valid package, does not return sensible data", async () => {

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -363,6 +363,7 @@ describe("GET /api/packages/:packageName", () => {
     expect(typeof res.body.releases.latest === "string").toBeTruthy();
     for (const v of Object.keys(res.body.versions)) {
       expect(typeof res.body.versions[v].license === "string").toBeTruthy();
+      expect(typeof res.body.versions[v].dist.tarball === "string").toBeTruthy();
     }
   });
   test("Valid package, does not return sensible data", async () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,7 @@ const crypto = require("crypto");
 /**
  * @async
  * @function isPackageNameBanned
- * @desc This uses the `storage.js` to retreive a banlist. And then simply
+ * @desc This uses the `storage.js` to retrieve a banlist. And then simply
  * iterates through the banList array, until it finds a match to the name
  * it was given. If no match is found then it returns false.
  * @param {string} name - The name of the package to check if it is banned.
@@ -28,7 +28,7 @@ async function isPackageNameBanned(name) {
     return { ok: true };
   }
 
-  logger.generic(6, "Success Status while retreiving Name Ban List.");
+  logger.generic(6, "Success Status while retrieving Name Ban List.");
   return banList.content.find((b) => name === b) ? { ok: true } : { ok: false };
 }
 
@@ -150,7 +150,7 @@ async function constructPackageObjectShort(pack) {
  * @async
  * @function constructPackageObjectJSON
  * @desc Takes the return of getPackageVersionByNameAndVersion and returns
- * a recreation of the package.json with a modified dist.tarball key, poionting
+ * a recreation of the package.json with a modified dist.tarball key, pointing
  * to this server for download.
  * @param {object} pack - The expected raw SQL return of `getPackageVersionByNameAndVersion`
  * @returns {object} A properly formatted Package Object Mini.
@@ -189,7 +189,7 @@ async function constructPackageObjectJSON(pack) {
  * @async
  * @function engineFilter
  * @desc A complex function that provides filtering by Atom engine version.
- * This should take a package with it's versions and retreive whatever matches
+ * This should take a package with it's versions and retrieve whatever matches
  * that engine version as provided.
  * @returns {object} The filtered object.
  */


### PR DESCRIPTION
### Requirements 

* [x] Have you ran tests against this code?

### Description of the Change

- Added a new `metadataAppendTarballInfo` in git module to append tarball and hash to version metadata package; this should fix the missing tarball url when publishing a new version.
- Little refactoring to `selectPackageRepository` using switch.
- In `postPackagesVersion` do not retrieve the tag parameter anymore since it's not used (I wonder if we should update the documentation to not require this parameter or leave it for compatibility reasons).
- Made a new URL parsing process in `getPackagesVersionTarball`, I hope this fixes the issue in production. @confused-Techie please, test it.

@confused-Techie I see we add a `dist` property in the response package with a custom tarball url, why? Can't we just pass the `tarball_url` we append previously?

Fixes #30