### PR TITLE
Use `URL` without failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,7 @@
         "express-rate-limit": "^6.7.0",
         "js-yaml": "^4.1.0",
         "postgres": "^3.3.2",
-        "superagent": "^8.0.6",
-        "url": "^0.11.0"
+        "superagent": "^8.0.6"
       },
       "devDependencies": {
         "@confused-techie/quick-webserver-docs": "^0.1.6",
@@ -6858,15 +6857,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -8057,20 +8047,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -13602,11 +13578,6 @@
         "side-channel": "^1.0.4"
       }
     },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
-    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -14493,22 +14464,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
-        }
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "express-rate-limit": "^6.7.0",
     "js-yaml": "^4.1.0",
     "postgres": "^3.3.2",
-    "superagent": "^8.0.6",
-    "url": "^0.11.0"
+    "superagent": "^8.0.6"
   },
   "devDependencies": {
     "@confused-techie/quick-webserver-docs": "^0.1.6",

--- a/src/dev-runner/migrations/0001-initial-migration.sql
+++ b/src/dev-runner/migrations/0001-initial-migration.sql
@@ -155,7 +155,8 @@ VALUES (
 INSERT INTO versions (package, status, semver, license, engine, meta)
 VALUES (
   'd28c7ce5-c9c4-4fb6-a499-a7c6dcec355b', 'published', '0.45.7', 'MIT', '{"atom": "*", "node": "*"}',
-  '{"name": "language-css", "description": "CSS Support in Atom", "keywords": ["tree-sitter"]}'
+  '{"name": "language-css", "description": "CSS Support in Atom", "keywords": ["tree-sitter"],
+     "tarball_url": "https://github.com/pulsar-edit/language-css"}'
 ), (
   'd28c7ce5-c9c4-4fb6-a499-a7c6dcec355b', 'latest', '0.46.0', 'MIT', '{"atom": "*", "node": "*"}',
   '{"name": "language-css", "description": "CSS Support in Atom", "keywords": ["tree-sitter"]}'

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -19,7 +19,7 @@ const { server_url } = require("../config.js").getConfig();
 const utils = require("../utils.js");
 const database = require("../database.js");
 const auth = require("../auth.js");
-const url = require("url");
+const { URL } = require("node:url");
 
 /**
  * @async
@@ -868,6 +868,12 @@ async function getPackagesVersionTarball(req, res) {
       3,
       `Malformed tarball URL for version ${params.versionName} of ${params.packageName}`
     );
+    await common.handleError(req, res, {
+      ok: false,
+      short: "Server Error",
+      content: e,
+    });
+    return;
   }
 
   const allowedHostnames = [

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -701,6 +701,10 @@ describe("GET /api/packages/:packageName/versions/:versionName/tarball", () => {
     );
     expect(res.redirect).toBeTruthy();
   });
+  test("Returns Expected Redirect URL", async () => {
+    const res = await request(app).get("/api/packages/language-css/versions/0.45.7/tarball");
+    expect(res.headers.location).toEqual("https://github.com/pulsar-edit/language-css");
+  });
 });
 
 describe("DELETE /api/packages/:packageName/versions/:versionName", () => {


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

A recent PR re-enabled the use of `URL` to ensure we only redirect users to safe locations. 

But there was some confusion about which URL module we wanted to use, because we had been importing a `url` module from NPM, but on that PR became aware that NodeJS has one included by default.

So this PR now uses NodeJS's `url` module, which changed the way we imported it. I've also gone ahead and added a test to ensure this works as expected, and redirects to the correct location.

Lastly in this PR, I've caused a malformed URL to actually return a server error rather than still attempt a redirect
