### PR TITLE
Health Check Script

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -10,6 +10,8 @@ docs/resources/
 docs/build.md
 docs/host_your_own.md
 docs/writingIntegrationTests.md
+scripts/
+health-check-output.json # Just in case it's output and not deleted
 # Git Tooling / NPM Tooling
 .git/
 .github/

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test_search": "node ./scripts/tools/search.js",
     "migrations": "pg-migrations apply --directory ./scripts/migrations",
     "ignore": "compactignore",
-    "tool:delete": "node ./scripts/tools/manual-delete-package.js"
+    "tool:delete": "node ./scripts/tools/manual-delete-package.js",
+    "tool:health": "node ./scripts/tools/health-check.js"
   },
   "author": "confused-Techie",
   "license": "MIT",

--- a/scripts/tools/health-check.js
+++ b/scripts/tools/health-check.js
@@ -115,6 +115,15 @@ async function init(params) {
       }
     }
 
+    if (typeof pointer.name !== "string") {
+      results.push(`The package ${pointer.name}::${pointer.pointer} is invalid without it's name!`);
+      continue;
+    }
+    if (typeof pointer.pointer !== "string") {
+      results.push(`The package ${pointer.name}::${pointer.pointer} likely has been deleted.`);
+      continue;
+    }
+
     if (config.packageMetadata) {
 
       let tmp = await validatePackageMetadata(pointer);

--- a/scripts/tools/health-check.js
+++ b/scripts/tools/health-check.js
@@ -22,7 +22,7 @@ Arguments:
   * loading=<value> : Sets the loading animation to use. When verbose is set, a loading
                       appear instead. Valid values:
                       - dots : Displays a dot for each package being checked.
-                      - count: Displays a count of the packages being checked.
+                      - count: Displays a count of the packages being checked. The default
                       - none : Outputs nothing.
   * packageMetadata : Runs this health check.
   * versionTagExists : Runs this health check.
@@ -54,7 +54,7 @@ let config = {
   verbose: false,
   useLimit: false,
   limit: 0,
-  loading: 'dots',
+  loading: 'count',
   githubContactBuffer: 10000, // The milliseconds to wait before contacting GitHub again.
   packageMetadata: false,
   versionTagExists: false,

--- a/scripts/tools/health-check.js
+++ b/scripts/tools/health-check.js
@@ -1,0 +1,213 @@
+/**
+The purpose of this script will be to manually run certain enabled
+health checks agains the packages on the Pulsar Registry.
+
+While initially these will be only to alert of any issues,
+ideally in the future this could work to resolve the issues as well.
+
+Each healthcheck function should return a string of the issue, or return `false`
+if there is no issue present. Or otherwise log why it can't find an issue, returning false.
+
+Usage:
+  npm run tool:health <services to enable seperated by spaces>
+  npm run tool:health mode=read
+  npm run tool:health verbose saveJSON mode=read packageMetadata
+
+Arguments:
+  * mode=<read|write> : Specifies if the health check should attempt automatic fixes
+                        By default runs in readonly mode.
+  * verbose : Should it run in verbose mode.
+  * saveJSON : Should the results be saved to the file system as JSON
+  * limit=<integer> : Set a custom limit, to avoid running the check on the entire DB.
+  * loading=<value> : Sets the loading animation to use. When verbose is set, a loading
+                      appear instead. Valid values:
+                      - dots : Displays a dot for each package being checked.
+                      - none : Outputs nothing.
+  * packageMetadata : Runs the checks to validate the package's `data` field.
+
+Notes:
+  - This script does rely on `./src/config.js` to collect db connection configuration
+*/
+
+const fs = require("fs");
+const postgres = require("postgres");
+const { DB_HOST, DB_USER, DB_PASS, DB_DB, DB_PORT, DB_SSL_CERT } = require("../../src/config.js").getConfig();
+
+let sqlStorage;
+
+let config = {
+  read: true,
+  saveJSON: false,
+  verbose: false,
+  useLimit: false,
+  limit: 0,
+  loading: 'dots',
+  packageMetadata: false,
+};
+
+async function init(params) {
+
+  let results = [];
+
+  for (const param of params) {
+    if (param === "mode=read") {
+      config.read = true;
+    }
+    if (param === "mode=write") {
+      config.read = false;
+    }
+    if (param === "saveJSON") {
+      config.saveJSON = true;
+    }
+    if (param === "verbose") {
+      config.verbose = true;
+    }
+    if (param.startsWith("limit=")) {
+      config.limit = parseInt(param.replace("limit=", ""));
+      config.useLimit = true;
+    }
+    if (param.startsWith("loading=")) {
+      config.loading = param.replace("loading=", "");
+    }
+    if (param === "packageMetadata") {
+      config.packageMetadata = true;
+    }
+  }
+
+
+  if (config.read) {
+    console.log("Health Check running in readonly mode.");
+  } else {
+    console.log("Health Check is running in write mode!");
+  }
+
+  const allPointers = await getPointers();
+
+  for (const pointer of allPointers) {
+    // Provides the function the { name: '', pointer: '' }
+    if (config.packageMetadata) {
+      if (config.verbose) {
+        console.log(`Checking: ${pointer.name}::${pointer.pointer}`);
+      } else {
+        // Since this can be a long running task, we will output a loading bar.
+        if (config.loading === "dots") {
+          process.stdout.write(".");
+        }
+      }
+
+      let tmp = await validatePackageMetadata(pointer);
+
+      if (typeof tmp === "string") {
+        results.push(tmp);
+      }
+    }
+
+  }
+
+  // Now to log the results
+  console.log("\n"); // Newline to ensure the loading doesn't appear
+  for (const res of results) {
+    console.log(res);
+  }
+
+  if (config.saveJSON) {
+    fs.writeFileSync("./health-check-output.json", JSON.stringify(results, null, 2));
+  }
+
+  process.exit(0);
+}
+
+function setupSQL() {
+  try {
+    sqlStorage = postgres({
+      host: DB_HOST,
+      username: DB_USER,
+      password: DB_PASS,
+      database: DB_DB,
+      port: DB_PORT,
+      ssl: {
+        rejectUnauthorized: true,
+        ca: fs.readFileSync(DB_SSL_CERT).toString(),
+      },
+    });
+
+    return sqlStorage;
+
+  } catch(err) {
+    console.log(err);
+    process.exit(100);
+  }
+}
+
+async function sqlEnd() {
+  if (sqlStorage !== undefined) {
+    await sqlStorage.end();
+    console.log("SQL Server Disconnected!");
+  }
+  return;
+}
+
+async function getPointers() {
+  sqlStorage ??= setupSQL();
+
+  let command;
+
+  if (config.useLimit) {
+    command = await sqlStorage`
+      SELECT * FROM names LIMIT ${config.limit};
+    `;
+  } else {
+    command = await sqlStorage`
+      SELECT * FROM names;
+    `;
+  }
+
+  if (command.count === 0) {
+    console.log("Failed to get all package pointers.");
+    await sqlEnd();
+    process.exit(1);
+  }
+
+  return command;
+}
+
+async function getPackageData(pointer) {
+  sqlStorage ??= setupSQL();
+
+  const command = await sqlStorage`
+    SELECT * from packages
+    WHERE pointer = ${pointer}
+  `;
+
+  if (command.count === 0) {
+    return { ok: false, content: `Failed to get package data of ${pointer}` };
+  }
+
+  return { ok: true, content: command[0] };
+}
+
+async function validatePackageMetadata(pointer) {
+  let packData = await getPackageData(pointer.pointer);
+
+  if (!packData.ok) {
+    console.log(packData.content);
+    return false;
+  }
+
+  let data = packData.content.data;
+
+  if (
+    typeof data.name === "string" &&
+    typeof data.readme === "string" &&
+    typeof data.repository?.url === "string" &&
+    typeof data.repository?.type === "string" &&
+    typeof data.metadata === "object"
+  ) {
+    return false;
+  } else {
+    return `The package ${pointer.name}::${pointer.pointer} has invalid Package Metadata!`;
+  }
+
+}
+
+init(process.argv.slice(2));

--- a/scripts/tools/health-check.js
+++ b/scripts/tools/health-check.js
@@ -22,6 +22,7 @@ Arguments:
   * loading=<value> : Sets the loading animation to use. When verbose is set, a loading
                       appear instead. Valid values:
                       - dots : Displays a dot for each package being checked.
+                      - count: Displays a count of the packages being checked.
                       - none : Outputs nothing.
   * packageMetadata : Runs this health check.
   * versionTagExists : Runs this health check.
@@ -104,6 +105,9 @@ async function init(params) {
 
   const allPointers = await getPointers();
 
+  const totalPointers = allPointers.length;
+  let pointerCount = 0;
+
   for (const pointer of allPointers) {
     // Provides the function the { name: '', pointer: '' }
     if (config.verbose) {
@@ -112,6 +116,9 @@ async function init(params) {
       // Since this can be a long running task, we will output a loading bar.
       if (config.loading === "dots") {
         process.stdout.write(".");
+      }
+      if (config.loading === "count") {
+        process.stdout.write(`\r[${pointerCount}/${totalPointers}] Packages Checked`);
       }
     }
 
@@ -150,6 +157,7 @@ async function init(params) {
       }
     }
 
+    pointerCount++;
   }
 
   // Now to log the results

--- a/scripts/tools/health-check.js
+++ b/scripts/tools/health-check.js
@@ -166,6 +166,7 @@ async function init(params) {
     for (const res of results) {
       console.log(res);
     }
+    console.log(`A total of ${results.length} packages have issues.`);
 
     if (config.saveJSON) {
       fs.writeFileSync("./health-check-output.json", JSON.stringify(results, null, 2));


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [ ] Have you ran tests against this code?
* [X] This PR contains zero code changes.

### Description of the Change

Because of various bugs or issues during migration, it's possible that some packages saved on our database have invalid data.

This new tool implements a way we can attempt to locate invalid data. While far from finished it begins the tooling needed to let this happen.

By firstly creating the major portion of the script, and including the first health check.

Using the documentation at the start of the file, we can run `npm run tool:health packageMetadata limit=10` to run the `packageMetadata` health check, and to set the limit of checked packages to `10` and get the following output:

```bash
> atom-backend@1.0.1 tool:health
> node ./scripts/tools/health-check.js packageMetadata limit=10

Health Check running in readonly mode.
..........

The package starrynight-helper::<packages-UUID> has invalid Package Metadata!
The package jscs-format::<packages-UUID> has invalid Package Metadata!
```
