### PR TITLE
Fix Query Parameter `rename`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## [Unreleased]
 
+* Fixed an issue that would stop the `rename` query parameter from being handled correctly.
 * Deprecate `/api/packages/:packageName/versions/:versionName/events/uninstall`. This endpoint no longer has any effect, but will still return a successful query to avoid user impact.
 * Refactored the existing testing platform
 * Refactored all interactions with GitHub, Git, and provided the base system to support multiple VCS services in the future.

--- a/src/query.js
+++ b/src/query.js
@@ -170,18 +170,21 @@ function rename(req) {
   const prov = req.query.rename;
 
   if (prov === undefined) {
-    // since this is supposed to be a boolean value, return false as the defaulting behavior
+    // Originally it was believed that this query parameter should be handled as
+    // if it was a text passed boolean. But appears to actually provide the string
+    // of text the package should be renamed too.
     return false;
   }
 
-  switch (prov.toLowerCase()) {
-    case "true":
-      return true;
-    case "false":
-      return false;
-    default:
-      return false;
+  // Due to the backend already being built in such a way that it will rename
+  // a package by finding the rename value on it's own, we will still return a
+  // boolean, but TODO:: this should be fixed in the future.
+
+  if (typeof prov === "string" && prov.length > 0) {
+    return true;
   }
+
+  return false;
 }
 
 /**

--- a/test/query.unit.test.js
+++ b/test/query.unit.test.js
@@ -128,12 +128,10 @@ describe("Verify Tag Query Returns", () => {
 });
 
 const renameCases = [
-  [{ query: { rename: "true" } }, true],
-  [{ query: { rename: "false" } }, false],
+  [{ query: { rename: "new-package-name" } }, true],
+  [{ query: { rename: "" } }, false],
   [{ query: {} }, false],
-  [{ query: { rename: "Schrodinger" } }, false],
-  [{ query: { rename: "TRUE" } }, true],
-  [{ query: { rename: "FALSE" } }, false],
+  [{ query: { rename: "a" } }, true],
 ];
 
 describe("Verify Rename Query Returns", () => {


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

When publishing a new package version there is an optional query parameter of `rename` that can be accepted.

During original research into the backend the belief was this was a string based boolean such as `rename=true` or `rename=false`.

But seeing as how the `--rename` flag of PPM functions, it seems that this command will actually modify the `package.json` with the text used after the CLI flag. And append it as a query parameter with the same value.

Such as using `pulsar -p publish --rename titanium` will translate to `?rename=titanium`.

So this PR changes how the `rename` query parameter is parsed.

Since the backend still is able to resolve the new name of a package by finding the `name` listed in the `package.json` of the remote package, we can keep the changes minimal for now. Instead parsing this properly to accept any string based value with a length more than `0` as setting `rename` true.

So technically using `rename=a` will successfully cause the backend to rename a package to whatever is listed in the `package.json`. Of course this shouldn't be recommended as the goal would be to fix this in future updates to the `package-backend`. But this does allow this flag to function as expected for now.

Resolves #108 