### PR TITLE
Simple Renovate Config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,8 @@
+{
+  "extends": [ "config:base", ":dependencyDashboardApproval"],
+  "constraints": {
+    "node": "< 18"
+  },
+  "labels": ["dependencies"],
+  "separateMajorMinor": "false"
+}


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [ ] Have you ran tests against this code?
* [X] This PR contains zero code changes.

### Description of the Change

As suggested in [`pulsar-edit/pulsar`#321](https://github.com/pulsar-edit/pulsar/issues/321) this PR switches the backend repo over to renovate from using dependabot.

These changes can hopefully allow more free form testing of this new service here, where the impact to misconfigurations will be much lower than over on the pulsar repo.
