### PR TITLE
Apply 'Made for Pulsar!' badge during delivery time

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -73,6 +73,19 @@ async function constructPackageObjectFull(pack) {
   // so no need to find the latest semver, it's the first one (index 0).
   newPack.releases = { latest: pack?.versions[0]?.semver ?? "" };
 
+  if (!Array.isArray(newPack.badges)) {
+    // A package that has yet to receive any permenant badges
+    newPack.badges = [];
+  }
+
+  // Apply any custom deliver time badges
+  if (newPack.creation_method === "User Made Package") {
+    newPack.badges.push({
+      title: "Made for Pulsar!",
+      type: "success"
+    });
+  }
+
   logger.generic(6, "Built Package Object Full without Error");
 
   return newPack;
@@ -97,6 +110,17 @@ async function constructPackageObjectShort(pack) {
     newPack.releases = {
       latest: p.semver,
     };
+
+    if (!Array.isArray(newPack.badges)) {
+      // A package that has yet to receive any permenant badges
+      newPack.badges = [];
+    }
+
+    // Apply any custom deliver time badges
+    if (newPack.creation_method === "User Made Package") {
+      newPack.badges.push({ title: "Made for Pulsar!", type: "success" });
+    }
+    
     return newPack;
   };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,7 +79,7 @@ async function constructPackageObjectFull(pack) {
   }
 
   // Apply any custom deliver time badges
-  if (newPack.creation_method === "User Made Package") {
+  if (pack.creation_method === "User Made Package") {
     newPack.badges.push({
       title: "Made for Pulsar!",
       type: "success"
@@ -117,10 +117,10 @@ async function constructPackageObjectShort(pack) {
     }
 
     // Apply any custom deliver time badges
-    if (newPack.creation_method === "User Made Package") {
+    if (pack.creation_method === "User Made Package") {
       newPack.badges.push({ title: "Made for Pulsar!", type: "success" });
     }
-    
+
     return newPack;
   };
 


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This PR adds our first badge to the backend. A simple 'Made for Pulsar!' success badge.

This badge is determined by delivery time, and requires zero change within the actual data of the package.

Simply when delivering a package to the end user, the backend will check the creation method of the package, and if it contains the string "User Made Package" (Which is only applied to packages made through the backend) then we give it this badge.

It's a simple way of letting users know that a package is more likely to work than not. And helps highlight some of the package creators we have on the Pulsar ecosystem.