### PR TITLE
Fix `vcs.ownership()` call when publishing a new version

### DIFF
--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -724,7 +724,7 @@ async function postPackagesVersion(req, res) {
   ownerRepo = utils.getOwnerRepoFromPackage(packMetadata.content.metadata);
 
   //const gitowner = await git.ownership(user.content, ownerRepo);
-  const gitowner = await vcs.ownership(user.content, packExists.content);
+  const gitowner = await vcs.ownership(user.content, packMetadata.content);
 
   if (!gitowner.ok) {
     logger.generic(6, `User Failed Git Ownership Check: ${gitowner.content}`);

--- a/src/vcs.js
+++ b/src/vcs.js
@@ -87,8 +87,10 @@ async function ownership(userObj, packObj, dev_override = false) {
   // Which if we are getting a string, then we will fallback to the default
   // which is GitHub, which will work for now.
   const repoObj =
-    typeof packObj.repository === "object" ? packObj.repository.type : packObj;
+    typeof packObj.repository === "object" ? packObj.repository.type : packObj.repository;
   // TODO: Double check validity of Object, but we should have `.type` & `.url`
+  // But if this check fails we will assume that repository is a string.
+  // We should likely add better protections and validation in the future TODO
 
   switch (repoObj) {
     // Additional supported VCS systems go here.

--- a/src/vcs.js
+++ b/src/vcs.js
@@ -87,7 +87,7 @@ async function ownership(userObj, packObj, dev_override = false) {
   // Which if we are getting a string, then we will fallback to the default
   // which is GitHub, which will work for now.
   const repoObj =
-    typeof packObj === "object" ? packObj.repository.type : packObj;
+    typeof packObj.repository === "object" ? packObj.repository.type : packObj;
   // TODO: Double check validity of Object, but we should have `.type` & `.url`
 
   switch (repoObj) {
@@ -219,7 +219,7 @@ async function newPackageData(userObj, ownerRepo, service) {
     // For this we just use the most recent tag published to the repo.
     // and now the object is complete, lets return the pack, as a Server Status Object.
     return new ServerStatus().isOk().setContent(newPack.buildFull()).build();
-    
+
   } catch (err) {
     // An error occured somewhere during package generation
     return new ServerStatus()


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This PR implements a fix being experienced in production when publishing a new version.

When attempting to publish a new version the newest package data should be passed to verify ownership rather than the data last stored on the DB incase of a package name changed or the like.

Additionally the check to protect `vcs.ownership()` from accessing an invalid object of `packObj.repository.type` was originally, inaccurately checking for `typeof packObj === "object"` rather than `typeof packObj.repository === "object"`
