### PR TITLE
Better search term handling

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -1335,6 +1335,11 @@ async function simpleSearch(term, page, dir, sort, themes = false) {
     // lowercase format (see atom-backend issue #86).
     const lcterm = term.toLowerCase();
 
+    const wordSeparators = /[-. ]/g; // Word Separators: - . SPACE
+
+    const searchTerm = lcterm.split(wordSeparators).join("_");
+    // Replaces all word separators with '_' which matches any single character
+
     const limit = paginated_amount;
     const offset = page > 1 ? (page - 1) * limit : 0;
 
@@ -1345,7 +1350,7 @@ async function simpleSearch(term, page, dir, sort, themes = false) {
           v.semver, p.created, v.updated
         FROM packages AS p
           INNER JOIN names AS n ON (p.pointer = n.pointer AND n.name LIKE ${
-            "%" + lcterm + "%"
+            "%" + searchTerm + "%"
           }
           ${
             themes === true

--- a/src/database.js
+++ b/src/database.js
@@ -1337,7 +1337,7 @@ async function simpleSearch(term, page, dir, sort, themes = false) {
 
     const wordSeparators = /[-. ]/g; // Word Separators: - . SPACE
 
-    const searchTerm = lcterm.split(wordSeparators).join("_");
+    const searchTerm = lcterm.replace(wordSeparators, "_");
     // Replaces all word separators with '_' which matches any single character
 
     const limit = paginated_amount;


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This PR came about while working on much larger changes to how we handle search. But discovering this trick, was so simple and small I thought it'd only be smart to try and push it out much earlier than the other branch ends up being completed.

This PR simply changes how we handle user input during a search to allow search to be more intuitive.

For the below examples we will assume the user has typed "Language HTML".

Currently when a user provides their search a few things happen to the search term.
* It's truncated to 50 characters, to prevent excessive computations
* It's passed through a malicious string filter
* It's converted to lower case

Then during the search we supply the following to the DB `%searchTerm%`, which with our example would look like `%language html%`.

Adding `%` means to allow anything before. So this current search would match: `this-is-my-super-cool-language htmlProject`

But it wouldn't match `language-html` because there is no dash.

So what this PR does is replace a collection of `wordSeparators` with `_`, which when searching on the DB means any single character.

All the stop words we filter currently are:
* `-`
* `.`
* ` `

This means any of those will be converted to `_`. So with our previous example will now be `%language_html%`

Which this will now match:
* `language html`
* `language-html`
* `cool-language-html`
* `language.html-awesome`

So this is an obvious improvement, the only downside is that it will not match `languagehtml`, but considering we already won't match that, it's not a downside so much as still room for improvement. 
