### PR TITLE
Change URL used to access readme

### DIFF
--- a/src/vcs_providers/github.js
+++ b/src/vcs_providers/github.js
@@ -176,7 +176,7 @@ class GitHub extends Git {
   async readme(userObj, ownerRepo) {
     try {
       const readmeRaw = await this._webRequestAuth(
-        `/repos/${ownerRepo}/contents/readme`,
+        `/repos/${ownerRepo}/readme`,
         userObj.token
       );
       // Using just `/readme` will let GitHub attempt to get the repos prefferred readme file,

--- a/test/vcs.vcs.test.js
+++ b/test/vcs.vcs.test.js
@@ -176,7 +176,7 @@ describe("Does NewPackageData Return as expected", () => {
         },
       },
       {
-        url: `/repos/${ownerRepo}/contents/readme`,
+        url: `/repos/${ownerRepo}/readme`,
         obj: {
           ok: false,
           short: "Failed Request",
@@ -246,7 +246,7 @@ describe("Does NewPackageData Return as expected", () => {
         },
       },
       {
-        url: `/repos/${ownerRepo}/contents/readme`,
+        url: `/repos/${ownerRepo}/readme`,
         obj: {
           ok: true,
           content: {
@@ -324,7 +324,7 @@ describe("Does newVersionData Return as Expected", () => {
     const ownerRepo = "confused-Techie/pulsar-backend";
     const mockData = [
       {
-        url: `/repos/${ownerRepo}/contents/readme`,
+        url: `/repos/${ownerRepo}/readme`,
         obj: {
           ok: false,
           short: "Failed Request",
@@ -386,7 +386,7 @@ describe("Does newVersionData Return as Expected", () => {
         },
       },
       {
-        url: `/repos/${ownerRepo}/contents/readme`,
+        url: `/repos/${ownerRepo}/readme`,
         obj: {
           ok: true,
           content: {
@@ -448,7 +448,7 @@ describe("Does newVersionData Return as Expected", () => {
         },
       },
       {
-        url: `/repos/${ownerRepo}/contents/readme`,
+        url: `/repos/${ownerRepo}/readme`,
         obj: {
           ok: true,
           content: {


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

There is a slightly different URL to access content via the GitHub API depending on if you want to access data generically or with GitHub's special handling.

Which in case of the readme I intended to use the special handling, but mistakenly used the generic API endpoint. 

You can read more about this on our [Discord Server](https://discord.com/channels/992103415163396136/992110095641088001/1077092013134069841).