### PR TITLE
Fix CodeQL issues + private properties

### DIFF
--- a/src/vcs.js
+++ b/src/vcs.js
@@ -93,7 +93,6 @@ async function readme(userObj, ownerRepo, service) {
       const github = new GitHub();
       return await github.readme(userObj, ownerRepo);
   }
-  )
 }
 
 /**

--- a/src/vcs_providers/git.js
+++ b/src/vcs_providers/git.js
@@ -10,28 +10,28 @@
 
  class Git {
    // Public properties:
-   api_url = "";
-   acceptable_status_codes = [200];
+   apiUrl = "";
+   acceptableStatusCodes = [200];
 
    // Setters:
-   set api_url(url) {
-     this.api_url = typeof url === "string" ? url : "";
+   set apiUrl(url) {
+     this.apiUrl = typeof url === "string" ? url : this.apiUrl;
    }
 
-   set acceptable_status_codes(codes) {
-     this.api_url = Array.isArray(codes) ? codes : this.acceptable_status_codes;
+   set acceptableStatusCodes(codes) {
+     this.acceptableStatusCodes = Array.isArray(codes) ? codes : this.acceptableStatusCodes;
    }
 
    _initializer(opts) {
-     this.api_url = opts.api_url ?? this.api_url;
-     this.acceptable_status_codes = opts.ok_status ?? this.acceptable_status_codes;
+     this.apiUrl = opts.api_url ?? this.apiUrl;
+     this.acceptableStatusCodes = opts.ok_status ?? this.acceptableStatusCodes;
    }
 
    async _webRequestAuth(url, token) {
      try {
 
        const res = await superagent
-        .get(`${this.api_url}${url}`)
+        .get(`${this.apiUrl}${url}`)
         .set({
           Authorization: `Bearer ${token}`,
         })
@@ -39,7 +39,7 @@
         // This last line here, lets the class define what HTTP Status Codes
         // It will not throw an error on.
         // If a status code not present in this array is received, it will throw an error.
-        .ok((res) => this.acceptable_status_codes.includes(res.status));
+        .ok((res) => this.acceptableStatusCodes.includes(res.status));
 
       if (res.status !== 200) {
         // We have not received 200 code: return a failure

--- a/src/vcs_providers/git.js
+++ b/src/vcs_providers/git.js
@@ -9,9 +9,22 @@
  const { GH_USERAGENT } = require("../config.js").getConfig();
 
  class Git {
-   constructor(opts) {
-     this.api_url = opts.api_url;
-     this.acceptable_status_codes = opts.ok_status ?? [200];
+   // Public properties:
+   api_url = "";
+   acceptable_status_codes = [200];
+
+   // Setters:
+   set api_url(url) {
+     this.api_url = typeof url === "string" ? url : "";
+   }
+
+   set acceptable_status_codes(codes) {
+     this.api_url = Array.isArray(codes) ? codes : this.acceptable_status_codes;
+   }
+
+   _initializer(opts) {
+     this.api_url = opts.api_url ?? this.api_url;
+     this.acceptable_status_codes = opts.ok_status ?? this.acceptable_status_codes;
    }
 
    async _webRequestAuth(url, token) {

--- a/src/vcs_providers/github.js
+++ b/src/vcs_providers/github.js
@@ -32,9 +32,9 @@ class GitHub extends Git {
    */
   async ownership(user, pack) {
     // expects full userObj, and repoObj
-    let ownerRepo = utils.getOwnerRepoFromPackage(pack.data);
+    const ownerRepo = utils.getOwnerRepoFromPackage(pack.data);
 
-    let owner = await this.doesUserHaveRepo(user, ownerRepo);
+    const owner = await this.doesUserHaveRepo(user, ownerRepo);
 
     if (owner.ok) {
       // We were able to confirm the ownership of the repo just fine and can return.
@@ -79,7 +79,7 @@ class GitHub extends Git {
    */
   async doesUserHaveRepo(user, ownerRepo, page = 1) {
     try {
-      let check = await this._webRequestAuth(`/repos/${ownerRepo}/contributors?page=${page}`, user.token);
+      const check = await this._webRequestAuth(`/repos/${ownerRepo}/contributors?page=${page}`, user.token);
 
       if (!check.ok) {
         if (check.short === "Failed Request") {

--- a/src/vcs_providers/github.js
+++ b/src/vcs_providers/github.js
@@ -13,11 +13,15 @@ const utils = require("../utils.js");
  * expected of a VCS service.
  */
 class GitHub extends Git {
-  constructor(opts) {
+  // Private properties:
+  #defaultApiUrl = "https://api.github.com";
+  #defaultAcceptableStatusCodes = [200, 401];
 
-    super({
-      api_url: opts?.api_url ?? "https://api.github.com",
-      ok_status: [200, 401]
+  constructor(opts) {
+    super();
+    this._initializer({
+      api_url: opts?.api_url ?? this.#defaultApiUrl,
+      ok_status: this.#defaultAcceptableStatusCodes
     });
   }
 

--- a/src/vcs_providers/github.js
+++ b/src/vcs_providers/github.js
@@ -213,7 +213,7 @@ class GitHub extends Git {
     }
   }
 
-  async function getRepoTags(userObj, ownerRepo) {
+  async getRepoTags(userObj, ownerRepo) {
     try {
       const raw = this._webRequestAuth(`/repos/${ownerRepo}/tags`, userObj.token);
 
@@ -253,7 +253,7 @@ class GitHub extends Git {
     }
   }
 
-  async function getPackageJSON(useerObj, ownerRepo) {
+  async getPackageJSON(useerObj, ownerRepo) {
     try {
 
     } catch(err) {


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [x] Have you ran tests against this code?

### Description of the Change

I wanted to contribute on this refactoring. Fixed CodeQL issues and introduced private properties.

It was a little tricky to add the private properties in the inherited constructor because `this` can be used only after the base constructor is executed, so I could not pass the private properties as argument.

That's because I wrongly intended it as an interface (or a trait), which is not, obviously. Anyway, to reuse the code, I thought it was better to make a method to initialize properties.

@confused-Techiet Tell me what do you think. If it's not worth, feel free to drop the last commits.

A question: @confused-Techie prefixing the `_` you meant the method as protected? Even if protected methods does not exist in JS.