### PR TITLE
Service Filter

### DIFF
--- a/src/handlers/get_package_handler.js
+++ b/src/handlers/get_package_handler.js
@@ -26,13 +26,12 @@ async function getPackages(req, res) {
     page: query.page(req),
     sort: query.sort(req),
     direction: query.dir(req),
+    serviceType: query.serviceType(req),
+    service: query.service(req),
+    serviceVersion: query.serviceVersion(req)
   };
 
-  const packages = await database.getSortedPackages(
-    params.page,
-    params.direction,
-    params.sort
-  );
+  const packages = await database.getSortedPackages(params);
 
   if (!packages.ok) {
     logger.generic(

--- a/src/handlers/theme_handler.js
+++ b/src/handlers/theme_handler.js
@@ -61,12 +61,7 @@ async function getThemes(req, res) {
     direction: query.dir(req),
   };
 
-  const packages = await database.getSortedPackages(
-    params.page,
-    params.direction,
-    params.sort,
-    true
-  );
+  const packages = await database.getSortedPackages(params, true);
 
   if (!packages.ok) {
     logger.generic(

--- a/src/main.js
+++ b/src/main.js
@@ -191,6 +191,22 @@ app.options("/api/pat", genericLimit, async (req, res) => {
  *   @valid desc, asc
  *   @required false
  *   @Pdesc Which direction to list the results. If sorting by stars, can only be sorted by desc.
+ * @param
+ *  @name service
+ *  @Ptype string
+ *  @required false
+ *  @Pdesc A service to filter results by.
+ * @param
+ *  @name serviceType
+ *  @Ptype string
+ *  @required false
+ *  @valid provided, consumed
+ *  @Pdesc The service type to filter results by. Must be supplied if a service is provided.
+ * @param
+ *  @name serviceVersion
+ *  @Ptype string
+ *  @required false
+ *  @Pdesc An optional (when providing a service) version to filter results by.
  * @response
  *   @status 200
  *   @Rtype application/json

--- a/src/query.js
+++ b/src/query.js
@@ -233,6 +233,49 @@ function login(req) {
   return req.params.login ?? "";
 }
 
+function serviceType(req) {
+  const prov = req.query.serviceType;
+
+  if (prov === undefined) {
+    return false;
+  }
+
+  if (prov === "provided") {
+    return "providedServices";
+  }
+
+  if (prov === "consumed") {
+    return "consumedServices"
+  }
+
+  return false; // fallback
+}
+
+function serviceVersion(req) {
+  const semver = req.query.serviceVersion;
+  try {
+    // Regex matching what's used in query.engine()
+    const regex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)/;
+
+    // Check if it's a valid semver
+    return semver.match(regex) !== null ? semver : false;
+  } catch(err) {
+    return false;
+  }
+}
+
+function service(req) {
+  // Functionality here matching that of our query.name()
+  const maxLength = 50;
+  const prov = req.query.service;
+
+  if (typeof prov !== "string") {
+    return false;
+  }
+
+  return pathTraversalAttempt(prov) ? false : prov.slice(0, maxLength).trim();
+}
+
 module.exports = {
   page,
   sort,
@@ -245,4 +288,7 @@ module.exports = {
   auth,
   packageName,
   login,
+  serviceType,
+  serviceVersion,
+  service,
 };

--- a/test/query.unit.test.js
+++ b/test/query.unit.test.js
@@ -139,3 +139,29 @@ describe("Verify Rename Query Returns", () => {
     expect(query.rename(arg)).toBe(result);
   });
 });
+
+const serviceTypeCases = [
+  [{ query: { serviceType: "consumed" } }, "consumedServices"],
+  [{ query: { serviceType: "provided" } }, "providedServices"],
+  [{ query: { serviceType: "invalid" } }, false],
+  [{ query: {} }, false]
+];
+
+describe("Verify serviceType Returns", () => {
+  test.each(serviceTypeCases)("Given %o Returns %p", (arg, result) => {
+    expect(query.serviceType(arg)).toBe(result);
+  });
+});
+
+const serviceVersionCases = [
+  [{ query: { serviceVersion: "1.0.0" } }, "1.0.0"],
+  [{ query: { serviceVersion: "1.0.0-abc" } }, "1.0.0-abc"],
+  [{ query: { serviceVersion: "1234" } }, false],
+  [{ query: {} }, false]
+];
+
+describe("Verify serviceVersion Returns", () => {
+  test.each(serviceVersionCases)("Given %o Returns %p", (arg, result) => {
+    expect(query.serviceVersion(arg)).toBe(result);
+  });
+});


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This PR adds the capability to filter packages results by the provided, or consumed service.

Allowing the editor to take advantage of this functionality to help users find packages that meet the consumed services of a package they install, or vice versa.

---

This PR extends the already existing `GET /api/packages` API endpoint with new query parameters to include this functionality.

The new query parameters for this endpoint are as follows:

* `service`: This is the actual string based service we will want to filter by. If you intend to filter by a service this is a required value. Otherwise can be omitted.
* `serviceType`: This determines if you want to filter by either a consumer or provider of the aforementioned service. Again, if you intend to filter services, this is a required value, or otherwise may be omitted. The following are valid values for this query parameter:
  - `provided`: To filter by `providedServices`
  - `consumed`: To filter by `consumedServices`
* `serviceVersion`: A fully optional parameter, even when filtering by services, let's you further filter by a specific version of the service.

---

Any and all results of this endpoint will continue to match the existing standards, and the return should not have changed at all from this new feature inclusion.

An example request would look like so:

`https://api.pulsar-edit.dev/api/packages?service=autocomplete.watchEditor&serviceType=provided`

All other previous query parameter for this endpoint are still supported when filtering, and will still take effect. Meaning you can still take these results and sort them by 'downloads', 'created_at', 'updated_at', 'stars' and then change the direction of their ordering in 'desc', or 'asc'.

The above example on our current database returns the `autocomplete-plus` package as it's the only provider.

But if we use `https://api.pulsar-edit.dev/api/packages?service=autocomplete.watchEditor&serviceType=consumed`

We get:
- `Hydrogen`
- `find-and-replace`
- `ide-haskell-repl`
- `atom-ide-console`
- `autocomplete-oracle`
- ... etc