### PR TITLE
Improved returned Error Messages to Users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## [Unreleased]
 
+* Improved errors returned in some situations to increase transparancy on the server's logic.
 * Deprecate `/api/packages/:packageName/versions/:versionName/events/uninstall`. This endpoint no longer has any effect, but will still return a successful query to avoid user impact.
 * Refactored the existing testing platform
 * Refactored all interactions with GitHub, Git, and provided the base system to support multiple VCS services in the future.

--- a/src/handlers/common_handler.js
+++ b/src/handlers/common_handler.js
@@ -47,6 +47,66 @@ async function handleError(req, res, obj, num) {
 
 /**
  * @async
+ * @function handleDetailedError
+ * @desc Less generic error handler than `handleError()`. Used for returned the
+ * improved error messages to users. Where instead of only returning an error
+ * `message` it will return `message` and `details`. Providing better insight into
+ * what has gone wrong with the server.
+ * Additionally this will aim to simplify error handling by not handing off the
+ * handling to additional functions.
+ * @param {object} req - The `Request` object inherited from the Express endpoint.
+ * @param {object} res - The `Response` object inherited from the Express endpoint.
+ * @param {object} obj - The Object provided to return the error message.
+ * @param {string} obj.short - The recognized Short Code string for error handling.
+ * @param {string} obj.content - The detailed user friendly content of what's gone wrong.
+ */
+async function handleDetailedError(req, res, obj) {
+  switch(obj.short) {
+    case "Not Found":
+      res.status(404).json({
+        message: "Not Found",
+        details: obj.content
+      });
+      logger.httpLog(req, res);
+      break;
+    case "Bad Repo":
+      res.status(400).json({
+        message: "That repo does not exist, isn't a Pulsar package, or pulsarbot does not have access.",
+        details: obj.content
+      });
+      logger.httpLog(req, res);
+      break;
+    case "Bad Package":
+      res.status(400).json({
+        message: "The package.json at owner/repo isn't valid.",
+        details: obj.content
+      });
+      logger.httpLog(req, res);
+      break;
+    case "No Repo Access":
+    case "Bad Auth":
+    case "No Repo Access":
+      res.status(401).json({
+        message: "Requires authentication. Please update your token if you haven't done so recently.",
+        details: obj.content
+      });
+      logger.httpLog(req, res);
+      break;
+    case "File Not Found":
+    case "Server Error":
+    default:
+      res.status(500).json({
+        message: "Application Error",
+        details: obj.content
+      });
+      logger.httpLog(req, res);
+      break;
+  }
+  return;
+}
+
+/**
+ * @async
  * @function authFail
  * @desc Will take the <b>failed</b> user object from VerifyAuth, and respond for the endpoint as
  * either a "Server Error" or a "Bad Auth", whichever is correct based on the Error bubbled from VerifyAuth.
@@ -221,4 +281,5 @@ module.exports = {
   packageExists,
   serverError,
   siteWideNotFound,
+  handleDetailedError,
 };

--- a/src/handlers/common_handler.js
+++ b/src/handlers/common_handler.js
@@ -85,7 +85,6 @@ async function handleDetailedError(req, res, obj) {
       break;
     case "No Repo Access":
     case "Bad Auth":
-    case "No Repo Access":
       res.status(401).json({
         message: "Requires authentication. Please update your token if you haven't done so recently.",
         details: obj.content

--- a/src/handlers/package_handler.js
+++ b/src/handlers/package_handler.js
@@ -746,13 +746,12 @@ async function postPackagesVersion(req, res) {
         3,
         `postPackages Blocked by banned package name: ${newName}`
       );
-      // is banned
-      await common.handleError(req, res, {
+
+      await common.handleDetailedError(req, res, {
         ok: false,
         short: "Server Error",
-        content: "Package Name is Banned",
+        content: "This Package Name is Banned on the Pulsar Registry."
       });
-      // TODO ^^^ Replace with specific error once more are supported.
       return;
     }
 
@@ -763,27 +762,30 @@ async function postPackagesVersion(req, res) {
         3,
         `postPackages Blocked by new name ${newName} not available`
       );
-      // is banned
-      await common.handleError(req, res, {
+
+      await common.handleDetailedError(req, res, {
         ok: false,
         short: "Server Error",
-        content: "Package Name is Not Available",
+        content: `The Package Name: ${newName} is not available.`
       });
-      // TODO ^^^ Replace with specific error once more are supported.
       return;
     }
   }
 
   // Now add the new Version key.
-
   const addVer = await database.insertNewPackageVersion(
     packMetadata.content.metadata,
     rename ? currentName : null
   );
 
   if (!addVer.ok) {
-    logger.generic(6, "Failed to add the new package version to the db");
-    await common.handleError(req, res, addVer);
+    // TODO: Use hardcoded message until we can verify messages from the db are safe
+    // to pass directly to end users.
+    await common.handleDetailedError(req, res, {
+      ok: addVer.ok,
+      short: addVer.short,
+      content: "Failed to add the new package version to the database."
+    });
     return;
   }
 


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This PR begins the process of improving the error messages returned to users when something on the backend fails. 

It's a grip of mine personally when something goes wrong and all you get is `Server Error` with no details on what can be done to fix it.

This PR aims to begin solving this problem. Since previously all returned error messages have always matched what was originally returned by the Atom API server, we are now taking the chance to improve on those. Since from Pulsar to PPM to the frontend website there don't seem to be any special checks for the exact string of error messages, so this move seems safe to consider. Even then, in case there are third party tools that check the exact strings returned, those will still work without issue. 

How this is done, is by not only returning the `message` that most users are familiar with, the backend will also return `details` (where supported) to provide deeper insight into what has gone wrong during the request. This new handling has first been added explicitly to the `postPackagesVersion()` function that handles the logic when a new package version is being published. As this seems to be the biggest current focus, it can help Pulsar Developers more quickly find the offending code when we have exact strings to use, and can help users to aid during troubleshooting to see what has gone wrong.

The eventual goal will be to have all error messages returned this way once possible.
