### PR TITLE
Create, and utilize HTTP Mock Object Builder Pattern for easier chaining of mocked API returns

### DIFF
--- a/test/github.vcs.test.js
+++ b/test/github.vcs.test.js
@@ -1,4 +1,5 @@
 const GitHub = require("../src/vcs_providers/github.js");
+const httpMock = require("./httpMock.helper.jest.js");
 
 const webRequestMockHelper = (data) => {
   const tmpMock = jest
@@ -11,13 +12,9 @@ const webRequestMockHelper = (data) => {
 
 describe("vcs_providers/github.doesUserHaveRepo() MOCK", () => {
   test("Returns No ownership with bad auth return of server", async () => {
-    const mockData = {
-      ok: false,
-      short: "Failed Request",
-      content: {
-        status: 401,
-      },
-    };
+    const mockData = new httpMock
+      .HTTP().ok(false).short("Failed Request").status(401).parse().obj;
+
     const tmpMock = webRequestMockHelper(mockData);
 
     const userData = {
@@ -32,12 +29,11 @@ describe("vcs_providers/github.doesUserHaveRepo() MOCK", () => {
     expect(res.ok).toBe(false);
     expect(res.short).toBe("Bad Auth");
   });
+
   test("Returns Successful Ownership", async () => {
-    const mockData = {
-      ok: true,
-      content: {
-        status: 200,
-        body: [
+    const mockData = new httpMock
+      .HTTP().ok(true).status(200).body(
+        [
           {
             node_id: "456",
             permissions: {
@@ -45,9 +41,9 @@ describe("vcs_providers/github.doesUserHaveRepo() MOCK", () => {
             },
             role_name: "admin",
           },
-        ],
-      },
-    };
+        ]
+      ).parse().obj;
+
     const tmpMock = webRequestMockHelper(mockData);
     const userData = {
       token: "123",
@@ -61,15 +57,12 @@ describe("vcs_providers/github.doesUserHaveRepo() MOCK", () => {
     expect(res.ok).toBe(true);
     expect(res.content).toBe("admin");
   });
+
   test("Returns No Access when the user isn't listed on a repo", async () => {
-    const mockData = {
-      ok: true,
-      content: {
-        status: 200,
-        headers: {
-          link: "",
-        },
-        body: [
+
+    const mockData = new httpMock
+      .HTTP().ok(true).status(200).headers({ link: "" }).body(
+        [
           {
             node_id: "789",
             permissions: {
@@ -77,9 +70,9 @@ describe("vcs_providers/github.doesUserHaveRepo() MOCK", () => {
             },
             role_name: "admin",
           },
-        ],
-      },
-    };
+        ]
+      ).parse().obj;
+
     const tmpMock = webRequestMockHelper(mockData);
     const userData = {
       token: "123",
@@ -94,14 +87,9 @@ describe("vcs_providers/github.doesUserHaveRepo() MOCK", () => {
     expect(res.short).toBe("No Access");
   });
   test("Returns No Access when the user has pull permission", async () => {
-    const mockData = {
-      ok: true,
-      content: {
-        status: 200,
-        headers: {
-          link: "",
-        },
-        body: [
+    const mockData = new httpMock
+      .HTTP().ok(true).status(200).headers({ link: ""}).body(
+        [
           {
             node_id: "123",
             permissions: {
@@ -113,9 +101,8 @@ describe("vcs_providers/github.doesUserHaveRepo() MOCK", () => {
             },
             role_name: "pull",
           },
-        ],
-      },
-    };
+        ]
+      ).parse().obj;
 
     const tmpMock = webRequestMockHelper(mockData);
     const userData = {
@@ -134,13 +121,8 @@ describe("vcs_providers/github.doesUserHaveRepo() MOCK", () => {
 
 describe("vcs_providers/github.readme() MOCK", () => {
   test("Returns Bad Auth", async () => {
-    const mockData = {
-      ok: false,
-      short: "Failed Request",
-      content: {
-        status: 401,
-      },
-    };
+    const mockData = new httpMock
+      .HTTP().ok(false).short("Failed Request").status(401).parse().obj;
 
     const tmpMock = webRequestMockHelper(mockData);
 
@@ -152,13 +134,8 @@ describe("vcs_providers/github.readme() MOCK", () => {
     expect(res.short).toBe("Bad Auth");
   });
   test("Unexpected Status Code Returns Server Error", async () => {
-    const mockData = {
-      ok: false,
-      short: "Failed Request",
-      content: {
-        status: 404,
-      },
-    };
+    const mockData = new httpMock
+      .HTTP().ok(false).short("Failed Request").status(404).parse().obj;
 
     const tmpMock = webRequestMockHelper(mockData);
 

--- a/test/httpMock.helper.jest.js
+++ b/test/httpMock.helper.jest.js
@@ -1,0 +1,83 @@
+/**
+ * @module httpMock.helper.jest.js
+ * @desc This module can help other tests create and mock API results from
+ * the `vcs_providers/git.js` module as needed.
+ * With support for crafting objects using an object builder pattern.
+ * And encoding data into `base64` as expected on the fly.
+ */
+ 
+const Git = require("../src/vcs_providers/git.js");
+
+class HTTP {
+  constructor(path) {
+    this.path = path ?? "";
+    this.ok;
+    this.status;
+    this.body;
+    this.short;
+  }
+
+  ok(bool) {
+    this.ok = bool;
+    return this;
+  }
+
+  short(val) {
+    this.short = val;
+    return this;
+  }
+
+  status(val) {
+    this.status = val;
+    return this;
+  }
+
+  body(val) {
+    this.body = val;
+    return this;
+  }
+
+  parse() {
+    // This returns a properly constructed object.
+
+    return {
+      url: this.path,
+      obj: {
+        ok: this.ok,
+        short: this.short,
+        content: {
+          status: this.status,
+          body: this.body
+        }
+      }
+    };
+  }
+}
+
+function base64(val) {
+  // takes a value, and returns a content and encoding, similar to how GitHub does.
+  let content = Buffer.from(val).toString("base64");
+  return {
+    content: content,
+    encoding: "base64"
+  };
+}
+
+const webRequestMock = (data) => {
+  const tmpMock = jest
+    .spyOn(Git.prototype, "_webRequestAuth")
+    .mockImplementation((url, token) => {
+      for (let i = 0; i < data.length; i++) {
+        if (url === data[i].url) {
+          return data[i].obj;
+        }
+      }
+    });
+    return tmpMock;
+}
+
+module.exports = {
+  webRequestMock,
+  base64,
+  HTTP
+};

--- a/test/httpMock.helper.jest.js
+++ b/test/httpMock.helper.jest.js
@@ -5,7 +5,7 @@
  * With support for crafting objects using an object builder pattern.
  * And encoding data into `base64` as expected on the fly.
  */
- 
+
 const Git = require("../src/vcs_providers/git.js");
 
 class HTTP {
@@ -13,6 +13,7 @@ class HTTP {
     this.path = path ?? "";
     this.ok;
     this.status;
+    this.headers;
     this.body;
     this.short;
   }
@@ -32,6 +33,11 @@ class HTTP {
     return this;
   }
 
+  headers(val) {
+    this.headers = val;
+    return this;
+  }
+
   body(val) {
     this.body = val;
     return this;
@@ -47,6 +53,7 @@ class HTTP {
         short: this.short,
         content: {
           status: this.status,
+          headers: this.headers,
           body: this.body
         }
       }
@@ -74,7 +81,7 @@ const webRequestMock = (data) => {
       }
     });
     return tmpMock;
-}
+};
 
 module.exports = {
   webRequestMock,


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

One factor holding back the, very much needed, total testing refactor, is that while all backend API calls have been moved into a singular function, chaining any type of complex requests can get complex, and become unwieldy to work with.

Since many of the integration functions that need to be properly tested can end up themselves making multiples of tests, and we need to have proper control over every return that may occur within that API return chain, there is no pretty way of creating all of these Mock API responses.

So to at least make them much more wieldy, and avoid duplicating code, this PR introduces a new testing module `httpMock.helper.jest.js` which exports a few functions and classes to assist with mocking API returns.

The most important the `HTTP` class, uses an object builder pattern to craft an object, that once parsed, mimics the API return that would be provided from an API call.

This in conjunction with the reused `webRequestMock` of the `vcs` test module, lets us provide an array of the parsed objects returned by `HTTP` and use them based on path as responses to API calls, to properly Mock any API return within a given chain.

Lastly, a global hashMap is used to retain every generated mock, so that it can be reused within a single files tests, to reduce duplication.
