### PR TITLE
Avoid names supply chain attack

### DIFF
--- a/scripts/database/create_names_table.sql
+++ b/scripts/database/create_names_table.sql
@@ -4,10 +4,26 @@
 
 CREATE TABLE names (
     name VARCHAR(128) NOT NULL PRIMARY KEY,
-    pointer UUID NOT NULL REFERENCES packages(pointer),
+    pointer UUID NULL,
     -- constraints
-    CONSTRAINT lowercase_names CHECK (name = LOWER(name))
+    CONSTRAINT lowercase_names CHECK (name = LOWER(name)),
+    CONSTRAINT package_names_fkey FOREIGN KEY (pointer) REFERENCES packages(pointer) ON DELETE SET NULL
 );
 
 -- Lowercase constraint added upon the following issue:
 -- https://github.com/confused-Techie/atom-backend/issues/90
+
+/*
+-- `pointer` was NOT NULL, then we made it nullable.
+-- The previous foreign key has been dropped and a new `package_names_fkey`
+-- has need added to avoid supply chain attacks.
+-- `pointer` is set to NULL when a row in packages table is deleted.
+-- Steps made to apply this change:
+
+ALTER TABLE names ALTER COLUMN pointer DROP NOT NULL;
+
+ALTER TABLE names DROP CONSTRAINT previous_foreign_key_name;
+
+ALTER TABLE names
+ADD CONSTRAINT package_names_fkey FOREIGN KEY (pointer) REFERENCES packages(pointer) ON DELETE SET NULL;
+*/

--- a/src/database.js
+++ b/src/database.js
@@ -68,6 +68,43 @@ async function shutdownSQL() {
 
 /**
  * @async
+ * @function packageNameAvailability
+ * @desc Determines if a name is ready to be used for a new package. Useful in the stage of the publication
+ * of a new package where checking if the package exists is not enough because a name could be not
+ * available if a deleted package was using it in the past.
+ * This function simply checks if the provided name is present in "names" table.
+ * @param {string} name - The candidate name for a new package.
+ * @returns {object} A Server Status Object.
+ */
+async function packageNameAvailability(name) {
+  try {
+    sqlStorage ??= setupSQL();
+
+    const command = await sqlStorage`
+      SELECT name FROM names
+      WHERE name = ${name};
+    `;
+
+    return command.count === 0
+      ? { ok: true, content: `${name} is available to be used for a new package.` }
+      : {
+          ok: false,
+          content: `${name} is not available to be used for a new package.`,
+          short: "Not Found",
+        };
+  } catch (err) {
+    return {
+      ok: false,
+      content: "Generic Error",
+      short: "Server Error",
+      error: err,
+    };
+  }
+}
+
+
+/**
+ * @async
  * @function insertNewPackage
  * @desc Insert a new package inside the DB taking a `Server Object Full` as argument.
  * @param {object} pack - The `Server Object Full` package.
@@ -1714,6 +1751,7 @@ async function authCheckAndDeleteStateKey(stateKey, timestamp = null) {
 
 module.exports = {
   shutdownSQL,
+  packageNameAvailability,
   insertNewPackage,
   getPackageByName,
   getPackageCollectionByName,

--- a/src/database.js
+++ b/src/database.js
@@ -72,6 +72,7 @@ async function shutdownSQL() {
  * @desc Determines if a name is ready to be used for a new package. Useful in the stage of the publication
  * of a new package where checking if the package exists is not enough because a name could be not
  * available if a deleted package was using it in the past.
+ * Useful also to check if a name is available for the renaming of a published package. 
  * This function simply checks if the provided name is present in "names" table.
  * @param {string} name - The candidate name for a new package.
  * @returns {object} A Server Status Object.

--- a/src/database.js
+++ b/src/database.js
@@ -72,7 +72,7 @@ async function shutdownSQL() {
  * @desc Determines if a name is ready to be used for a new package. Useful in the stage of the publication
  * of a new package where checking if the package exists is not enough because a name could be not
  * available if a deleted package was using it in the past.
- * Useful also to check if a name is available for the renaming of a published package. 
+ * Useful also to check if a name is available for the renaming of a published package.
  * This function simply checks if the provided name is present in "names" table.
  * @param {string} name - The candidate name for a new package.
  * @returns {object} A Server Status Object.
@@ -867,7 +867,7 @@ async function removePackageByName(name) {
         // No check on deleted stars because the package could also have 0 stars.
       }*/
 
-      // Remove names related to the package
+      /* We do not remove the package names to avoid supply chain attacks.
       const commandName = await sqlTrans`
         DELETE FROM names
         WHERE pointer = ${pointer}
@@ -877,6 +877,7 @@ async function removePackageByName(name) {
       if (commandName.count === 0) {
         throw `Failed to delete names for: ${name}`;
       }
+      */
 
       const commandPack = await sqlTrans`
         DELETE FROM packages

--- a/src/dev-runner/migrations/0001-initial-migration.sql
+++ b/src/dev-runner/migrations/0001-initial-migration.sql
@@ -47,9 +47,10 @@ EXECUTE PROCEDURE now_on_updated_package();
 
 CREATE TABLE names (
     name VARCHAR(128) NOT NULL PRIMARY KEY,
-    pointer UUID NOT NULL REFERENCES packages(pointer),
+    pointer UUID NULL,
     -- constraints
-    CONSTRAINT lowercase_names CHECK (name = LOWER(name))
+    CONSTRAINT lowercase_names CHECK (name = LOWER(name)),
+    CONSTRAINT package_names_fkey FOREIGN KEY (pointer) REFERENCES packages(pointer) ON DELETE SET NULL
 );
 
 -- Create users Table

--- a/src/dev-runner/migrations/0001-initial-migration.sql
+++ b/src/dev-runner/migrations/0001-initial-migration.sql
@@ -56,20 +56,20 @@ CREATE TABLE names (
 -- Create users Table
 
 CREATE TABLE users (
-  id SERIAL PRIMARY KEY,
-  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  username VARCHAR(256) NOT NULL UNIQUE,
-  node_id VARCHAR(256) UNIQUE,
-  avatar VARCHAR(100),
-  data JSONB
+    id SERIAL PRIMARY KEY,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    username VARCHAR(256) NOT NULL UNIQUE,
+    node_id VARCHAR(256) UNIQUE,
+    avatar VARCHAR(100),
+    data JSONB
 );
 
 -- Create stars Table
 
 CREATE TABLE stars (
-  package UUID NOT NULL REFERENCES packages(pointer),
-  userid INTEGER NOT NULL REFERENCES users(id),
-  PRIMARY KEY (package, userid)
+    package UUID NOT NULL REFERENCES packages(pointer),
+    userid INTEGER NOT NULL REFERENCES users(id),
+    PRIMARY KEY (package, userid)
 );
 
 -- Create versions Table

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -117,13 +117,10 @@ async function postPackages(req, res) {
     return;
   }
 
-  // Check the package does NOT exists.
-  // We will utilize our database.getPackageByName to see if it returns an error,
-  // which means the package doesn't exist.
   // Currently though the repository is in `owner/repo` format,
-  // meanwhile getPackageByName expects just `repo`
+  // meanwhile needed functions expects just `repo`
 
-  const repo = params.repository.split("/")[1];
+  const repo = params.repository.split("/")[1]?.toLowerCase();
 
   if (repo === undefined) {
     logger.generic(6, "Repository determined invalid after failed split");
@@ -147,23 +144,27 @@ async function postPackages(req, res) {
     return;
   }
 
-  const exists = await database.getPackageByName(repo, true);
+  // Check the package does NOT exists.
+  // We will utilize our database.packageNameAvailability to see if the name is available.
 
-  if (exists.ok) {
-    logger.generic(6, "Seems Package Already exists, aborting publish");
+  const nameAvailable = await database.packageNameAvailability(repo);
+
+  if (!nameAvailable.ok) {
+    logger.generic(6, "The name for the package is not available: aborting publish");
     // The package exists.
     await common.packageExists(req, res);
     return;
   }
 
-  // Even further though we need to check that the error is not found, since errors here can bubble.
-  if (exists.short !== "Not Found") {
+  // Even further though we need to check that the error is not "Not Found",
+  // since an exception could have been caught.
+  if (nameAvailable.short !== "Not Found") {
     logger.generic(
       3,
-      `postPackages-getPackageByName Not OK: ${exists.content}`
+      `postPackages-getPackageByName Not OK: ${nameAvailable.content}`
     );
     // The server failed for some other bubbled reason, and is now encountering an error.
-    await common.handleError(req, res, exists);
+    await common.handleError(req, res, nameAvailable);
     return;
   }
 
@@ -619,7 +620,7 @@ async function postPackagesVersion(req, res) {
   if (!packExists.ok) {
     logger.generic(
       6,
-      "Seems Package exists when trying to publish new version"
+      "Seems Package does not exist when trying to publish new version"
     );
     await common.handleError(req, res, packExists);
     return;

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -726,12 +726,26 @@ async function postPackagesVersion(req, res) {
     const isBanned = await utils.isPackageNameBanned(newName);
 
     if (isBanned.ok) {
-      logger.generic(3, `postPackages Blocked by banned package name: ${repo}`);
+      logger.generic(3, `postPackages Blocked by banned package name: ${newName}`);
       // is banned
       await common.handleError(req, res, {
         ok: false,
         short: "Server Error",
         content: "Package Name is Banned",
+      });
+      // TODO ^^^ Replace with specific error once more are supported.
+      return;
+    }
+
+    const isAvailable = await database.packageNameAvailability(newName);
+
+    if (isAvailable.ok) {
+      logger.generic(3, `postPackages Blocked by new name ${newName} not available`);
+      // is banned
+      await common.handleError(req, res, {
+        ok: false,
+        short: "Server Error",
+        content: "Package Name is Not Available",
       });
       // TODO ^^^ Replace with specific error once more are supported.
       return;

--- a/src/tests_integration/database.test.js
+++ b/src/tests_integration/database.test.js
@@ -91,13 +91,17 @@ describe("Package Lifecycle Tests", () => {
   test("Package A Lifecycle", async () => {
     const pack = require("./fixtures/lifetime/package-a.js");
 
+    // === Is the package name available?
+    const nameIsAvailable = await database.packageNameAvailability("package-a-lifetime");
+    expect(nameIsAvailable.ok).toBeTruthy();
+
     // === Let's publish our package
     const publish = await database.insertNewPackage(pack.createPack);
     expect(publish.ok).toBeTruthy();
     expect(typeof publish.content === "string").toBeTruthy();
     // this endpoint only returns a pointer on success.
 
-    // === Do we get all the right data back when asking for our package
+    // === Do we get all the right data back when asking for our package?
     const getAfterPublish = await database.getPackageByName(
       pack.createPack.name
     );
@@ -405,6 +409,10 @@ describe("Package Lifecycle Tests", () => {
     const ghostPack = await database.getPackageByName(NEW_NAME);
     expect(ghostPack.ok).toBeFalsy();
     expect(ghostPack.short).toEqual("Not Found");
+
+    // === Is the name of the deleted package available?
+    const deletedNameAvailable = await database.packageNameAvailability("package-a-lifetime");
+    expect(deletedNameAvailable.ok).toBeFalsy();
   });
   test("User A Lifecycle Test", async () => {
     const user = require("./fixtures/lifetime/user-a.js");


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [x] Have you ran tests against this code?

### Description of the Change

As we agreed, we do not want the names to be available after a package is deleted. So we have to keep them into the `names` table after the package deletion.

@confused-Techie To do this we have to change che foreign key in `names` table. The following steps have to be made:

- Drop NOT NULL on `names.pointer`
```sql
ALTER TABLE names ALTER COLUMN pointer DROP NOT NULL;
``` 

- Retrieve the foreign key constraint name in `names` table
```sql
SELECT conrelid::regclass AS table_name, 
       conname AS foreign_key, 
       pg_get_constraintdef(oid) 
FROM   pg_constraint 
WHERE  contype = 'f' and conrelid::regclass::text = 'names' 
AND    connamespace = 'public'::regnamespace   
ORDER  BY conrelid::regclass::text, contype DESC;
```

- Get the name of the constraint and drop it
```sql
ALTER TABLE names DROP CONSTRAINT replace_here_the_constraint_name;
```

- Make a new foreign key constraint using the policy of setting NULL on deletion
```sql
ALTER TABLE names ADD CONSTRAINT package_names_fkey FOREIGN KEY (pointer) REFERENCES packages(pointer) ON DELETE SET NULL;
```

This way the names are kept when the package is deleted. Then I also made another function to check the name availability on new publication. Self explaining reading the commits. There are also new tests. The tests are passing on my system.

@confused-Techie for any doubt, tag me.