### PR TITLE
Properly Update the `package` metadata during a new Version Publish

### DIFF
--- a/src/handlers/post_package_handler.js
+++ b/src/handlers/post_package_handler.js
@@ -407,7 +407,7 @@ async function postPackagesVersion(req, res) {
   // Now add the new Version key.
 
   const addVer = await database.insertNewPackageVersion(
-    packMetadata.content.metadata,
+    packMetadata.content,
     rename ? currentName : null
   );
 

--- a/test/database.integration.test.js
+++ b/test/database.integration.test.js
@@ -182,7 +182,6 @@ describe("Package Lifecycle Tests", () => {
     // === Now let's add a version
     const v1_0_1 = pack.addVersion("1.0.1");
     const addNextVersion = await database.insertNewPackageVersion(
-      v1_0_1,
       pack.packageDataForVersion(v1_0_1)
     );
     if (!addNextVersion.ok) {
@@ -211,7 +210,6 @@ describe("Package Lifecycle Tests", () => {
 
     // === Can we publish a duplicate or a lower version?
     const dupVer = await database.insertNewPackageVersion(
-      v1_0_1,
       pack.packageDataForVersion(v1_0_1)
     );
     expect(dupVer.ok).toBeFalsy();
@@ -306,7 +304,6 @@ describe("Package Lifecycle Tests", () => {
     // This is intentionally unsupported because we want a new package to be always
     // higher than the previous latest one in order to trigger an update to the user.
     const reAddNextVersion = await database.insertNewPackageVersion(
-      v1_0_1,
       pack.packageDataForVersion(v1_0_1)
     );
     const latestVer = await database.getPackageByName(NEW_NAME);
@@ -320,7 +317,6 @@ describe("Package Lifecycle Tests", () => {
     const newSemver = "1.1.0";
     const newVersion = pack.addVersion(newSemver);
     const addNewVersion = await database.insertNewPackageVersion(
-      newVersion,
       pack.packageDataForVersion(newVersion)
     );
     expect(addNewVersion.ok).toBeTruthy();
@@ -340,7 +336,6 @@ describe("Package Lifecycle Tests", () => {
     // === Can we add an odd yet valid semver?
     const oddVer = pack.addVersion("1.2.3-beta.0");
     const oddNewVer = await database.insertNewPackageVersion(
-      oddVer,
       pack.packageDataForVersion(oddVer)
     );
     expect(oddNewVer.ok).toBeTruthy();
@@ -351,8 +346,7 @@ describe("Package Lifecycle Tests", () => {
     // === What about another Odd yet valid semver?
     const oddVer2 = pack.addVersion("1.2.4-alpha1");
     const oddNewVer2 = await database.insertNewPackageVersion(
-      oddVer2,
-      pack.createPack
+      pack.packageDataForVersion(oddVer2)
     );
     expect(oddNewVer2.ok).toBeTruthy();
     expect(oddNewVer2.content).toEqual(

--- a/test/fixtures/lifetime/package-a.js
+++ b/test/fixtures/lifetime/package-a.js
@@ -30,6 +30,7 @@ const addVersion = (v) => {
     version: v,
     description: "A package.json description",
     license: "MIT",
+    engines: { atom: "*" }
   };
 };
 


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

Resolves #97 

This changes how we pass data to `database.insertNewPackageVersion()` and properly passes all data from the VCS service, since the object there was already built how we need to update the metadata field.

I've added the needed SQL statements to update this additional field, after they were removed when attempting to migrate away from keeping data in these fields. Should resolve the above issues, but will only work on new publishes, rather than fixing old ones
