### PR TITLE
PackageObject Builder Pattern

### DIFF
--- a/src/PackageObject.js
+++ b/src/PackageObject.js
@@ -70,7 +70,7 @@ class PackageObject {
   }
 
   setReadme(readmeString) {
-    if (typeof readmeString !=== "string") {
+    if (typeof readmeString !== "string") {
       logger.generic(3, `PackageObject.setReadme() called with invalid argument type ${readmeString}::${typeof readmeString}. Ignoring assignment.`);
       return this;
     }

--- a/src/PackageObject.js
+++ b/src/PackageObject.js
@@ -2,6 +2,9 @@
  * @module PackageObject
  * @desc
  */
+ 
+const logger = require("./logger.js");
+const utils = require("./utils.js");
 
 class PackageObject {
   constructor() {
@@ -15,72 +18,150 @@ class PackageObject {
     this.downloads = undefined;
     this.stargazers_count = undefined;
     this.readme = undefined;
-    this.packJSON = undefined;
+    this.creationMethod = undefined;
   }
 
-  setName(value) {
-    this.name = value;
+  setName(packNameString) {
+    if (typeof packNameString !== "string") {
+      logger.generic(3, `PackageObject.setName() called wtih ${packNameString}::${typeof packNameString}. Ignoring assignment.`);
+      return this;
+    }
+
+    this.name = packNameString;
     return this;
   }
 
-  setOwnerRepo(value) {
-    this.ownerRepo = value;
+  setOwnerRepo(ownerRepoString) {
+    if (typeof ownerRepoString !== "string") {
+      logger.generic(3, `PackageObject.setOwnerRepo() called with ${ownerRepoString}::${typeof ownerRepoString}. Ignoring assignment.`);
+      return this;
+    }
+
+    let testValidation = ownerRepoString.split("/");
+
+    if (testValidation.length !== 2) {
+      // If the name is longer than 2, then it is not owner/repo
+      logger.generic(3, `PackageObject.setOwnerRepo() called with invalid split length value ${ownerRepoString}. Ignoring assignment.`);
+      return this;
+    }
+
+    this.ownerRepo = ownerRepoString;
     return this;
   }
 
-  setDownloads(value) {
-    this.downloads = value;
+  setDownloads(downloadCount) {
+    if (Number.isNaN(parseInt(downloadCount))) {
+      logger.generic(3, `PackageObject.setDownloads() called with invalid argument ${downloadCount}. Ignoring assignment.`);
+      return this;
+    }
+
+    this.downloads = downloadCount;
     return this;
   }
 
-  setStargazers(value) {
-    this.stargazers_count = value;
+  setStargazers(stagazerCount) {
+    if (Number.isNaN(parseInt(stargazerCount))) {
+      logger.generic(3, `PackageObject.setStargazers() called with invalid argument ${stagazerCount}. Ignoring assignment.`);
+      return this;
+    }
+
+    this.stargazers_count = stargazerCount;
     return this;
   }
 
-  setReadme(value) {
-    this.readme = value;
+  setReadme(readmeString) {
+    if (typeof readmeString !=== "string") {
+      logger.generic(3, `PackageObject.setReadme() called with invalid argument type ${readmeString}::${typeof readmeString}. Ignoring assignment.`);
+      return this;
+    }
+
+    this.readme = readmeString;
     return this;
   }
 
-  setRepository(value) {
-    this.repository = value;
+  setRepository(repoObject) {
+    if (!repoObject.type || !repoObject.url) {
+      logger.generic(3, `PackageObject.setRepository() called with invalid object ${repoObject}. Ignoring assignment.`);
+      return this;
+    }
+
+    this.repository.type = repoObject.type;
+    this.repository.url = repoObject.url;
     return this;
   }
 
-  setRepositoryType(value) {
-    this.repository.type = value;
+  setRepositoryType(repoType) {
+    this.repository.type = repoType;
     return this;
   }
 
-  setRepositoryURL(value) {
-    this.repository.url = value;
+  setRepositoryURL(repoURL) {
+    this.repository.url = repoURL;
+    return this;
+  }
+
+  setCreationMethod(method) {
+    this.creationMethod = method;
     return this;
   }
 
   parse(pack) {
     // Parse can take a packages data and destructure accordingly
-
-    this.name = pack.name ?? this.name;
+    throw new Error("Not Implemented! ~ PackageObject.parse()");
   }
 
   buildShort() {
+    // The structure of this object is based off `./docs/resources/package_object_short.json`
+    // And should be considered our master reference for the Package Object Short Data Structure
+    let obj = {
+      name: this.name,
+      repository: this.repository,
+      downloads: this.downloads,
+      stargazers_count: this.stargazers_count,
+      releases: {
+        latest: this.Versions.getLatestVersionSemver()
+      },
+      readme: this.readme,
+      metadata: this.Versions.getLatestVersionPackageJSON()
+    };
 
+    // Here we could use Joi to validate the values within our data structure
+    // prior to returning. In the long term this is very much the method we should
+    // use, as the API should never be sending out invalid data. But for now TODO
+    return obj;
   }
 
   buildFull() {
+    // This object structure is modeled directly off of `./docs/resources/package_object_full.json`
+    // Should be considered the master Package Object Full data structure
+    let obj = {
+      name: this.name,
+      repository: this.repository,
+      downloads: this.downloads,
+      stargazers_count: this.stargazers_count,
+      releases: {
+        latest: this.Versions.getLatestVersionSemver()
+      },
+      readme: this.readme,
+      metadata: this.Versions.getLatestVersionPackageJSON(),
+      versions: this.Versions.buildFullVersions()
+    };
 
+    // Again would likely in the future want to use Joi to validate our object
+    return obj;
   }
 
 }
 
 class Version {
   constructor() {
-    this.latest = undefined;
+    this.latestSemver = null;
+    this.versions = {};
+    this.semverInitRegex = /^\s*v/i;
   }
 
   addVersion(value) {
-
+    throw new Error("Not Implmented! ~ Version.addVersion()");
   }
 
   addVersions(values) {
@@ -88,6 +169,102 @@ class Version {
       this.addVersion(value);
     }
     return this;
+  }
+
+  addSemver(semver) {
+    // Allows adding a standalone semver to the version list.
+    if (this.versions[semver]) {
+      logger.generic(3, `Version.addSemver() called with semver already within range! ${semver}`);
+      return this;
+    }
+
+    this.versions[semver] = {};
+
+    // Now to determine if our newer semver is larger than the current latestSemver
+    if (this.latestSemver === null) {
+      this.latestSemver = semver;
+    } else {
+      if (utils.semverGt(utils.semverArray(semver.replace(this.semverInitRegex, "").trim()), utils.semverArray(this.latestSemver.replace(this.semverInitRegex, "").trim()))) {
+        // The provided semver is greater than our current latest
+        this.latestSemver = semver;
+      }
+    }
+
+    return this;
+  }
+
+  addTarball(semver, tarballURL) {
+    // Takes a valid existing semver to add the url too
+    if (!this.versions[semver]) {
+      logger.generic(3, `Version.addTarball() called with semver outside known range! ${semver}`);
+      return this;
+    }
+
+    this.versions[semver].tarball_url = tarballURL;
+    return this;
+  }
+
+  addSHA(semver, sha) {
+    // Takes a valid existing semver to add the sha too
+    if (!this.versions[semver]) {
+      logger.generic(3, `Version.addSHA() called with semver outside known range! ${semver}`);
+      return this;
+    }
+
+    this.versions[semver].sha = sha;
+    return this;
+  }
+
+  addPackageJSON(semver, pack) {
+    // Takes a valid existing semver to add the package data to
+    if (!this.versions[semver]) {
+      logger.generic(3, `Version.addPackageJSON() called with semver outside known range! ${semver}`);
+      return this;
+    }
+
+    this.versions[semver].package = pack;
+    return this;
+  }
+
+  getLatestVersion() {
+    return this.versions[this.latestSemver];
+  }
+
+  getLatestVersionSemver() {
+    return this.latestSemver;
+  }
+
+  getLatestVersionTarball() {
+    return this.versions[this.latestSemver].tarball_url;
+  }
+
+  getLatestVersionSha() {
+    return this.versions[this.latestSemver].sha;
+  }
+
+  getLatestVersionPackageJSON() {
+    return this.versions[this.latestSemver].package;
+  }
+
+  buildFullVersions() {
+
+    let obj = {};
+
+    // this.versions === this.versions.package | this.versions.sha | this.versions.tarball_url
+    for (const ver in this.versions) {
+      obj[ver] = this.versions[ver].pack;
+      obj[ver].dist = {
+        tarball: this.versions[ver].tarball_url,
+        sha: this.versions[ver].sha
+      };
+    }
+
+    // This should result in a hashmap of values by the versions of a package
+    // where each object holds the full versions package.json with an added dist
+    // key that contains the tarball url and sha
+
+    // This is likely where in the future we want to use Joi to validate our object
+    return obj;
   }
 
 }

--- a/src/PackageObject.js
+++ b/src/PackageObject.js
@@ -2,7 +2,7 @@
  * @module PackageObject
  * @desc
  */
- 
+
 const logger = require("./logger.js");
 const utils = require("./utils.js");
 
@@ -204,7 +204,7 @@ class Version {
     return this;
   }
 
-  addSHA(semver, sha) {
+  addSha(semver, sha) {
     // Takes a valid existing semver to add the sha too
     if (!this.versions[semver]) {
       logger.generic(3, `Version.addSHA() called with semver outside known range! ${semver}`);

--- a/src/PackageObject.js
+++ b/src/PackageObject.js
@@ -1,0 +1,95 @@
+/**
+ * @module PackageObject
+ * @desc
+ */
+
+class PackageObject {
+  constructor() {
+    this.Version = new Version();
+    this.name = undefined;
+    this.ownerRepo = undefined;
+    this.repository = {
+      type: undefined,
+      url: undefined
+    };
+    this.downloads = undefined;
+    this.stargazers_count = undefined;
+    this.readme = undefined;
+    this.packJSON = undefined;
+  }
+
+  setName(value) {
+    this.name = value;
+    return this;
+  }
+
+  setOwnerRepo(value) {
+    this.ownerRepo = value;
+    return this;
+  }
+
+  setDownloads(value) {
+    this.downloads = value;
+    return this;
+  }
+
+  setStargazers(value) {
+    this.stargazers_count = value;
+    return this;
+  }
+
+  setReadme(value) {
+    this.readme = value;
+    return this;
+  }
+
+  setRepository(value) {
+    this.repository = value;
+    return this;
+  }
+
+  setRepositoryType(value) {
+    this.repository.type = value;
+    return this;
+  }
+
+  setRepositoryURL(value) {
+    this.repository.url = value;
+    return this;
+  }
+
+  parse(pack) {
+    // Parse can take a packages data and destructure accordingly
+
+    this.name = pack.name ?? this.name;
+  }
+
+  buildShort() {
+
+  }
+
+  buildFull() {
+
+  }
+
+}
+
+class Version {
+  constructor() {
+    this.latest = undefined;
+  }
+
+  addVersion(value) {
+
+  }
+
+  addVersions(values) {
+    for (const value in values) {
+      this.addVersion(value);
+    }
+    return this;
+  }
+
+}
+
+module.exports = PackageObject;

--- a/test/PackageObject.unit.test.js
+++ b/test/PackageObject.unit.test.js
@@ -1,0 +1,12 @@
+const PackageObject = require("../src/PackageObject.js");
+
+describe("Building Objects with PackageObject Return as Expected", () => {
+
+  test("Formal Usage", () => {
+    const obj = new PackageObject()
+      .setName("hello");
+
+    expect(obj.name).toBe("hello");
+  });
+
+});


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This PR creates the `PackageObject.js` which is a Package Object Builder. This builder has not been implemented with the rest of the codebase. This PR is used as a general sanity check prior to utilizing this further within the codebase.

This builds off of changes made in #86 or at least borrows from the methodology used there.

The major thing this repo deals with are the objects of packages, that is their data structure, but without any unified way of creating, modifying or validating these objects the code to do so is scattered throughout the codebase. (Which has brought concerns from some contributors that the object may contradict itself in some locations. Additionally this leads to wasteful time spent checking values or portions that have already been checked.

Using a Object Builder Pattern we can alleviate nearly all of these concerns by never allowing the rest of the codebase to directly modify a package, or give it the need.

Using a package builder we can have a unified location to do anything we might need to on the package.

It's current implementation is in it's obvious infancy, missing many features or functions that would be needed to properly export it's data to the database functions that would be saving it. But as the general concept and initial implementation it's been based off the needs and requirements of the `VCS` system to create packages during their first publish.

Which with the above implementation in mind would take nearly 200 lines of code form `./src/vcs.js` and turn it into the following (Error checking is excluded purposefully as well as handling of async tasks):

```javascript
let pack = new PackageObject().setOwnerRepo(ownerRepo);

pack.addPackageJSON(provider.packageJSON());

let tags = await provider.tags();

for (const tag of tags) {
  pack.Versions.addSemver(tags[tag].name);
  pack.Versions.addTarball(tags[tag].name, tags[tag].tarball_url);
  pack.Versions.addSha(tags[tag].name, tags[tag].commit.sha);
}

pack.setReadme(provider.readme());

pack.setRepositoryURL(determineProvider().url);
pack.setRepositoryType(determineProvider().type);

const package_object_full = pack.buildFull();
```

With this huge simplification in mind the goal was to make this object builder as simplistic as possible. Where no single function needs to do all that much, instead relying on the use of many functions to create the resulting object. Which these can all be chained if needed such as 

```javascript
let pack = new PackageObject().setOwnerRepo(ownerRepo)
  .addPackageJSON(provider.packageJSON())
  .setReadme(provider.readme())
  .setRepositoryURL(determineProvider().url)
  .setRepositoryType(determineProvider().type)
  .buildFull();

// pack is now equal to a standardized Package Object Full
```

If no major issues are brought up to this PR then it can be merged and work done to introduce this new builder to the rest of the codebase, ideally replacing all instances of working with package objects everywhere. Adding the proper returns needed to provide data to database functions and anything else. So that we can get everything all in one place, and like mentioned in the comments if wanted could go so far as to begin verifying the data structure with `Joi` which we already use in our tests to verify object data structure as needed.
