### PR TITLE
Attempted fix of embed URL

### DIFF
--- a/src/webhook.js
+++ b/src/webhook.js
@@ -31,11 +31,13 @@ async function alertPublishPackage(pack, user) {
     content: `${user.username} Published ${pack.name} to Pulsar!`,
     embeds: [
       {
-        url: `https://web.pulsar-edit.dev/packages/${pack.name}`,
         image: {
           url: `https://image.pulsar-edit.dev/packages/${pack.name}?image_kind=default`,
         },
       },
+      {
+        url: `https://web.pulsar-edit.dev/packages/${pack.name}`
+      }
     ],
   };
 
@@ -77,11 +79,13 @@ async function alertPublishVersion(pack, user) {
     content: `${user.username} Published version ${pack.metadata.version} of ${pack.name} to Pulsar!`,
     embeds: [
       {
-        url: `https://web.pulsar-edit.dev/packages/${pack.name}`,
         image: {
           url: `https://image.pulsar-edit.dev/packages/${pack.name}?image_kind=default`,
         },
       },
+      {
+        url: `https://web.pulsar-edit.dev/packages/${pack.name}`
+      }
     ],
   };
 


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

Currently URls are not showing up properly when a webhook is sent to Discord. This attempts to fix this issue by creating an array of embed objects, rather than a singular object.
