### PR TITLE
Add Outdated badge to `hydrogen` & `glacier-darkula-ui`

### DIFF
--- a/docs/reference/Admin_Actions.md
+++ b/docs/reference/Admin_Actions.md
@@ -4,6 +4,38 @@ When you consider that most backend services are a black box of code and decisio
 
 With that said this document will serve as the ongoing history of administrative actions that must be taken against the backend.
 
+## 2023 - March 28
+
+The following packages will recieve the Outdated Badge:
+
+### Hydrogen
+
+The Hydrogen package has a bug where it will fallback to using incorrect old Atom API's when interacting with Pulsar.
+
+One of the Pulsar devs had submitted a fix for this bug [`nteract/hydrogen#2162`](https://github.com/nteract/hydrogen/pull/2162) and that was accepted into the package. Additionally, the package maintainers released a new version [`v2.16.5`](https://github.com/nteract/hydrogen/releases/tag/v2.16.5) containing this fix. But this fix has **not** been published to the Pulsar Package Registry.
+
+It is for this reason it is recommended to install the `hydrogen` package with the following command:
+
+```bash
+pulsar -p install https://github.com/nteract/hydrogen -t v2.16.5
+```
+
+With the above said, `hydrogen` will receive an [`outdated`](./badge-spec.md#outdated) badge.
+
+### Glacier-Darkula-UI
+
+The Glacier-Darkula-UI package uses an old, no longer supported CSS selector when styling the scrollbar. Resulting in the scrollbar taking on OS Native styling when used within Pulsar.
+
+One of the Pulsar devs had submitted a fix for this bug [`pit00/glacier-darkula-ui#1`](https://github.com/pit00/glacier-darkula-ui/pull/1) and that was accepted into the package. But this fix has **not** been published to the Pulsar Package Registry, or added to any tagged release of the package.
+
+It is for this reason it is recommended to install the `glacier-darkula-ui` package with the following command:
+
+```bash
+pulsar -p install https://github.com/pit00/glacier-darkula-ui -t 34c5f677527310463f6930967fdf55f502a818c2
+```
+
+With the above said, `glacier-darkula-ui` will receive an [`outdated`](./badge-spec.md#outdated) badge.
+
 ## 2023 - March 25
 
 For a period of time there was a bug on the backend that, when a package author would publish a new version of their package, the package's main `data` field would be saved improperly. Resulting in the package becoming corrupt and un-downloadable. Some package authors were effected by this.

--- a/docs/reference/badge-spec.md
+++ b/docs/reference/badge-spec.md
@@ -65,7 +65,7 @@ The `Outdated` badge is used to indicate that the version of a package that may 
 
 This badge should only be used when the main functionality of the branch is missing/broken/or otherwise non-functional when installed onto Pulsar as the latest branch, in a supported Pulsar configuration.
 
-That is, if a Pulsar users on a supported platform, indepent of any other issues, installs a package and it immediately does not work, displays severe visual bugs, or causes an error message logged as a notification, and there is a fix available for that package within it's source code, that has not been pushed to Pulsar in a reasonable time, then it is elligble to receive this badge.
+That is, if a Pulsar users on a supported platform, indepent of any other issues, installs a package and it immediately does not work, displays severe visual bugs, or causes an error message logged as a notification, and there is a fix available for that package within it's source code, that has not been pushed to Pulsar in a reasonable time, then it is eligible to receive this badge.
 
 This badge would be added on a case by case basis, and would likely only be added if Pulsar users are reporting the error.
 

--- a/docs/reference/badge-spec.md
+++ b/docs/reference/badge-spec.md
@@ -56,3 +56,17 @@ The following are some valid examples of badges:
   }
 ]
 ```
+
+# Types of Badges & Why They May be Added
+
+## Outdated
+
+The `Outdated` badge is used to indicate that the version of a package that may exist on the Pulsar Package Registry, may be out of date when compared to the package on GitHub (Or other VCS host).
+
+This badge should only be used when the main functionality of the branch is missing/broken/or otherwise non-functional when installed onto Pulsar as the latest branch, in a supported Pulsar configuration.
+
+That is, if a Pulsar users on a supported platform, indepent of any other issues, installs a package and it immediately does not work, displays severe visual bugs, or causes an error message logged as a notification, and there is a fix available for that package within it's source code, that has not been pushed to Pulsar in a reasonable time, then it is elligble to receive this badge.
+
+This badge would be added on a case by case basis, and would likely only be added if Pulsar users are reporting the error.
+
+As with all other badges this badge may be removed at any time, and if you, as a package maintainer have updated a package and did not see this badge removed automatically, or within a reasonable time, feel free to [create an issue](https://github.com/pulsar-edit/package-backend/issues) asking for it to be removed.


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [ ] Have you ran tests against this code?
* [X] This PR contains zero code changes.

### Description of the Change

This PR adds the outdated badges to the above packages, while also adding the docs for what the outdated badge means, and how it can be removed.

The listing in Admin Actions here, would be the location the link of the badge points to, so contains full instructions for the end users on how to install the proper version of the package. As well as the full reasoning of why this was added.
