### PR TITLE
Support GH Repo Rename when publishing new Package Version

### DIFF
--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -637,7 +637,7 @@ async function postPackagesVersion(req, res) {
   }
 
   // Get `owner/repo` string format from package.
-  const ownerRepo = utils.getOwnerRepoFromPackage(packExists.content.data);
+  let ownerRepo = utils.getOwnerRepoFromPackage(packExists.content.data);
 
   // Now it's important to note, that getPackageJSON was intended to be an internal function.
   // As such does not return a Server Status Object. This may change later, but for now,
@@ -712,6 +712,12 @@ async function postPackagesVersion(req, res) {
   // Else we will continue, and trust the name provided from the package as being accurate.
   // And now we can ensure the user actually owns this repo, with our updated name.
 
+  // But to support a GH repo being renamed, we will now regrab the owner/repo combo
+  // From the newest updated `package.json` info, just in case it's changed that will be
+  // supported here
+
+  ownerRepo = utils.getOwnerRepoFromPackage(packJSON);
+  
   const gitowner = await git.ownership(user.content, ownerRepo);
 
   if (!gitowner.ok) {


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

Alright, this PR gets one endpoint supporting a GH repo rename. Only during a package publish.

Realistically this needs to be done to other endpoints that interact with `git.ownership()`  But we will have to consider how this is done more so, but this will fix an error in production currently affecting one of our package maintainers
