### PR TITLE
Reduce type coercion

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -35,7 +35,7 @@ let sqlStorage; // SQL object, to interact with the DB.
  * @returns {object} PostgreSQL connection object.
  */
 function setupSQL() {
-  return process.env.PULSAR_STATUS === "dev" && process.env.MOCK_DB != "false"
+  return process.env.PULSAR_STATUS === "dev" && process.env.MOCK_DB !== "false"
     ? postgres({
         host: DB_HOST,
         username: DB_USER,
@@ -625,7 +625,7 @@ async function updatePackageStargazers(name, pointer = null) {
   try {
     sqlStorage ??= setupSQL();
 
-    if (pointer == null) {
+    if (pointer === null) {
       const packID = await getPackageByNameSimple(name);
 
       if (!packID.ok) {
@@ -1144,8 +1144,8 @@ async function updateIncrementStar(user, pack) {
       // Now we expect to get our data right back, and can check the
       // validity to know if this happened successfully or not.
       if (
-        pointer != commandStar[0].package ||
-        user.id != commandStar[0].userid
+        pointer !== commandStar[0].package ||
+        user.id !== commandStar[0].userid
       ) {
         return {
           ok: false,
@@ -1220,8 +1220,8 @@ async function updateDecrementStar(user, pack) {
 
     // If the return does not match our input, it failed.
     if (
-      user.id != commandUnstar[0].userid ||
-      pointer != commandUnstar[0].package
+      user.id !== commandUnstar[0].userid ||
+      pointer !== commandUnstar[0].package
     ) {
       return {
         ok: false,

--- a/src/dev_server.js
+++ b/src/dev_server.js
@@ -15,7 +15,7 @@ const dbTeardown = require("../node_modules/@databases/pg-test/jest/globalTeardo
 async function test() {
   await processArgs();
 
-  if (process.env.MOCK_DB != "false") {
+  if (process.env.MOCK_DB !== "false") {
     // We only Mock the Database if our argument flags permit.
     console.log("Setting up Database Mock");
 
@@ -44,7 +44,7 @@ async function test() {
   const database = require("./database.js");
   // We can only require these items after we have set our env variables
 
-  if (process.env.MOCK_DB != "false") {
+  if (process.env.MOCK_DB !== "false") {
     logger.generic(
       3,
       "Pulsar Server is in Development Mode with a Local Database!"
@@ -97,19 +97,19 @@ async function processArgs() {
   let rawArgs = process.argv.slice(2);
 
   for (let i = 0; i < rawArgs.length; i++) {
-    if (rawArgs[i] == "--gh") {
+    if (rawArgs[i] === "--gh") {
       console.log("Setting No Mock GitHub");
       process.env.MOCK_GH = "false";
     }
-    if (rawArgs[i] == "--google") {
+    if (rawArgs[i] === "--google") {
       console.log("Setting No Mock Google");
       process.env.MOCK_GOOGLE = "false";
     }
-    if (rawArgs[i] == "--db") {
+    if (rawArgs[i] === "--db") {
       console.log("Setting No Mock Database");
       process.env.MOCK_DB = "false";
     }
-    if (rawArgs[i] == "--auth") {
+    if (rawArgs[i] === "--auth") {
       console.log("Setting No Mock Authentication");
       process.env.MOCK_AUTH = "false";
     }

--- a/src/git.js
+++ b/src/git.js
@@ -53,7 +53,7 @@ async function ownership(user, repo, dev_override = false) {
   if (
     process.env.PULSAR_STATUS === "dev" &&
     !dev_override &&
-    process.env.MOCK_GH != "false"
+    process.env.MOCK_GH !== "false"
   ) {
     console.log(
       `git.js.Ownership() Is returning Dev Only Permissions for ${logger.sanitizeLogs(

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -288,7 +288,7 @@ async function getPackagesSearch(req, res) {
   );
 
   if (!packs.ok) {
-    if (packs.short == "Not Found") {
+    if (packs.short === "Not Found") {
       logger.generic(
         4,
         "getPackagesSearch-simpleSearch Responding with Empty Array for Not Found Status"

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -577,21 +577,10 @@ async function getPackagesStargazers(req, res) {
  */
 async function postPackagesVersion(req, res) {
   const params = {
-    // tag: query.tag(req), // unused parameter
     rename: query.rename(req),
     auth: query.auth(req),
     packageName: query.packageName(req),
   };
-
-  /* Check tag validity
-  if (params.tag === "") {
-    await common.handleError(req, res, {
-      ok: false,
-      short: "Bad Repo",
-      content: "The tag parameter is not specified correctly",
-    });
-    return;
-  }*/
 
   // On renaming:
   // When a package is being renamed, we will expect that packageName will

--- a/src/handlers/theme_handler.js
+++ b/src/handlers/theme_handler.js
@@ -127,7 +127,7 @@ async function getThemesSearch(req, res) {
   );
 
   if (!packs.ok) {
-    if (packs.short == "Not Found") {
+    if (packs.short === "Not Found") {
       logger.generic(
         4,
         "getThemesSearch-simpleSearch Responding with Empty Array for Not Found Status"

--- a/src/main.js
+++ b/src/main.js
@@ -696,7 +696,7 @@ app.options(
  * @path /api/packages/:packageName/versions
  * @auth true
  * @method POST
- * @desc Creates a new package version from a git tag. If `rename` is not `true`, the `name` field in `package.json` _must_ match the current package name.
+ * @desc Creates a new package version. If `rename` is not `true`, the `name` field in `package.json` _must_ match the current package name.
  * @param
  *   @name packType
  *   @location path
@@ -715,11 +715,6 @@ app.options(
  *  @required false
  *  @Pdesc Boolean indicating whether this version contains a new name for the package.
  * @param
- *  @location query
- *  @name tag
- *  @required true
- *  @Pdesc A git tag for the version you'd like to create. It's important to note that the version name will not be taken from the tag, but from the `version` key in the `package.json` file at that ref.
- * @param
  *  @location header
  *  @name auth
  *  @required true
@@ -730,9 +725,6 @@ app.options(
  * @response
  *  @status 400
  *  @Rdesc Git tag not found / Repository inaccessible / package.json invalid.
- * @response
- *  @status 409
- *  @Rdesc Version exists.
  */
 app.post(
   "/api/:packType/:packageName/versions",

--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -53,7 +53,7 @@ describe("engineFilter returns version expected.", () => {
     const engine = "1.5.0";
 
     const res = await utils.engineFilter(pack, engine);
-    expect(res.metadata.version == "2.0.0");
+    expect(res.metadata.version === "2.0.0");
   });
 
   test("Returns Matching version when given an equal upper bound.", async () => {
@@ -77,7 +77,7 @@ describe("engineFilter returns version expected.", () => {
     const engine = "1.4.9";
 
     const res = await utils.engineFilter(pack, engine);
-    expect(res.metadata.version == "1.9.9");
+    expect(res.metadata.version === "1.9.9");
   });
 
   test("Returns First Matching version on lower bond equal.", async () => {
@@ -101,7 +101,7 @@ describe("engineFilter returns version expected.", () => {
     const engine = "1.2.3";
 
     const res = await utils.engineFilter(pack, engine);
-    expect(res.metadata.version == "2.0.0");
+    expect(res.metadata.version === "2.0.0");
   });
 
   test("Catches non String correctly", async () => {

--- a/src/tests_integration/main.test.js
+++ b/src/tests_integration/main.test.js
@@ -60,6 +60,7 @@ expect.extend({
     }
   },
   toHaveHTTPCode(req, want) {
+    // Type coercion here because the statusCode in the request object could be set as a string.
     if (req.statusCode == want) {
       return {
         pass: true,
@@ -140,8 +141,7 @@ describe("Get /api/packages", () => {
   test("Should respond with an array not containing sensible data", async () => {
     const res = await request(app).get("/api/packages");
     for (const p of res.body) {
-      // Use type coercion to catch also undefined
-      expect(p.pointer == null).toBeTruthy();
+      expect(p.pointer === undefined).toBeTruthy();
     }
   });
   test("Should respond with the expected headers", async () => {
@@ -275,8 +275,7 @@ describe("GET /api/packages/featured", () => {
   test("Does Not Return Sensible Data", async () => {
     const res = await request(app).get("/api/packages/featured");
     for (const p of res.body) {
-      // Use type coercion to catch also undefined
-      expect(p.pointer == null).toBeTruthy();
+      expect(p.pointer === undefined).toBeTruthy();
     }
   });
 });
@@ -304,8 +303,7 @@ describe("GET /api/packages/search", () => {
   test("Valid Search Does Not Return Sensible Data", async () => {
     const res = await request(app).get("/api/packages/search?q=language");
     for (const p of res.body) {
-      // Use type coercion to catch also undefined
-      expect(p.pointer == null).toBeTruthy();
+      expect(p.pointer === undefined).toBeTruthy();
     }
   });
   test("Valid Search Returns Expected Headers", async () => {
@@ -370,11 +368,10 @@ describe("GET /api/packages/:packageName", () => {
   });
   test("Valid package, does not return sensible data", async () => {
     const res = await request(app).get("/api/packages/language-css");
-    // Use type coercion to catch also undefined
-    expect(res.body.pointer == null).toBeTruthy();
+    expect(res.body.pointer === undefined).toBeTruthy();
     for (const v of Object.keys(res.body.versions)) {
-      expect(res.body.versions[v].id == null).toBeTruthy();
-      expect(res.body.versions[v].package == null).toBeTruthy();
+      expect(res.body.versions[v].id === undefined).toBeTruthy();
+      expect(res.body.versions[v].package === undefined).toBeTruthy();
     }
   });
   test("Valid package, gives success status code", async () => {
@@ -657,10 +654,9 @@ describe("GET /api/packages/:packageName/versions/:versionName", () => {
     const res = await request(app).get(
       "/api/packages/language-css/versions/0.45.7"
     );
-    // Use type coercion to catch also undefined
-    expect(res.body.id == null).toBeTruthy();
-    expect(res.body.package == null).toBeTruthy();
-    expect(res.body.sha == null).toBeTruthy();
+    expect(res.body.id === undefined).toBeTruthy();
+    expect(res.body.package === undefined).toBeTruthy();
+    expect(res.body.sha === undefined).toBeTruthy();
   });
 });
 
@@ -881,8 +877,7 @@ describe("GET /api/themes", () => {
   test("Should respond with an array not containing sensible data", async () => {
     const res = await request(app).get("/api/themes");
     for (const p of res.body) {
-      // Use type coercion to catch also undefined
-      expect(p.pointer == null).toBeTruthy();
+      expect(p.pointer === undefined).toBeTruthy();
     }
   });
   test("Should respond with the expected headers", async () => {
@@ -910,7 +905,7 @@ describe("GET /api/themes/search", () => {
   test("Valid Search does not Return Sensitive Data", async () => {
     const res = await request(app).get("/api/themes/search?q=syntax");
     for (const p of res.body) {
-      expect(p.pointer == null).toBeTruthy();
+      expect(p.pointer === undefined).toBeTruthy();
     }
   });
   test("Valid Search Returns Valid Data", async () => {
@@ -943,7 +938,7 @@ describe("Ensure Themes is passed to each endpoint Properly", () => {
     const res = await request(app).get("/api/themes/language-css");
     expect(res).toHaveHTTPCode(200);
     expect(res.body.name).toBe("language-css");
-    expect(res.body.pointer == null).toBeTruthy();
+    expect(res.body.pointer === undefined).toBeTruthy();
   });
   test("GET /api/themes/:packageName/stargazers", async () => {
     const res = await request(app).get("/api/themes/language-css/stargazers");
@@ -960,9 +955,9 @@ describe("Ensure Themes is passed to each endpoint Properly", () => {
     expect(res).toHaveHTTPCode(200);
     expect(res.body.name).toEqual("language-css");
     expect(typeof res.body.dist.tarball === "string").toBeTruthy();
-    expect(res.body.id == null).toBeTruthy();
-    expect(res.body.package == null).toBeTruthy();
-    expect(res.body.sha == null).toBeTruthy();
+    expect(res.body.id === undefined).toBeTruthy();
+    expect(res.body.package === undefined).toBeTruthy();
+    expect(res.body.sha === undefined).toBeTruthy();
   });
   test("GET /api/themes/:pakageName/versions/:versionName/tarball", async () => {
     const res = await request(app).get(
@@ -1047,9 +1042,9 @@ describe("GET /api/users/:login", () => {
   test("Returns No Senstive Data for Valid User", async () => {
     const res = await request(app).get("/api/users/dever");
     expect(res).toHaveHTTPCode(200);
-    expect(res.body.token == null).toBeTruthy();
-    expect(res.body.id == null).toBeTruthy();
-    expect(res.body.node_id == null).toBeTruthy();
+    expect(res.body.token === undefined).toBeTruthy();
+    expect(res.body.id === undefined).toBeTruthy();
+    expect(res.body.node_id === undefined).toBeTruthy();
   });
 });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -241,7 +241,7 @@ async function engineFilter(pack, engine) {
       /(>=?)(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)/
     );
 
-    if (lowSv != null) {
+    if (lowSv !== null) {
       // Lower end condition present, so test it.
       switch (lowSv[0]) {
         case ">":
@@ -271,7 +271,7 @@ async function engineFilter(pack, engine) {
       /(<=?)(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)/
     );
 
-    if (upSv != null) {
+    if (upSv !== null) {
       // Upper end condition present, so test it.
       switch (upSv[1]) {
         case "<":


### PR DESCRIPTION
### Requirements 

* [x] Have you ran tests against this code?

### Description of the Change

Little of code refactoring. Avoid type coercion where possible.

Anyway, in style guide, I don't find the following sentences much clear:

> Some instances it will be needed to use alternative comparisons, and these are accounted for. This rule will not flag usage when comparing against two literal values, when evaluating typeof, and when comparing against null.

Besides we should also require to specify with a comment why a type coercion is needed, if used.