### PR TITLE
POST new package version: remove unused tag parameter

### DIFF
--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -577,21 +577,10 @@ async function getPackagesStargazers(req, res) {
  */
 async function postPackagesVersion(req, res) {
   const params = {
-    // tag: query.tag(req), // unused parameter
     rename: query.rename(req),
     auth: query.auth(req),
     packageName: query.packageName(req),
   };
-
-  /* Check tag validity
-  if (params.tag === "") {
-    await common.handleError(req, res, {
-      ok: false,
-      short: "Bad Repo",
-      content: "The tag parameter is not specified correctly",
-    });
-    return;
-  }*/
 
   // On renaming:
   // When a package is being renamed, we will expect that packageName will

--- a/src/main.js
+++ b/src/main.js
@@ -696,7 +696,7 @@ app.options(
  * @path /api/packages/:packageName/versions
  * @auth true
  * @method POST
- * @desc Creates a new package version from a git tag. If `rename` is not `true`, the `name` field in `package.json` _must_ match the current package name.
+ * @desc Creates a new package version. If `rename` is not `true`, the `name` field in `package.json` _must_ match the current package name.
  * @param
  *   @name packType
  *   @location path
@@ -715,11 +715,6 @@ app.options(
  *  @required false
  *  @Pdesc Boolean indicating whether this version contains a new name for the package.
  * @param
- *  @location query
- *  @name tag
- *  @required true
- *  @Pdesc A git tag for the version you'd like to create. It's important to note that the version name will not be taken from the tag, but from the `version` key in the `package.json` file at that ref.
- * @param
  *  @location header
  *  @name auth
  *  @required true
@@ -730,9 +725,6 @@ app.options(
  * @response
  *  @status 400
  *  @Rdesc Git tag not found / Repository inaccessible / package.json invalid.
- * @response
- *  @status 409
- *  @Rdesc Version exists.
  */
 app.post(
   "/api/:packType/:packageName/versions",


### PR DESCRIPTION
### Requirements 

* [x] Have you ran tests against this code?

### Description of the Change

Removes unused tag parameter from POST /api/packages/:packageName/versions endpoint.

Fixes #34 