### PR TITLE
Fixes in Production

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -465,7 +465,7 @@ async function getPackageByName(name, user = false) {
       SELECT
         ${
           user ? sqlStorage`` : sqlStorage`p.pointer,`
-        } p.name, p.created, p.updated, p.creation_method, p.downloads,
+        } p.name, p.created, p.updated, p.creation_method, p.downloads, p.data,
         (p.stargazers_count + p.original_stargazers) AS stargazers_count,
         JSONB_AGG(
           JSON_BUILD_OBJECT(
@@ -1462,7 +1462,7 @@ async function getSortedPackages(page, dir, method, themes = false) {
 
     const command = await sqlStorage`
       WITH latest_versions AS (
-        SELECT DISTINCT ON (p.name) p.name, v.meta AS data, p.downloads,
+        SELECT DISTINCT ON (p.name) p.name, p.data, p.downloads,
           (p.stargazers_count + p.original_stargazers) AS stargazers_count,
           v.semver, p.created, v.updated
         FROM packages AS p

--- a/src/utils.js
+++ b/src/utils.js
@@ -63,7 +63,8 @@ async function constructPackageObjectFull(pack) {
 
   // We need to copy the metadata of the latest version in order to avoid an
   // auto-reference in the versions array that leads to a freeze in JSON stringify stage.
-  let newPack = structuredClone(pack?.versions[0]?.meta ?? {});
+  //let newPack = structuredClone(pack?.versions[0]?.meta ?? {});
+  let newPack = pack.data;
   newPack.name = pack.name;
   newPack.downloads = pack.downloads;
   newPack.stargazers_count = pack.stargazers_count;


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [ ] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

When pushing our huge list of changes to production turns out we broke the format of the Package Object Short and Package Object Full. This in turn broke usage of the backend with Pulsar, and with the Frontend Website.

The changes in this PR resolves the issue, by reverting the changes made to depreciate `packages.data` since we still do require data from this format. Namely (Since we should still do away with this) we missed out on the ReadMe of the repo, the name of the package on Pulsar, and the fact that we can use the `metadata` key.

If we are able to recreate that functionality then we should be good to go. This will likely mean we need to create a field solely for the Readme, then do a little more work within the package constructor functions.

Otherwise the changes in this PR are already in production.
