### PR TITLE
Embed Links in Package Version Publish Webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## [Unreleased]
 
+* Added webhooks to be triggered after a package, or package version are published. Allowing notifications of these events to other services. Like the Pulsar Discord.
+
 ## [v1.1.0](https://github.com/pulsar-edit/package-backend/releases/tag/v1.1.0)
 
 * Removed nearly all static data returns during dev runs, to reduce chance of bugs being missed.

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -75,6 +75,14 @@ async function alertPublishVersion(pack, user) {
   let sendObj = {
     username: WEBHOOK_USERNAME,
     content: `${user.username} Published version ${pack.metadata.version} of ${pack.name} to Pulsar!`,
+    embeds: [
+      {
+        url: `https://web.pulsar-edit.dev/packages/${pack.name}`,
+        image: {
+          url: `https://image.pulsar-edit.dev/packages/${pack.name}?image_kind=default`,
+        }
+      }
+    ]
   };
 
   let sendHook = await sendWebHook(sendObj, WEBHOOK_VERSION);

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -4,7 +4,7 @@
  */
 
 const superagent = require("superagent");
-const { WEBHOOK_PUBLISH, WEBHOOK_VERSION, WEBHOOK_USERNAME, server_url } =
+const { WEBHOOK_PUBLISH, WEBHOOK_VERSION, WEBHOOK_USERNAME } =
   require("./config.js").getConfig();
 const logger = require("./logger.js");
 
@@ -106,7 +106,7 @@ async function alertPublishVersion(pack, user) {
 async function sendWebHook(obj, webhookURL) {
   try {
     // Send our webhook data
-    let send = await superagent.post(webhookURL).send(obj);
+    await superagent.post(webhookURL).send(obj);
     // there was no error caught, so return
     return { ok: true };
   } catch (err) {


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

Previously only the webhook event during a package publication would send it's link and image for the package. This PR adds those data fields to the package version publish as well.

Additionally, this PR updates the `CHANGELOG.md`