### PR TITLE
Monkey-Patch JSDoc BigInt Support

### DIFF
--- a/docs/reference/Source_Documentation.md
+++ b/docs/reference/Source_Documentation.md
@@ -81,7 +81,7 @@ verbosity, and duplication within the codebase.</p>
 ## Functions
 
 <dl>
-<dt><a href="#verifyAuth">verifyAuth()</a></dt>
+<dt><a href="#verifyAuth">verifyAuth()</a> ⇒ <code>object</code></dt>
 <dd><p>This will be the major function to determine, confirm, and provide user
 details of an authenticated user. This will take a users provided token,
 and use it to check GitHub for the details of whoever owns this token.
@@ -89,15 +89,15 @@ Once that is done, we can go ahead and search for said user within the database.
 If the user exists, then we can confirm that they are both locally and globally
 authenticated, and execute whatever action it is they wanted to.</p>
 </dd>
+<dt><a href="#getUserDataDevMode">getUserDataDevMode()</a> ⇒ <code>object</code></dt>
+<dd><p>An internal util to retrieve the user data object in developer mode only.</p>
+</dd>
 </dl>
 
 <a name="module_cache"></a>
 
 ## cache
-Provides an interface for helpful caching mechanisms.
-Originally created after some circular dependency issues arouse during
-rapid redevelopment of the entire storage system.
-But this does provide an opportunity to allow multiple caching systems.
+Provides an interface for helpful caching mechanisms.Originally created after some circular dependency issues arouse duringrapid redevelopment of the entire storage system.But this does provide an opportunity to allow multiple caching systems.
 
 
 * [cache](#module_cache)
@@ -132,16 +132,14 @@ Module that access' and returns the server wide configuration.
 <a name="module_config..getConfigFile"></a>
 
 ### config~getConfigFile() ⇒ <code>object</code>
-Used to read the `yaml` config file from the root of the project.
-Returning the YAML parsed file, or an empty obj.
+Used to read the `yaml` config file from the root of the project.Returning the YAML parsed file, or an empty obj.
 
 **Kind**: inner method of [<code>config</code>](#module_config)  
 **Returns**: <code>object</code> - A parsed YAML file config, or an empty object.  
 <a name="module_config..getConfig"></a>
 
 ### config~getConfig() ⇒ <code>object</code>
-Used to get Server Config data from the `app.yaml` file at the root of the project.
-Or from environment variables. Prioritizing environment variables.
+Used to get Server Config data from the `app.yaml` file at the root of the project.Or from environment variables. Prioritizing environment variables.
 
 **Kind**: inner method of [<code>config</code>](#module_config)  
 **Returns**: <code>object</code> - The different available configuration values.  
@@ -152,8 +150,7 @@ const { search_algorithm } = require("./config.js").getConfig();
 <a name="module_database"></a>
 
 ## database
-Provides an interface of a large collection of functions to interact
-with and retrieve data from the cloud hosted database instance.
+Provides an interface of a large collection of functions to interactwith and retrieve data from the cloud hosted database instance.
 
 
 * [database](#module_database)
@@ -162,7 +159,7 @@ with and retrieve data from the cloud hosted database instance.
     * [~insertNewPackage(pack)](#module_database..insertNewPackage) ⇒ <code>object</code>
     * [~insertNewPackageVersion(packJSON, oldName)](#module_database..insertNewPackageVersion) ⇒ <code>object</code>
     * [~insertNewPackageName(newName, oldName)](#module_database..insertNewPackageName) ⇒ <code>object</code>
-    * [~insertNewUser(user)](#module_database..insertNewUser) ⇒ <code>object</code>
+    * [~insertNewUser(username, id, avatar)](#module_database..insertNewUser) ⇒ <code>object</code>
     * [~getPackageByName(name, user)](#module_database..getPackageByName) ⇒ <code>object</code>
     * [~getPackageByNameSimple(name)](#module_database..getPackageByNameSimple) ⇒ <code>object</code>
     * [~getPackageVersionByNameAndVersion(name, version)](#module_database..getPackageVersionByNameAndVersion) ⇒ <code>object</code>
@@ -185,14 +182,13 @@ with and retrieve data from the cloud hosted database instance.
     * [~simpleSearch()](#module_database..simpleSearch) ⇒ <code>object</code>
     * [~getUserCollectionById(ids)](#module_database..getUserCollectionById) ⇒ <code>object</code>
     * [~getSortedPackages(page, dir, dir, method, [themes])](#module_database..getSortedPackages) ⇒ <code>object</code>
+    * [~authStoreStateKey(stateKey)](#module_database..authStoreStateKey) ⇒ <code>object</code>
+    * [~authCheckAndDeleteStateKey(stateKey, timestamp)](#module_database..authCheckAndDeleteStateKey) ⇒ <code>object</code>
 
 <a name="module_database..setupSQL"></a>
 
 ### database~setupSQL() ⇒ <code>object</code>
-Initialize the connection to the PostgreSQL database.
-In order to avoid the initialization multiple times,
-the logical nullish assignment (??=) can be used in the caller.
-Exceptions thrown here should be caught and handled in the caller.
+Initialize the connection to the PostgreSQL database.In order to avoid the initialization multiple times,the logical nullish assignment (??=) can be used in the caller.Exceptions thrown here should be caught and handled in the caller.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - PostgreSQL connection object.  
@@ -230,16 +226,13 @@ Adds a new package version to the db.
 <a name="module_database..insertNewPackageName"></a>
 
 ### database~insertNewPackageName(newName, oldName) ⇒ <code>object</code>
-Insert a new package name with the same pointer as the old name.
-This essentially renames an existing package.
+Insert a new package name with the same pointer as the old name.This essentially renames an existing package.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object.  
 **Todo**
 
-- [ ] This function has been left only for testing purpose since it has been integrated
-inside insertNewPackageVersion, so it should be removed when we can test the rename process
-directly on the endpoint.
+- [ ] This function has been left only for testing purpose since it has been integratedinside insertNewPackageVersion, so it should be removed when we can test the rename processdirectly on the endpoint.
 
 
 | Param | Type | Description |
@@ -249,7 +242,7 @@ directly on the endpoint.
 
 <a name="module_database..insertNewUser"></a>
 
-### database~insertNewUser(user) ⇒ <code>object</code>
+### database~insertNewUser(username, id, avatar) ⇒ <code>object</code>
 Insert a new user into the database.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
@@ -257,15 +250,14 @@ Insert a new user into the database.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| user | <code>object</code> | An object containing information related to the user. |
+| username | <code>string</code> | Username of the user. |
+| id | <code>object</code> | Identifier code of the user. |
+| avatar | <code>object</code> | The avatar of the user. |
 
 <a name="module_database..getPackageByName"></a>
 
 ### database~getPackageByName(name, user) ⇒ <code>object</code>
-Takes a package name and returns the raw SQL package with all its versions.
-This module is also used to get the data to be sent to utils.constructPackageObjectFull()
-in order to convert the query result in Package Object Full format.
-In that case it's recommended to set the user flag as true for security reasons.
+Takes a package name and returns the raw SQL package with all its versions.This module is also used to get the data to be sent to utils.constructPackageObjectFull()in order to convert the query result in Package Object Full format.In that case it's recommended to set the user flag as true for security reasons.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object.  
@@ -278,8 +270,7 @@ In that case it's recommended to set the user flag as true for security reasons.
 <a name="module_database..getPackageByNameSimple"></a>
 
 ### database~getPackageByNameSimple(name) ⇒ <code>object</code>
-Internal util used by other functions in this module to get the package row by the given name.
-It's like getPackageByName(), but with a simple and faster query.
+Internal util used by other functions in this module to get the package row by the given name.It's like getPackageByName(), but with a simple and faster query.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object.  
@@ -304,8 +295,7 @@ Uses the name of a package and it's version to return the version info.
 <a name="module_database..getPackageCollectionByName"></a>
 
 ### database~getPackageCollectionByName(packArray) ⇒ <code>object</code>
-Takes a package name array, and returns an array of the package objects.
-You must ensure that the packArray passed is compatible. This function does not coerce compatibility.
+Takes a package name array, and returns an array of the package objects.You must ensure that the packArray passed is compatible. This function does not coerce compatibility.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object.  
@@ -378,9 +368,7 @@ Given a package name, removes its record alongside its names, versions, stars.
 <a name="module_database..removePackageVersion"></a>
 
 ### database~removePackageVersion(packName, semVer) ⇒ <code>object</code>
-Mark a version of a specific package as removed. This does not delete the record,
-just mark the status as removed, but only if one published version remain available.
-This also makes sure that a new latest version is selected in case the previous one is removed.
+Mark a version of a specific package as removed. This does not delete the record,just mark the status as removed, but only if one published version remain available.This also makes sure that a new latest version is selected in case the previous one is removed.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object.  
@@ -393,17 +381,14 @@ This also makes sure that a new latest version is selected in case the previous 
 <a name="module_database..getFeaturedPackages"></a>
 
 ### database~getFeaturedPackages() ⇒ <code>object</code>
-Collects the hardcoded featured packages array from the storage.js
-module. Then uses this.getPackageCollectionByName to retrieve details of the
-package.
+Collects the hardcoded featured packages array from the storage.jsmodule. Then uses this.getPackageCollectionByName to retrieve details of thepackage.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object.  
 <a name="module_database..getFeaturedThemes"></a>
 
 ### database~getFeaturedThemes() ⇒ <code>object</code>
-Collects the hardcoded featured themes array from the storage.js module.
-Then uses this.getPackageCollectionByName to retrieve details of the package.
+Collects the hardcoded featured themes array from the storage.js module.Then uses this.getPackageCollectionByName to retrieve details of the package.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object.  
@@ -472,8 +457,7 @@ Register the removal of the star on a package by a user.
 <a name="module_database..getStarredPointersByUserID"></a>
 
 ### database~getStarredPointersByUserID(userid) ⇒ <code>object</code>
-Get all packages which the user gave the star.
-The result of this function should not be returned to the user because it contains pointers UUID.
+Get all packages which the user gave the star.The result of this function should not be returned to the user because it contains pointers UUID.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object.  
@@ -497,8 +481,7 @@ Use the pointer of a package to collect all users that have starred it.
 <a name="module_database..simpleSearch"></a>
 
 ### database~simpleSearch() ⇒ <code>object</code>
-The current Fuzzy-Finder implementation of search. Ideally eventually
-will use a more advanced search method.
+The current Fuzzy-Finder implementation of search. Ideally eventuallywill use a more advanced search method.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object containing the results and the pagination object.  
@@ -517,10 +500,7 @@ Returns an array of Users and their associated data via the ids.
 <a name="module_database..getSortedPackages"></a>
 
 ### database~getSortedPackages(page, dir, dir, method, [themes]) ⇒ <code>object</code>
-Takes the page, direction, and sort method returning the raw sql package
-data for each. This monolithic function handles trunication of the packages,
-and sorting, aiming to provide back the raw data, and allow later functions to
-then reconstruct the JSON as needed.
+Takes the page, direction, and sort method returning the raw sql packagedata for each. This monolithic function handles trunication of the packages,and sorting, aiming to provide back the raw data, and allow later functions tothen reconstruct the JSON as needed.
 
 **Kind**: inner method of [<code>database</code>](#module_database)  
 **Returns**: <code>object</code> - A server status object containing the results and the pagination object.  
@@ -533,18 +513,40 @@ then reconstruct the JSON as needed.
 | method | <code>string</code> |  | The column name the results have to be sorted by. |
 | [themes] | <code>boolean</code> | <code>false</code> | Optional Parameter to specify if this should only return themes. |
 
+<a name="module_database..authStoreStateKey"></a>
+
+### database~authStoreStateKey(stateKey) ⇒ <code>object</code>
+Gets a state key from login process and saves it on the database.
+
+**Kind**: inner method of [<code>database</code>](#module_database)  
+**Returns**: <code>object</code> - A server status object.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| stateKey | <code>string</code> | The key code string. |
+
+<a name="module_database..authCheckAndDeleteStateKey"></a>
+
+### database~authCheckAndDeleteStateKey(stateKey, timestamp) ⇒ <code>object</code>
+Gets a state key from oauth process and delete it from the database.It's used to verify if the request for the authentication is valid. The code should be first generated in theinitial stage of the login and then deleted by this function.If the deletion is successful, the returned record is used to retrieve the created timestamp of the state keyand check if it's not expired (considering a specific timeout).A custom timestamp can be passed as argument for testing purpose, otherwise the current timestamp is considered.
+
+**Kind**: inner method of [<code>database</code>](#module_database)  
+**Returns**: <code>object</code> - A server status object.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| stateKey | <code>string</code> | The key code string to delete. |
+| timestamp | <code>string</code> | A string in SQL timestamp format to check against the created timestamp of the given state key. If not provided, the current UNIX timestamp is used. |
+
 <a name="module_debug_util"></a>
 
 ## debug\_util
-A collection of simple functions to help devs debug the application during runtime,
-to better assist in tracking down bugs. Since many sets of data cannot be reliably output to the console
-this can help to view the transmutations of data as its handled.
+A collection of simple functions to help devs debug the application during runtime,to better assist in tracking down bugs. Since many sets of data cannot be reliably output to the consolethis can help to view the transmutations of data as its handled.
 
 <a name="module_debug_util..roughSizeOfObject"></a>
 
 ### debug_util~roughSizeOfObject(obj) ⇒ <code>integer</code>
-Returns the rough size of the object in memory, in Bytes. Can be used
-to help determine how an object changes over time.
+Returns the rough size of the object in memory, in Bytes. Can be usedto help determine how an object changes over time.
 
 **Kind**: inner method of [<code>debug\_util</code>](#module_debug_util)  
 **Returns**: <code>integer</code> - Returns the integer value of the object in Bytes.  
@@ -556,10 +558,7 @@ to help determine how an object changes over time.
 <a name="module_dev_server"></a>
 
 ## dev\_server
-The Development initializer of `main.js` as well as managing the startup of a locally created Docker SQL
-Server. This uses pg-test to set up a database hosted on local Docker. Migrating all data as needed,
-to allow the real server feel, without having access or the risk of the production database. But otherwise runs
-the backend API server as normal.
+The Development initializer of `main.js` as well as managing the startup of a locally created Docker SQLServer. This uses pg-test to set up a database hosted on local Docker. Migrating all data as needed,to allow the real server feel, without having access or the risk of the production database. But otherwise runsthe backend API server as normal.
 
 
 * [dev_server](#module_dev_server)
@@ -607,8 +606,7 @@ Assists in interactions between the backend and GitHub.
 <a name="module_git..setGHWebURL"></a>
 
 ### git~setGHWebURL(val)
-Allows this module to be more testable. Sets a single place to modify
-the URL to which all Web based outgoing requests are destined.
+Allows this module to be more testable. Sets a single place to modifythe URL to which all Web based outgoing requests are destined.
 
 **Kind**: inner method of [<code>git</code>](#module_git)  
 
@@ -619,8 +617,7 @@ the URL to which all Web based outgoing requests are destined.
 <a name="module_git..setGHAPIURL"></a>
 
 ### git~setGHAPIURL(val)
-Allows this module to be more testable. Sets a single place to modify
-the URL to which all API based outgoing requests are destined.
+Allows this module to be more testable. Sets a single place to modifythe URL to which all API based outgoing requests are destined.
 
 **Kind**: inner method of [<code>git</code>](#module_git)  
 
@@ -631,11 +628,7 @@ the URL to which all API based outgoing requests are destined.
 <a name="module_git..ownership"></a>
 
 ### git~ownership(user, repo, [dev_override])
-Allows the ability to check if a user has permissions to write to a repo.
-<b>MUST</b> Be provided `owner/repo` to successfully function, and expects the
-full `user` object. Returns `ok: true` where content is the repo data from GitHub
-on success, returns `short: "No Repo Access"` if they do not have permisison
-to affect said repo or `short: "Server Error"` if any other error has occured.
+Allows the ability to check if a user has permissions to write to a repo.<b>MUST</b> Be provided `owner/repo` to successfully function, and expects thefull `user` object. Returns `ok: true` where content is the repo data from GitHubon success, returns `short: "No Repo Access"` if they do not have permisisonto affect said repo or `short: "Server Error"` if any other error has occured.
 
 **Kind**: inner method of [<code>git</code>](#module_git)  
 
@@ -648,9 +641,7 @@ to affect said repo or `short: "Server Error"` if any other error has occured.
 <a name="module_git..createPackage"></a>
 
 ### git~createPackage(repo) ⇒ <code>object</code>
-Creates a compatible `Server Object Full` object, from only receiving a `repo` as in
-`owner/repo`. With this it contacts GitHub API's and modifies data as needed to
-return back a proper `Server Object Full` object within a `Server Status`.content object.
+Creates a compatible `Server Object Full` object, from only receiving a `repo` as in`owner/repo`. With this it contacts GitHub API's and modifies data as needed toreturn back a proper `Server Object Full` object within a `Server Status`.content object.
 
 **Kind**: inner method of [<code>git</code>](#module_git)  
 **Returns**: <code>object</code> - A `Server Status` Object where `content` is the `Server Package Full` object.  
@@ -665,8 +656,7 @@ return back a proper `Server Object Full` object within a `Server Status`.conten
 Get the version metadata package object and append tarball and hash.
 
 **Kind**: inner method of [<code>git</code>](#module_git)  
-**Returns**: <code>object</code> \| <code>undefined</code> - The metadata object with tarball URL and sha hash code
-appended, or undefined or error.  
+**Returns**: <code>object</code> \| <code>undefined</code> - The metadata object with tarball URL and sha hash codeappended, or undefined or error.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -677,8 +667,7 @@ appended, or undefined or error.
 <a name="module_git..selectPackageRepository"></a>
 
 ### git~selectPackageRepository(repo) ⇒ <code>object</code>
-Determines the repository object by the given argument.
-The functionality will only be declarative for now, and may change later on.
+Determines the repository object by the given argument.The functionality will only be declarative for now, and may change later on.
 
 **Kind**: inner method of [<code>git</code>](#module_git)  
 **Returns**: <code>object</code> - The object related to the package repository type.  
@@ -690,13 +679,10 @@ The functionality will only be declarative for now, and may change later on.
 <a name="module_git..doesUserHaveRepo"></a>
 
 ### git~doesUserHaveRepo(user, repo, [page]) ⇒ <code>object</code>
-Unexported function, that determines if the specified user has access
-to the specified repository. Will loop itself through all valid pages
-of users repo list, until it finds a match, otherwise returning accordingly.
+Unexported function, that determines if the specified user has accessto the specified repository. Will loop itself through all valid pagesof users repo list, until it finds a match, otherwise returning accordingly.
 
 **Kind**: inner method of [<code>git</code>](#module_git)  
-**Returns**: <code>object</code> - A server status object of true if they do have access.
-And returns false in all other situations.  
+**Returns**: <code>object</code> - A server status object of true if they do have access.And returns false in all other situations.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -707,8 +693,7 @@ And returns false in all other situations.
 <a name="module_git..getRepoExistance"></a>
 
 ### git~getRepoExistance(repo) ⇒ <code>boolean</code>
-Intends to determine if a repo exists, or at least is accessible and public
-on GitHub.
+Intends to determine if a repo exists, or at least is accessible and publicon GitHub.
 
 **Kind**: inner method of [<code>git</code>](#module_git)  
 **Returns**: <code>boolean</code> - A true if the repo exists, false otherwise. Including an error.  
@@ -723,8 +708,7 @@ on GitHub.
 Intends to retrieve the raw text of the GitHub repo package.
 
 **Kind**: inner method of [<code>git</code>](#module_git)  
-**Returns**: <code>string</code> \| <code>undefined</code> - Returns a proper string of the readme if successful.
-And returns `undefined` otherwise.  
+**Returns**: <code>string</code> \| <code>undefined</code> - Returns a proper string of the readme if successful.And returns `undefined` otherwise.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -733,12 +717,10 @@ And returns `undefined` otherwise.
 <a name="module_git..getRepoReadMe"></a>
 
 ### git~getRepoReadMe(repo) ⇒ <code>string</code> \| <code>undefined</code>
-Intends to retrieve the GitHub repo readme file. Will look for both
-`readme.md` and `README.md` just in case.
+Intends to retrieve the GitHub repo readme file. Will look for both`readme.md` and `README.md` just in case.
 
 **Kind**: inner method of [<code>git</code>](#module_git)  
-**Returns**: <code>string</code> \| <code>undefined</code> - Returns the raw string of the readme if available,
-otherwise returns undefined.  
+**Returns**: <code>string</code> \| <code>undefined</code> - Returns the raw string of the readme if available,otherwise returns undefined.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -747,12 +729,10 @@ otherwise returns undefined.
 <a name="module_git..getRepoTags"></a>
 
 ### git~getRepoTags(repo) ⇒ <code>object</code> \| <code>undefined</code>
-Intends to get all tags associated with a repo. Since this is how APM
-natively publishes new package versions on GitHub.
+Intends to get all tags associated with a repo. Since this is how APMnatively publishes new package versions on GitHub.
 
 **Kind**: inner method of [<code>git</code>](#module_git)  
-**Returns**: <code>object</code> \| <code>undefined</code> - Returns the JSON parsed object of all tags if successful,
-and returns undefined otherwise.  
+**Returns**: <code>object</code> \| <code>undefined</code> - Returns the JSON parsed object of all tags if successful,and returns undefined otherwise.  
 **See**: https://docs.github.com/en/rest/repos/repos#list-repository-tags  
 
 | Param | Type | Description |
@@ -762,8 +742,7 @@ and returns undefined otherwise.
 <a name="module_logger"></a>
 
 ## logger
-Allows easy logging of the server. Allowing it to become simple to add additional
-logging methods if a log server is ever implemented.
+Allows easy logging of the server. Allowing it to become simple to add additionallogging methods if a log server is ever implemented.
 
 
 * [logger](#module_logger)
@@ -792,10 +771,7 @@ HTTP:: IP [DATE (as ISO String)] "HTTP_METHOD URL PROTOCOL" STATUS_CODE DURATION
 <a name="module_logger..sanitizeLogs"></a>
 
 ### logger~sanitizeLogs(val) ⇒ <code>string</code>
-This function intends to assist in sanitizing values from users that
-are input into the logs. Ensuring log forgery does not occur.
-And to help ensure that other malicious actions are unable to take place to
-admins reviewing the logs.
+This function intends to assist in sanitizing values from users thatare input into the logs. Ensuring log forgery does not occur.And to help ensure that other malicious actions are unable to take place toadmins reviewing the logs.
 
 **Kind**: inner method of [<code>logger</code>](#module_logger)  
 **Returns**: <code>string</code> - A sanitized log from the provided value.  
@@ -808,12 +784,7 @@ admins reviewing the logs.
 <a name="module_logger..generic"></a>
 
 ### logger~generic(lvl, val, [meta])
-A generic logger, that will can accept all types of logs. And from then
-create warning, or info logs debending on the Log Level provided.
-Additionally the generic logger accepts a meta object argument, to extend
-it's logging capabilities, to include system objects, or otherwise unexpected values.
-It will have support for certain objects in the meta field to create specific
-logs, but otherwise will attempt to display the data provided.
+A generic logger, that will can accept all types of logs. And from thencreate warning, or info logs debending on the Log Level provided.Additionally the generic logger accepts a meta object argument, to extendit's logging capabilities, to include system objects, or otherwise unexpected values.It will have support for certain objects in the meta field to create specificlogs, but otherwise will attempt to display the data provided.
 
 **Kind**: inner method of [<code>logger</code>](#module_logger)  
 
@@ -826,12 +797,10 @@ logs, but otherwise will attempt to display the data provided.
 <a name="module_logger..craftError"></a>
 
 ### logger~craftError(meta) ⇒ <code>string</code>
-Used to help `logger.generic()` build it's logs. Used when type is
-specified as `error`.
+Used to help `logger.generic()` build it's logs. Used when type isspecified as `error`.
 
 **Kind**: inner method of [<code>logger</code>](#module_logger)  
-**Returns**: <code>string</code> - A crafted string message containing the output of the data
-provided.  
+**Returns**: <code>string</code> - A crafted string message containing the output of the dataprovided.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -840,12 +809,10 @@ provided.
 <a name="module_logger..craftHttp"></a>
 
 ### logger~craftHttp(meta) ⇒ <code>string</code>
-Used to help `logger.generic()` build it's logs. Used when type is
-specified as `http`. Based largely off `logger.httpLog()`
+Used to help `logger.generic()` build it's logs. Used when type isspecified as `http`. Based largely off `logger.httpLog()`
 
 **Kind**: inner method of [<code>logger</code>](#module_logger)  
-**Returns**: <code>string</code> - A crafted string message containing the output of the data
-provided.  
+**Returns**: <code>string</code> - A crafted string message containing the output of the dataprovided.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -854,15 +821,12 @@ provided.
 <a name="module_main"></a>
 
 ## main
-The Main functionality for the entire server. Sets up the Express server, providing
-all endpoints it listens on. With those endpoints being further documented in `api.md`.
+The Main functionality for the entire server. Sets up the Express server, providingall endpoints it listens on. With those endpoints being further documented in `api.md`.
 
 <a name="module_query"></a>
 
 ## query
-Home to parsing all query parameters from the `Request` object. Ensuring a valid response.
-While most values will just return their default there are some expecptions:
-engine(): Returns false if not defined, to allow a fast way to determine if results need to be pruned.
+Home to parsing all query parameters from the `Request` object. Ensuring a valid response.While most values will just return their default there are some expecptions:engine(): Returns false if not defined, to allow a fast way to determine if results need to be pruned.
 
 
 * [query](#module_query)
@@ -907,12 +871,10 @@ Parser for the 'sort' query parameter. Defaulting usually to downloads.
 <a name="module_query..dir"></a>
 
 ### query~dir(req) ⇒ <code>string</code>
-Parser for either 'direction' or 'order' query parameter, prioritizing
-'direction'.
+Parser for either 'direction' or 'order' query parameter, prioritizing'direction'.
 
 **Kind**: inner method of [<code>query</code>](#module_query)  
-**Returns**: <code>string</code> - The valid direction value from the 'direction' or 'order'
-query parameter.  
+**Returns**: <code>string</code> - The valid direction value from the 'direction' or 'order'query parameter.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -921,8 +883,7 @@ query parameter.
 <a name="module_query..query"></a>
 
 ### query~query(req) ⇒ <code>string</code>
-Checks the 'q' query parameter, trunicating it at 50 characters, and checking simplisticly that
-it is not a malicious request. Returning "" if an unsafe or invalid query is passed.
+Checks the 'q' query parameter, trunicating it at 50 characters, and checking simplisticly thatit is not a malicious request. Returning "" if an unsafe or invalid query is passed.
 
 **Kind**: inner method of [<code>query</code>](#module_query)  
 **Implements**: <code>pathTraversalAttempt</code>  
@@ -983,8 +944,7 @@ Parses the 'tag' query parameter, returning it if valid, otherwise returning ''.
 <a name="module_query..rename"></a>
 
 ### query~rename(req) ⇒ <code>boolean</code>
-Since this is intended to be returning a boolean value, returns false
-if invalid, otherwise returns true. Checking for mixed captilization.
+Since this is intended to be returning a boolean value, returns falseif invalid, otherwise returns true. Checking for mixed captilization.
 
 **Kind**: inner method of [<code>query</code>](#module_query)  
 **Returns**: <code>boolean</code> - Returns false if invalid, or otherwise returns the boolean value of the string.  
@@ -996,8 +956,7 @@ if invalid, otherwise returns true. Checking for mixed captilization.
 <a name="module_query..packageName"></a>
 
 ### query~packageName(req) ⇒ <code>string</code>
-This function will convert a user provided package name into a safe format.
-It ensures the name is converted to lower case. As is the requirement of all package names.
+This function will convert a user provided package name into a safe format.It ensures the name is converted to lower case. As is the requirement of all package names.
 
 **Kind**: inner method of [<code>query</code>](#module_query)  
 **Returns**: <code>string</code> - Returns the package name in a safe format that can be worked with further.  
@@ -1009,9 +968,7 @@ It ensures the name is converted to lower case. As is the requirement of all pac
 <a name="module_query..pathTraversalAttempt"></a>
 
 ### query~pathTraversalAttempt(data) ⇒ <code>boolean</code>
-Completes some short checks to determine if the data contains a malicious
-path traversal attempt. Returning a boolean indicating if a path traversal attempt
-exists in the data.
+Completes some short checks to determine if the data contains a maliciouspath traversal attempt. Returning a boolean indicating if a path traversal attemptexists in the data.
 
 **Kind**: inner method of [<code>query</code>](#module_query)  
 **Returns**: <code>boolean</code> - True indicates a path traversal attempt was found. False otherwise.  
@@ -1035,14 +992,12 @@ Returns the User from the URL Path, otherwise ''
 <a name="module_server"></a>
 
 ## server
-The initializer of `main.js` starting up the Express Server, and setting the port
-to listen on. As well as handling a graceful shutdown of the server.
+The initializer of `main.js` starting up the Express Server, and setting the portto listen on. As well as handling a graceful shutdown of the server.
 
 <a name="module_server..exterminate"></a>
 
 ### server~exterminate(callee)
-This is called when the server process receives a `SIGINT` or `SIGTERM` signal.
-Which this will then handle closing the server listener, as well as calling `data.Shutdown`.
+This is called when the server process receives a `SIGINT` or `SIGTERM` signal.Which this will then handle closing the server listener, as well as calling `data.Shutdown`.
 
 **Kind**: inner method of [<code>server</code>](#module_server)  
 
@@ -1053,38 +1008,33 @@ Which this will then handle closing the server listener, as well as calling `dat
 <a name="module_storage"></a>
 
 ## storage
-This module is the second generation of data storage methodology,
-in which this provides static access to files stored within regular cloud
-file storage. Specifically intended for use with Google Cloud Storage.
+This module is the second generation of data storage methodology,in which this provides static access to files stored within regular cloudfile storage. Specifically intended for use with Google Cloud Storage.
 
 
 * [storage](#module_storage)
-    * [~checkGCS()](#module_storage..checkGCS)
+    * [~setupGCS()](#module_storage..setupGCS) ⇒ <code>object</code>
     * [~getBanList()](#module_storage..getBanList) ⇒ <code>Array</code>
     * [~getFeaturedPackages()](#module_storage..getFeaturedPackages) ⇒ <code>Array</code>
     * [~getFeaturedThemes()](#module_storage..getFeaturedThemes) ⇒ <code>Array</code>
 
-<a name="module_storage..checkGCS"></a>
+<a name="module_storage..setupGCS"></a>
 
-### storage~checkGCS()
+### storage~setupGCS() ⇒ <code>object</code>
 Sets up the Google Cloud Storage Class, to ensure its ready to use.
 
 **Kind**: inner method of [<code>storage</code>](#module_storage)  
+**Returns**: <code>object</code> - - A new Google Cloud Storage instance.  
 <a name="module_storage..getBanList"></a>
 
 ### storage~getBanList() ⇒ <code>Array</code>
-Reads the ban list from the Google Cloud Storage Space.
-Returning the cached parsed JSON object.
-If it has been read before during this instance of hosting just the cached
-version is returned.
+Reads the ban list from the Google Cloud Storage Space.Returning the cached parsed JSON object.If it has been read before during this instance of hosting just the cachedversion is returned.
 
 **Kind**: inner method of [<code>storage</code>](#module_storage)  
 **Returns**: <code>Array</code> - Parsed JSON Array of all Banned Packages.  
 <a name="module_storage..getFeaturedPackages"></a>
 
 ### storage~getFeaturedPackages() ⇒ <code>Array</code>
-Returns the hardcoded featured packages file from Google Cloud Storage.
-Caching the object once read for this instance of the server run.
+Returns the hardcoded featured packages file from Google Cloud Storage.Caching the object once read for this instance of the server run.
 
 **Kind**: inner method of [<code>storage</code>](#module_storage)  
 **Returns**: <code>Array</code> - Parsed JSON Array of all Featured Packages.  
@@ -1102,7 +1052,6 @@ A helper for any functions that are agnostic in handlers.
 
 
 * [utils](#module_utils)
-    * [~StateStore](#module_utils..StateStore)
     * [~isPackageNameBanned(name)](#module_utils..isPackageNameBanned) ⇒ <code>object</code>
     * [~constructPackageObjectFull(pack)](#module_utils..constructPackageObjectFull) ⇒ <code>object</code>
     * [~constructPackageObjectShort(pack)](#module_utils..constructPackageObjectShort) ⇒ <code>object</code> \| <code>array</code>
@@ -1114,27 +1063,15 @@ A helper for any functions that are agnostic in handlers.
     * [~getOwnerRepoFromPackage(pack)](#module_utils..getOwnerRepoFromPackage) ⇒ <code>string</code>
     * [~getOwnerRepoFromUrlString(url)](#module_utils..getOwnerRepoFromUrlString) ⇒ <code>string</code>
     * [~semverEq(a1, a2)](#module_utils..semverEq) ⇒ <code>boolean</code>
-    * [~getState(ip, state)](#module_utils..getState) ⇒ <code>object</code>
-    * [~setState(ip)](#module_utils..setState) ⇒ <code>object</code>
+    * [~generateRandomString(n)](#module_utils..generateRandomString) ⇒ <code>string</code>
 
-<a name="module_utils..StateStore"></a>
-
-### utils~StateStore
-This simple state store acts as a hash map, allowing authentication request
-to quickly add a new state related to an IP, and retrieve it later on.
-These states are used during the authentication flow to help ensure against malicious activity.
-
-**Kind**: inner class of [<code>utils</code>](#module_utils)  
 <a name="module_utils..isPackageNameBanned"></a>
 
 ### utils~isPackageNameBanned(name) ⇒ <code>object</code>
-This uses the `storage.js` to retrieve a banlist. And then simply
-iterates through the banList array, until it finds a match to the name
-it was given. If no match is found then it returns false.
+This uses the `storage.js` to retrieve a banlist. And then simplyiterates through the banList array, until it finds a match to the nameit was given. If no match is found then it returns false.
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
-**Returns**: <code>object</code> - Returns Server Status Object with ok as true if blocked,
-false otherwise.  
+**Returns**: <code>object</code> - Returns Server Status Object with ok as true if blocked,false otherwise.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1143,10 +1080,7 @@ false otherwise.
 <a name="module_utils..constructPackageObjectFull"></a>
 
 ### utils~constructPackageObjectFull(pack) ⇒ <code>object</code>
-Takes the raw return of a full row from database.getPackageByName() and
-constructs a standardized package object full from it.
-This should be called only on the data provided by database.getPackageByName(),
-otherwise the behavior is unexpected.
+Takes the raw return of a full row from database.getPackageByName() andconstructs a standardized package object full from it.This should be called only on the data provided by database.getPackageByName(),otherwise the behavior is unexpected.
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
 **Returns**: <code>object</code> - A properly formatted and converted Package Object Full.  
@@ -1163,8 +1097,7 @@ otherwise the behavior is unexpected.
 <a name="module_utils..constructPackageObjectShort"></a>
 
 ### utils~constructPackageObjectShort(pack) ⇒ <code>object</code> \| <code>array</code>
-Takes a single or array of rows from the db, and returns a JSON
-construction of package object shorts
+Takes a single or array of rows from the db, and returns a JSONconstruction of package object shorts
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
 **Returns**: <code>object</code> \| <code>array</code> - A properly formatted and converted Package Object Short.  
@@ -1181,9 +1114,7 @@ construction of package object shorts
 <a name="module_utils..constructPackageObjectJSON"></a>
 
 ### utils~constructPackageObjectJSON(pack) ⇒ <code>object</code>
-Takes the return of getPackageVersionByNameAndVersion and returns
-a recreation of the package.json with a modified dist.tarball key, pointing
-to this server for download.
+Takes the return of getPackageVersionByNameAndVersion and returnsa recreation of the package.json with a modified dist.tarball key, pointingto this server for download.
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
 **Returns**: <code>object</code> - A properly formatted Package Object Mini.  
@@ -1196,17 +1127,14 @@ to this server for download.
 <a name="module_utils..engineFilter"></a>
 
 ### utils~engineFilter() ⇒ <code>object</code>
-A complex function that provides filtering by Atom engine version.
-This should take a package with it's versions and retrieve whatever matches
-that engine version as provided.
+A complex function that provides filtering by Atom engine version.This should take a package with it's versions and retrieve whatever matchesthat engine version as provided.
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
 **Returns**: <code>object</code> - The filtered object.  
 <a name="module_utils..semverArray"></a>
 
 ### utils~semverArray(semver) ⇒ <code>array</code> \| <code>null</code>
-Takes a semver string and returns it as an Array of strings.
-This can also be used to check for semver valitidy. If it's not a semver, null is returned.
+Takes a semver string and returns it as an Array of strings.This can also be used to check for semver valitidy. If it's not a semver, null is returned.
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
 **Returns**: <code>array</code> \| <code>null</code> - The formatted semver in array of three strings, or null if no match.  
@@ -1228,9 +1156,7 @@ semverArray("1.Hello.World");
 <a name="module_utils..semverGt"></a>
 
 ### utils~semverGt(a1, a2) ⇒ <code>boolean</code>
-Compares two sermver and return true if the first is greater than the second.
-Expects to get the semver formatted as array of strings.
-Should be always executed after running semverArray.
+Compares two sermver and return true if the first is greater than the second.Expects to get the semver formatted as array of strings.Should be always executed after running semverArray.
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
 **Returns**: <code>boolean</code> - The result of the comparison  
@@ -1243,9 +1169,7 @@ Should be always executed after running semverArray.
 <a name="module_utils..semverLt"></a>
 
 ### utils~semverLt(a1, a2) ⇒ <code>boolean</code>
-Compares two sermver and return true if the first is less than the second.
-Expects to get the semver formatted as array of strings.
-Should be always executed after running semverArray.
+Compares two sermver and return true if the first is less than the second.Expects to get the semver formatted as array of strings.Should be always executed after running semverArray.
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
 **Returns**: <code>boolean</code> - The result of the comparison  
@@ -1258,8 +1182,7 @@ Should be always executed after running semverArray.
 <a name="module_utils..getOwnerRepoFromPackage"></a>
 
 ### utils~getOwnerRepoFromPackage(pack) ⇒ <code>string</code>
-A function that takes a package and tries to extract `owner/repo` string from it
-relying on getOwnerRepoFromUrlString util.
+A function that takes a package and tries to extract `owner/repo` string from itrelying on getOwnerRepoFromUrlString util.
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
 **Returns**: <code>string</code> - The `owner/repo` string from the URL. Or an empty string if unable to parse.  
@@ -1271,8 +1194,7 @@ relying on getOwnerRepoFromUrlString util.
 <a name="module_utils..getOwnerRepoFromUrlString"></a>
 
 ### utils~getOwnerRepoFromUrlString(url) ⇒ <code>string</code>
-A function that takes the URL string of a GitHub repo and return the `owner/repo`
-string for the repo. Intended to be used from a packages entry `data.repository.url`
+A function that takes the URL string of a GitHub repo and return the `owner/repo`string for the repo. Intended to be used from a packages entry `data.repository.url`
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
 **Returns**: <code>string</code> - The `owner/repo` string from the URL. Or an empty string if unable to parse.  
@@ -1284,53 +1206,32 @@ string for the repo. Intended to be used from a packages entry `data.repository.
 <a name="module_utils..semverEq"></a>
 
 ### utils~semverEq(a1, a2) ⇒ <code>boolean</code>
-Compares two sermver and return true if the first is equal to the second.
-Expects to get the semver formatted as array of strings.
-Should be always executed after running semverArray.
+Compares two sermver and return true if the first is equal to the second.Expects to get the semver formatted as array of strings.Should be always executed after running semverArray.
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
-**Returns**: <code>boolean</code> - The result of the comparison  
+**Returns**: <code>boolean</code> - The result of the comparison.  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| a1 | <code>array</code> | First semver as array |
-| a2 | <code>array</code> | Second semver as array |
+| a1 | <code>array</code> | First semver as array. |
+| a2 | <code>array</code> | Second semver as array. |
 
-<a name="module_utils..getState"></a>
+<a name="module_utils..generateRandomString"></a>
 
-### utils~getState(ip, state) ⇒ <code>object</code>
-`getState` of `StateStore` checks if the given IP in the hashmap matches
-the given IP and given State in the StateStore.
+### utils~generateRandomString(n) ⇒ <code>string</code>
+Uses the crypto module to generate and return a random string.
 
 **Kind**: inner method of [<code>utils</code>](#module_utils)  
-**Returns**: <code>object</code> - A Server Status Object, where `ok` is true if the IP corresponds to
-the given state. And `ok` is false otherwise.  
+**Returns**: <code>string</code> - A string exported from the generated Buffer using the "hex" format (encodeeach byte as two hexadecimal characters).  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| ip | <code>string</code> | The IP Address to check with. |
-| state | <code>string</code> | The State to check with. |
-
-<a name="module_utils..setState"></a>
-
-### utils~setState(ip) ⇒ <code>object</code>
-A Promise that inputs the given IP into the StateStore, and returns
-it's generated State Hash.
-
-**Kind**: inner method of [<code>utils</code>](#module_utils)  
-**Returns**: <code>object</code> - A Server Status Object where if `ok` is true, `content` contains
-the generated state.  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| ip | <code>string</code> | The IP to enter into the State Store. |
+| n | <code>string</code> | The number of bytes to generate. |
 
 <a name="module_common_handler"></a>
 
 ## common\_handler
-Provides a simplistic way to refer to implement common endpoint returns.
-So these can be called as an async function without more complex functions, reducing
-verbosity, and duplication within the codebase.
+Provides a simplistic way to refer to implement common endpoint returns.So these can be called as an async function without more complex functions, reducingverbosity, and duplication within the codebase.
 
 **Implements**: <code>logger</code>  
 
@@ -1349,9 +1250,7 @@ verbosity, and duplication within the codebase.
 <a name="module_common_handler..handleError"></a>
 
 ### common_handler~handleError(req, res, obj)
-Generic error handler mostly used to reduce the duplication of error handling in other modules.
-It checks the short error string and calls the relative endpoint.
-Note that it's designed to be called as the last async function before the return.
+Generic error handler mostly used to reduce the duplication of error handling in other modules.It checks the short error string and calls the relative endpoint.Note that it's designed to be called as the last async function before the return.
 
 **Kind**: inner method of [<code>common\_handler</code>](#module_common_handler)  
 
@@ -1364,8 +1263,7 @@ Note that it's designed to be called as the last async function before the retur
 <a name="module_common_handler..authFail"></a>
 
 ### common_handler~authFail(req, res, user)
-Will take the <b>failed</b> user object from VerifyAuth, and respond for the endpoint as
-either a "Server Error" or a "Bad Auth", whichever is correct based on the Error bubbled from VerifyAuth.
+Will take the <b>failed</b> user object from VerifyAuth, and respond for the endpoint aseither a "Server Error" or a "Bad Auth", whichever is correct based on the Error bubbled from VerifyAuth.
 
 **Kind**: inner method of [<code>common\_handler</code>](#module_common_handler)  
 **Implements**: <code>MissingAuthJSON</code>, <code>ServerErrorJSON</code>, <code>logger.HTTPLog</code>  
@@ -1379,10 +1277,7 @@ either a "Server Error" or a "Bad Auth", whichever is correct based on the Error
 <a name="module_common_handler..serverError"></a>
 
 ### common_handler~serverError(req, res, err)
-Returns a standard Server Error to the user as JSON. Logging the detailed error message to the server.
-###### Setting:
-* Status Code: 500
-* JSON Response Body: message: "Application Error"
+Returns a standard Server Error to the user as JSON. Logging the detailed error message to the server.###### Setting:* Status Code: 500* JSON Response Body: message: "Application Error"
 
 **Kind**: inner method of [<code>common\_handler</code>](#module_common_handler)  
 **Implements**: <code>logger.HTTPLog</code>, <code>logger.generic</code>  
@@ -1396,10 +1291,7 @@ Returns a standard Server Error to the user as JSON. Logging the detailed error 
 <a name="module_common_handler..notFound"></a>
 
 ### common_handler~notFound(req, res)
-Standard endpoint to return the JSON Not Found error to the user.
-###### Setting:
-* Status Code: 404
-* JSON Respone Body: message: "Not Found"
+Standard endpoint to return the JSON Not Found error to the user.###### Setting:* Status Code: 404* JSON Respone Body: message: "Not Found"
 
 **Kind**: inner method of [<code>common\_handler</code>](#module_common_handler)  
 **Implements**: <code>logger.HTTPLog</code>  
@@ -1412,10 +1304,7 @@ Standard endpoint to return the JSON Not Found error to the user.
 <a name="module_common_handler..notSupported"></a>
 
 ### common_handler~notSupported(req, res)
-Returns a Not Supported message to the user.
-###### Setting:
-* Status Code: 501
-* JSON Response Body: message: "While under development this feature is not supported."
+Returns a Not Supported message to the user.###### Setting:* Status Code: 501* JSON Response Body: message: "While under development this feature is not supported."
 
 **Kind**: inner method of [<code>common\_handler</code>](#module_common_handler)  
 **Implements**: <code>logger.HTTPLog</code>  
@@ -1428,10 +1317,7 @@ Returns a Not Supported message to the user.
 <a name="module_common_handler..siteWideNotFound"></a>
 
 ### common_handler~siteWideNotFound(req, res)
-Returns the SiteWide 404 page to the end user.
-###### Setting Currently:
-* Status Code: 404
-* JSON Response Body: message: "This is a standin for the proper site wide 404 page."
+Returns the SiteWide 404 page to the end user.###### Setting Currently:* Status Code: 404* JSON Response Body: message: "This is a standin for the proper site wide 404 page."
 
 **Kind**: inner method of [<code>common\_handler</code>](#module_common_handler)  
 **Implements**: <code>logger.HTTPLog</code>  
@@ -1444,10 +1330,7 @@ Returns the SiteWide 404 page to the end user.
 <a name="module_common_handler..badRepoJSON"></a>
 
 ### common_handler~badRepoJSON(req, res)
-Returns the BadRepoJSON message to the user.
-###### Setting:
-* Status Code: 400
-* JSON Response Body: message: That repo does not exist, isn't an atom package, or atombot does not have access.
+Returns the BadRepoJSON message to the user.###### Setting:* Status Code: 400* JSON Response Body: message: That repo does not exist, isn't an atom package, or atombot does not have access.
 
 **Kind**: inner method of [<code>common\_handler</code>](#module_common_handler)  
 **Implements**: <code>logger.HTTPLog</code>  
@@ -1460,10 +1343,7 @@ Returns the BadRepoJSON message to the user.
 <a name="module_common_handler..badPackageJSON"></a>
 
 ### common_handler~badPackageJSON(req, res)
-Returns the BadPackageJSON message to the user.
-###### Setting:
-* Status Code: 400
-* JSON Response Body: message: The package.json at owner/repo isn't valid.
+Returns the BadPackageJSON message to the user.###### Setting:* Status Code: 400* JSON Response Body: message: The package.json at owner/repo isn't valid.
 
 **Kind**: inner method of [<code>common\_handler</code>](#module_common_handler)  
 **Implements**: <code>logger.HTTPLog</code>  
@@ -1476,10 +1356,7 @@ Returns the BadPackageJSON message to the user.
 <a name="module_common_handler..packageExists"></a>
 
 ### common_handler~packageExists(req, res)
-Returns the PackageExist message to the user.
-###### Setting:
-* Status Code: 409
-* JSON Response Body: message: "A Package by that name already exists."
+Returns the PackageExist message to the user.###### Setting:* Status Code: 409* JSON Response Body: message: "A Package by that name already exists."
 
 **Kind**: inner method of [<code>common\_handler</code>](#module_common_handler)  
 **Implements**: <code>logger.HTTPLog</code>  
@@ -1492,10 +1369,7 @@ Returns the PackageExist message to the user.
 <a name="module_common_handler..missingAuthJSON"></a>
 
 ### common_handler~missingAuthJSON(req, res)
-Returns the MissingAuth message to the user.
-###### Setting:
-* Status Code: 401
-* JSON Response Body: message: "Requires authentication. Please update your token if you haven't done so recently."
+Returns the MissingAuth message to the user.###### Setting:* Status Code: 401* JSON Response Body: message: "Requires authentication. Please update your token if you haven't done so recently."
 
 **Kind**: inner method of [<code>common\_handler</code>](#module_common_handler)  
 **Implements**: <code>logger.HTTPLog</code>  
@@ -1520,8 +1394,7 @@ Endpoint Handlers for Authentication URLs
 <a name="module_oauth_handler..getLogin"></a>
 
 ### oauth_handler~getLogin(req, res)
-Endpoint used to direct users to login, directing the user to the
-proper GitHub OAuth Page based on the backends client id.
+Endpoint used to redirect users to login. Users will reach GitHub OAuth Pagebased on the backends client id. A key from crypto module is retrieved and used asstate parameter for GH authentication.
 
 **Kind**: inner method of [<code>oauth\_handler</code>](#module_oauth_handler)  
 
@@ -1601,8 +1474,7 @@ Endpoint Handlers in all relating to the packages themselves.
 <a name="module_package_handler..getPackages"></a>
 
 ### package_handler~getPackages(req, res)
-Endpoint to return all packages to the user. Based on any filtering
-theyved applied via query parameters.
+Endpoint to return all packages to the user. Based on any filteringtheyved applied via query parameters.
 
 **Kind**: inner method of [<code>package\_handler</code>](#module_package_handler)  
 
@@ -1621,13 +1493,10 @@ theyved applied via query parameters.
 <a name="module_package_handler..postPackages"></a>
 
 ### package_handler~postPackages(req, res) ⇒ <code>string</code>
-This endpoint is used to publish a new package to the backend server.
-Taking the repo, and your authentication for it, determines if it can be published,
-then goes about doing so.
+This endpoint is used to publish a new package to the backend server.Taking the repo, and your authentication for it, determines if it can be published,then goes about doing so.
 
 **Kind**: inner method of [<code>package\_handler</code>](#module_package_handler)  
-**Returns**: <code>string</code> - JSON object of new data pushed into the database, but stripped of
-sensitive informations like primary and foreign keys.  
+**Returns**: <code>string</code> - JSON object of new data pushed into the database, but stripped ofsensitive informations like primary and foreign keys.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -1644,10 +1513,7 @@ sensitive informations like primary and foreign keys.
 <a name="module_package_handler..getPackagesFeatured"></a>
 
 ### package_handler~getPackagesFeatured(req, res)
-Allows the user to retrieve the featured packages, as package object shorts.
-This endpoint was originally undocumented. The decision to return 200 is based off similar endpoints.
-Additionally for the time being this list is created manually, the same method used
-on Atom.io for now. Although there are plans to have this become automatic later on.
+Allows the user to retrieve the featured packages, as package object shorts.This endpoint was originally undocumented. The decision to return 200 is based off similar endpoints.Additionally for the time being this list is created manually, the same method usedon Atom.io for now. Although there are plans to have this become automatic later on.
 
 **Kind**: inner method of [<code>package\_handler</code>](#module_package_handler)  
 **See**
@@ -1671,15 +1537,12 @@ on Atom.io for now. Although there are plans to have this become automatic later
 <a name="module_package_handler..getPackagesSearch"></a>
 
 ### package_handler~getPackagesSearch(req, res)
-Allows user to search through all packages. Using their specified
-query parameter.
+Allows user to search through all packages. Using their specifiedquery parameter.
 
 **Kind**: inner method of [<code>package\_handler</code>](#module_package_handler)  
 **Todo**
 
-- [ ] Note: This **has** been migrated to the new DB, and is fully functional.
-The TODO here is to eventually move this to use the custom built in LCS search,
-rather than simple search.
+- [ ] Note: This **has** been migrated to the new DB, and is fully functional.The TODO here is to eventually move this to use the custom built in LCS search,rather than simple search.
 
 
 | Param | Type | Description |
@@ -1697,8 +1560,7 @@ rather than simple search.
 <a name="module_package_handler..getPackagesDetails"></a>
 
 ### package_handler~getPackagesDetails(req, res)
-Allows the user to request a single package object full, depending
-on the package included in the path parameter.
+Allows the user to request a single package object full, dependingon the package included in the path parameter.
 
 **Kind**: inner method of [<code>package\_handler</code>](#module_package_handler)  
 
@@ -1774,8 +1636,7 @@ Used to remove a star from a specific package for the authenticated usesr.
 <a name="module_package_handler..getPackagesStargazers"></a>
 
 ### package_handler~getPackagesStargazers(req, res)
-Endpoint returns the array of `star_gazers` from a specified package.
-Taking only the package wanted, and returning it directly.
+Endpoint returns the array of `star_gazers` from a specified package.Taking only the package wanted, and returning it directly.
 
 **Kind**: inner method of [<code>package\_handler</code>](#module_package_handler)  
 
@@ -1794,8 +1655,7 @@ Taking only the package wanted, and returning it directly.
 <a name="module_package_handler..postPackagesVersion"></a>
 
 ### package_handler~postPackagesVersion(req, res)
-Allows a new version of a package to be published. But also can allow
-a user to rename their application during this process.
+Allows a new version of a package to be published. But also can allowa user to rename their application during this process.
 
 **Kind**: inner method of [<code>package\_handler</code>](#module_package_handler)  
 
@@ -1833,8 +1693,7 @@ Used to retrieve a specific version from a package.
 <a name="module_package_handler..getPackagesVersionTarball"></a>
 
 ### package_handler~getPackagesVersionTarball(req, res)
-Allows the user to get the tarball for a specific package version.
-Which should initiate a download of said tarball on their end.
+Allows the user to get the tarball for a specific package version.Which should initiate a download of said tarball on their end.
 
 **Kind**: inner method of [<code>package\_handler</code>](#module_package_handler)  
 
@@ -1872,10 +1731,7 @@ Allows a user to delete a specific version of their package.
 <a name="module_package_handler..postPackagesEventUninstall"></a>
 
 ### package_handler~postPackagesEventUninstall(req, res)
-Used when a package is uninstalled, decreases the download count by 1.
-And saves this data, Originally an undocumented endpoint.
-The decision to return a '201' was based on how other POST endpoints return,
-during a successful event.
+Used when a package is uninstalled, decreases the download count by 1.And saves this data, Originally an undocumented endpoint.The decision to return a '201' was based on how other POST endpoints return,during a successful event.
 
 **Kind**: inner method of [<code>package\_handler</code>](#module_package_handler)  
 **See**: [https://github.com/atom/apm/blob/master/src/uninstall.coffee](https://github.com/atom/apm/blob/master/src/uninstall.coffee)  
@@ -1900,8 +1756,7 @@ Handler for any endpoints whose slug after `/api/` is `star`.
 <a name="module_star_handler..getStars"></a>
 
 ### star_handler~getStars(req, res)
-Endpoint for `GET /api/stars`. Whose endgoal is to return an array of all packages
-the authenticated user has stared.
+Endpoint for `GET /api/stars`. Whose endgoal is to return an array of all packagesthe authenticated user has stared.
 
 **Kind**: inner method of [<code>star\_handler</code>](#module_star_handler)  
 
@@ -1932,10 +1787,7 @@ Endpoint Handlers relating to themes only.
 <a name="module_theme_handler..getThemeFeatured"></a>
 
 ### theme_handler~getThemeFeatured(req, res)
-Used to retrieve all Featured Packages that are Themes. Originally an undocumented
-endpoint. Returns a 200 response based on other similar responses.
-Additionally for the time being this list is created manually, the same method used
-on Atom.io for now. Although there are plans to have this become automatic later on.
+Used to retrieve all Featured Packages that are Themes. Originally an undocumentedendpoint. Returns a 200 response based on other similar responses.Additionally for the time being this list is created manually, the same method usedon Atom.io for now. Although there are plans to have this become automatic later on.
 
 **Kind**: inner method of [<code>theme\_handler</code>](#module_theme_handler)  
 **See**
@@ -1959,8 +1811,7 @@ on Atom.io for now. Although there are plans to have this become automatic later
 <a name="module_theme_handler..getThemes"></a>
 
 ### theme_handler~getThemes(req, res)
-Endpoint to return all Themes to the user. Based on any filtering
-they'ved applied via query parameters.
+Endpoint to return all Themes to the user. Based on any filteringthey'ved applied via query parameters.
 
 **Kind**: inner method of [<code>theme\_handler</code>](#module_theme_handler)  
 
@@ -2009,8 +1860,7 @@ Used to retrieve new editor update information.
 **Kind**: inner method of [<code>update\_handler</code>](#module_update_handler)  
 **Todo**
 
-- [ ] This function has never been implemented on this system. Since there is currently no
-update methodology.
+- [ ] This function has never been implemented on this system. Since there is currently noupdate methodology.
 
 
 | Param | Type | Description |
@@ -2077,8 +1927,7 @@ Endpoint that returns the currently authenticated Users User Details
 <a name="module_user_handler..getUser"></a>
 
 ### user_handler~getUser(req, res)
-Endpoint that returns the user account details of another user. Including all packages
-published.
+Endpoint that returns the user account details of another user. Including all packagespublished.
 
 **Kind**: inner method of [<code>user\_handler</code>](#module_user_handler)  
 
@@ -2096,13 +1945,17 @@ published.
 
 <a name="verifyAuth"></a>
 
-## verifyAuth()
-This will be the major function to determine, confirm, and provide user
-details of an authenticated user. This will take a users provided token,
-and use it to check GitHub for the details of whoever owns this token.
-Once that is done, we can go ahead and search for said user within the database.
-If the user exists, then we can confirm that they are both locally and globally
-authenticated, and execute whatever action it is they wanted to.
+## verifyAuth() ⇒ <code>object</code>
+This will be the major function to determine, confirm, and provide userdetails of an authenticated user. This will take a users provided token,and use it to check GitHub for the details of whoever owns this token.Once that is done, we can go ahead and search for said user within the database.If the user exists, then we can confirm that they are both locally and globallyauthenticated, and execute whatever action it is they wanted to.
 
 **Kind**: global function  
-**Params**: <code>object</code> token - The token the user provided.  
+**Returns**: <code>object</code> - A server status object.  
+**Params**: <code>string</code> token - The token the user provided.  
+<a name="getUserDataDevMode"></a>
+
+## getUserDataDevMode() ⇒ <code>object</code>
+An internal util to retrieve the user data object in developer mode only.
+
+**Kind**: global function  
+**Returns**: <code>object</code> - A mocked HTTP return containing the minimum information required to mock the return expected from GitHub.  
+**Params**: <code>string</code> token - The token the user provided.  

--- a/jsdoc.conf.js
+++ b/jsdoc.conf.js
@@ -11,4 +11,23 @@ module.exports = {
   // There's no need for us to actually configure JSDoc
   // We are only using the config file to be able to parse BigInts
   // Once the above linked issue is resolved, we can remove our config
+  //
+  // But with that said, seems that Codacy fails with this empty config,
+  // Possibly using it internally? (For some reason)
+  // Lets try putting the default config here
+  "plugins": [],
+  "recurseDepth": 10,
+  "source": {
+    "includePattern": ".+\\.js(doc|x)?$",
+    "excludePattern": "(^|\\/|\\\\)_"
+  },
+  "sourceType": "module",
+  "tags": {
+    "allowUnkownTags": true,
+    "dictionaries": ["jsdoc", "closure"]
+  },
+  "templates": {
+    "cleverLinks": false,
+    "monospaceLinks": false
+  }
 };

--- a/jsdoc.conf.js
+++ b/jsdoc.conf.js
@@ -11,23 +11,4 @@ module.exports = {
   // There's no need for us to actually configure JSDoc
   // We are only using the config file to be able to parse BigInts
   // Once the above linked issue is resolved, we can remove our config
-  //
-  // But with that said, seems that Codacy fails with this empty config,
-  // Possibly using it internally? (For some reason)
-  // Lets try putting the default config here
-  "plugins": [],
-  "recurseDepth": 10,
-  "source": {
-    "includePattern": ".+\\.js(doc|x)?$",
-    "excludePattern": "(^|\\/|\\\\)_"
-  },
-  "sourceType": "module",
-  "tags": {
-    "allowUnkownTags": true,
-    "dictionaries": ["jsdoc", "closure"]
-  },
-  "templates": {
-    "cleverLinks": false,
-    "monospaceLinks": false
-  }
 };

--- a/jsdoc.conf.js
+++ b/jsdoc.conf.js
@@ -1,0 +1,14 @@
+'use strict'
+
+// BigInt JSON serialization.
+// JSDoc by default will fail when BigInts are used within the codebase
+// https://github.com/jsdoc/jsdoc/issues/1918
+BigInt.prototype.toJSON = function() {
+  return this.toString() + 'n';
+};
+
+module.exports = {
+  // There's no need for us to actually configure JSDoc
+  // We are only using the config file to be able to parse BigInts
+  // Once the above linked issue is resolved, we can remove our config
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "api-docs": "quick-webserver-docs -i ./src/main.js -o ./docs/reference/API_Definition.md",
     "lint": "prettier --check -u -w .",
     "complex": "cr --newmi --config .complexrc .",
-    "js-docs": "jsdoc2md ./src/*.js ./src/handlers/*.js > ./docs/reference/Source_Documentation.md",
+    "js-docs": "jsdoc2md -c ./jsdoc.conf.js ./src/*.js ./src/handlers/*.js > ./docs/reference/Source_Documentation.md",
     "contributors:add": "all-contributors add",
     "test_search": "node ./scripts/tools/search.js",
     "migrations": "pg-migrations apply --directory ./src/dev-runner/migrations"


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

Our GitHub Actions Standards are currently failing, because JSDoc doesn't have any support for finding BigInts within the codebase, which have recently been added.

This PR provides a monkeypatch that resolves the issue, by providing an empty config to JSDoc and manually overriding it's handling of BigInts within the code.

This has been added and tested based off the recommendations within the [JSDoc Issue](https://github.com/jsdoc/jsdoc/issues/1918) and once resolved we can remove this.