### PR TITLE
Newly updated packages `tarball_url` won't resolve

### DIFF
--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -889,7 +889,7 @@ async function getPackagesVersionTarball(req, res) {
   // the download to take place from their servers.
 
   // But right before, lets do a couple simple checks to make sure we are sending to a legit site.
-  const tarballURL = pack.content.meta?.tarball_url ?? "";
+  const tarballURL = pack.content.meta?.tarball_url ?? pack.content.meta?.dist?.tarball ?? "";
   let hostname = "";
 
   // Try to extract the hostname


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

Seems an unintended side effect from our VCS refactor.

When a new package is published to the backend, the location and name of it's tarball URL is slightly different than what was previously expected. This PR adds support for the old style of tarball location, and the new style. So that either will work and properly be validated and returned to the user once validated.
