### PR TITLE
Remove Uninstallation Behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## [Unreleased]
 
+* Deprecate `/api/packages/:packageName/versions/:versionName/events/uninstall`. This endpoint no longer has any effect, but will still return a successful query to avoid user impact.
 * Refactored the existing testing platform
 * Refactored all interactions with GitHub, Git, and provided the base system to support multiple VCS services in the future.
 

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -1017,7 +1017,10 @@ async function deletePackageVersion(req, res) {
  * @desc Used when a package is uninstalled, decreases the download count by 1.
  * And saves this data, Originally an undocumented endpoint.
  * The decision to return a '201' was based on how other POST endpoints return,
- * during a successful event.
+ * during a successful event. This endpoint has now been deprecated, as it serves
+ * no useful features, and on further examination may have been intended as a way
+ * to collect data on users, which is not something we implement.
+ * @deprecated since v 1.0.2
  * @see {@link https://github.com/atom/apm/blob/master/src/uninstall.coffee}
  * @param {object} req - The `Request` object inherited from the Express endpoint.
  * @param {object} res - The `Response` object inherited from the Express endpoint.
@@ -1025,39 +1028,6 @@ async function deletePackageVersion(req, res) {
  * @property {http_endpoint} - /api/packages/:packageName/versions/:versionName/events/uninstall
  */
 async function postPackagesEventUninstall(req, res) {
-  const params = {
-    auth: query.auth(req),
-    packageName: query.packageName(req),
-    // TODO: versionName unused parameter. On the roadmap to be removed.
-    // See https://github.com/confused-Techie/atom-backend/pull/88#issuecomment-1331809594
-    versionName: query.engine(req.params.versionName),
-  };
-
-  const user = await auth.verifyAuth(params.auth);
-
-  if (!user.ok) {
-    await common.handleError(req, res, user);
-    return;
-  }
-
-  // TODO: How does this impact performance? Wonder if we could return
-  // the next command with more intelligence to know the pack doesn't exist.
-  const packExists = await database.getPackageByName(params.packageName, true);
-
-  if (!packExists.ok) {
-    await common.handleError(req, res, packExists);
-    return;
-  }
-
-  const write = await database.updatePackageDecrementDownloadByName(
-    params.packageName
-  );
-
-  if (!write.ok) {
-    await common.handleError(req, res, write);
-    return;
-  }
-
   res.status(200).json({ ok: true });
   logger.httpLog(req, res);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -946,6 +946,7 @@ app.options(
  * @ignore
  * @path /api/packages/:packageName/versions/:versionName/events/uninstall
  * @desc Previously undocumented endpoint. BETA: Decreases the packages download count, by one. Indicating an uninstall.
+ * v1.0.2 - Now has no effect. Being deprecated, but presents no change to end users.
  * @method POST
  * @auth true
  * @param

--- a/test/packages.handler.integration.test.js
+++ b/test/packages.handler.integration.test.js
@@ -653,43 +653,9 @@ describe("GET /api/packages/:packageName/versions/:versionName/tarball", () => {
 });
 
 describe("POST /api/packages/:packageName/versions/:versionName/events/uninstall", () => {
-  test.todo("Write all of these");
-  test("Returns 401 with No Auth", async () => {
-    const res = await request(app).post(
-      "/api/packages/language-css/versions/0.45.7/events/uninstall"
-    );
-    expect(res).toHaveHTTPCode(401);
-  });
-  test("Returns Bad Auth Message with No Auth", async () => {
-    const res = await request(app).post(
-      "/api/packages/langauge-css/versions/0.45.7/events/uninstall"
-    );
-    expect(res.body.message).toEqual(msg.badAuth);
-  });
-  test("Returns 401 with Bad Auth", async () => {
-    const res = await request(app)
-      .post("/api/packages/language-css/versions/0.45.7/events/uninstall")
-      .set("Authorization", "invalid");
-    expect(res).toHaveHTTPCode(401);
-  });
-  test("Returns Bad Auth Message with No Auth", async () => {
-    const res = await request(app)
-      .post("/api/packages/langauge-css/versions/0.45.7/events/uninstall")
-      .set("Authorization", "invalid");
-    expect(res.body.message).toEqual(msg.badAuth);
-  });
-  test("Returns 404 with Bad Package", async () => {
-    const res = await request(app)
-      .post("/api/packages/language-golang/versions/1.0.0/events/uninstall")
-      .set("Authorization", "valid-token");
-    expect(res).toHaveHTTPCode(404);
-  });
-  test("Returns Not Found Message with Bad Package", async () => {
-    const res = await request(app)
-      .post("/api/packages/language-golang/versions/1.0.0/events/uninstall")
-      .set("Authorization", "valid-token");
-    expect(res.body.message).toEqual(msg.notFound);
-  });
+  // This endpoint is now being deprecated, so we will remove tests
+  // for handling any kind of actual functionality.
+  // Instead ensuring this returns as success to users are unaffected.
   test("Returns 200 with Valid Package, Bad Version", async () => {
     const res = await request(app)
       .post("/api/packages/language-css/versions/1.0.0/events/uninstall")
@@ -718,13 +684,13 @@ describe("POST /api/packages/:packageName/versions/:versionName/events/uninstall
       .set("Authorization", "valid-token");
     expect(res.body.ok).toBeTruthy();
   });
-  test("Properly decrements the download count", async () => {
+  test("After deprecating endpoint, ensure the endpoint has no effect", async () => {
     const orig = await request(app).get("/api/packages/language-css");
     const res = await request(app)
       .post("/api/packages/language-css/versions/0.45.7/events/uninstall")
       .set("Authorization", "valid-token");
     const after = await request(app).get("/api/packages/language-css");
-    expect(parseInt(orig.body.downloads, 10)).toBeGreaterThan(
+    expect(parseInt(orig.body.downloads, 10)).toEqual(
       parseInt(after.body.downloads, 10)
     );
   });


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

When creating the original Pulsar Backend, there was an undocumented endpoint discovered `/api/:packType/:packageName/versions/:versionName/events/uninstall`. This endpoint was a `POST` message that was triggered each time a package was uninstalled. Without much thought this was assumed to have decreased the download count of the package.

But after further investigation and communication with other Pulsar Devs we determined that this likely was not the case, as the download count for packages was unlikely to represent current installs rather it's more likely showing the total ever installs, as one would initially expect.

We then came to the conclusion that this was likely used as a way to measure current active users of any given package, and for us this seemed to much like telemetry of users.

Especially considering we had not been using this endpoint in that way, we went ahead then and decided it would be best to remove it. So this PR does just that.

Removes any logic associated with the endpoint. While the endpoint will still resolve, it will *always* return a successful request. This is done to prevent this change having any effect on users, and not have to bump our semver version, and not have to implement any changes on PPM in a time coordinated fashion.

So this PR should make it feel like nothing has changed, meanwhile now changing the download count of a package to be total downloads, whereas uninstalling the package does nothing. 