### PR TITLE
Decouple logic and HTTP Handling + Rely on passing modules more than requiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## [Unreleased]
 
+* Decouple HTTP Handling from backend logic
 * Added webhooks to be triggered after a package, or package version are published. Allowing notifications of these events to other services. Like the Pulsar Discord.
 
 ## [v1.1.0](https://github.com/pulsar-edit/package-backend/releases/tag/v1.1.0)

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,10 @@ const config = {
     {
       displayName: "Unit-Tests",
       setupFilesAfterEnv: ["<rootDir>/test/global.setup.jest.js"],
-      testMatch: ["<rootDir>/test/*.unit.test.js"],
+      testMatch: [
+        "<rootDir>/test/*.unit.test.js",
+        "<rootDir>/test/handlers/**/**.js"
+      ],
     },
     {
       displayName: "VCS-Tests",

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,4 +1,3 @@
-const database = require("./database.js");
 const superagent = require("superagent");
 const { GH_USERAGENT } = require("./config.js").getConfig();
 const logger = require("./logger.js");
@@ -15,7 +14,7 @@ const logger = require("./logger.js");
  * @params {string} token - The token the user provided.
  * @returns {object} A server status object.
  */
-async function verifyAuth(token) {
+async function verifyAuth(token, db) {
   if (token === null || token === undefined || token.length === 0) {
     logger.generic(
       5,
@@ -64,7 +63,7 @@ async function verifyAuth(token) {
     const provNodeId = userData.body.node_id;
 
     // Now we want to see if we are able to locate this user's node_id in our db.
-    const dbUser = await database.getUserByNodeID(provNodeId);
+    const dbUser = await db.getUserByNodeID(provNodeId);
 
     if (!dbUser.ok) {
       return dbUser;

--- a/src/handlers/common_handler.js
+++ b/src/handlers/common_handler.js
@@ -37,6 +37,10 @@ async function handleError(req, res, obj, num) {
       await authFail(req, res, obj, num);
       break;
 
+    case "Package Exists":
+      await packageExists(req, res);
+      break;
+      
     case "File Not Found":
     case "Server Error":
     default:

--- a/src/handlers/delete_package_handler.js
+++ b/src/handlers/delete_package_handler.js
@@ -3,7 +3,6 @@
  * @desc Endpoint Handlers for every DELETE Request that relates to packages themselves
  */
 
-const vcs = require("../vcs.js");
 const logger = require("../logger.js");
 
 /**
@@ -15,10 +14,11 @@ const logger = require("../logger.js");
  * @param {string} params.packageName - The name of the package
  * @param {module} db - An instance of the `database.js` module
  * @param {module} auth - An instance of the `auth.js` module
+ * @param {module} vcs - An instance of the `vcs.js` module
  * @property {http_method} - DELETE
  * @property {http_endpoint} - /api/packages/:packageName
  */
-async function deletePackagesName(params, db, auth) {
+async function deletePackagesName(params, db, auth, vcs) {
 
   const user = await auth.verifyAuth(params.auth, db);
 
@@ -116,11 +116,12 @@ async function deletePackagesStar(params, db, auth) {
  * @param {string} params.packageName - The name of the package
  * @param {string} params.versionName - The version of the package
  * @param {module} db - An instance of the `database.js` module
- * @param {module} auth - An instance of the `auth.js` module 
+ * @param {module} auth - An instance of the `auth.js` module
+ * @param {module} vcs - An instance of the `vcs.js` module
  * @property {http_method} - DELETE
  * @property {http_endpoint} - /api/packages/:packageName/versions/:versionName
  */
-async function deletePackageVersion(params, db, auth) {
+async function deletePackageVersion(params, db, auth, vcs) {
 
   // Moving this forward to do the least computationally expensive task first.
   // Check version validity

--- a/src/handlers/delete_package_handler.js
+++ b/src/handlers/delete_package_handler.js
@@ -3,11 +3,8 @@
  * @desc Endpoint Handlers for every DELETE Request that relates to packages themselves
  */
 
-const common = require("./common_handler.js");
-const query = require("../query.js");
 const vcs = require("../vcs.js");
 const logger = require("../logger.js");
-const database = require("../database.js");
 const auth = require("../auth.js");
 
 /**
@@ -19,7 +16,7 @@ const auth = require("../auth.js");
  * @property {http_method} - DELETE
  * @property {http_endpoint} - /api/packages/:packageName
  */
-async function deletePackagesName(params) {
+async function deletePackagesName(params, db) {
 
   const user = await auth.verifyAuth(params.auth);
 
@@ -31,7 +28,7 @@ async function deletePackagesName(params) {
   }
 
   // Lets also first check to make sure the package exists.
-  const packageExists = await database.getPackageByName(
+  const packageExists = await db.getPackageByName(
     params.packageName,
     true
   );
@@ -53,7 +50,7 @@ async function deletePackagesName(params) {
   }
 
   // Now they are logged in locally, and have permission over the GitHub repo.
-  const rm = await database.removePackageByName(params.packageName);
+  const rm = await db.removePackageByName(params.packageName);
 
   if (!rm.ok) {
     return {
@@ -76,7 +73,7 @@ async function deletePackagesName(params) {
  * @property {http_method} - DELETE
  * @property {http_endpoint} - /api/packages/:packageName/star
  */
-async function deletePackagesStar(params) {
+async function deletePackagesStar(params, db) {
 
   const user = await auth.verifyAuth(params.auth);
 
@@ -87,7 +84,7 @@ async function deletePackagesStar(params) {
     };
   }
 
-  const unstar = await database.updateDecrementStar(
+  const unstar = await db.updateDecrementStar(
     user.content,
     params.packageName
   );
@@ -114,7 +111,7 @@ async function deletePackagesStar(params) {
  * @property {http_method} - DELETE
  * @property {http_endpoint} - /api/packages/:packageName/versions/:versionName
  */
-async function deletePackageVersion(params) {
+async function deletePackageVersion(params, db) {
 
   // Moving this forward to do the least computationally expensive task first.
   // Check version validity
@@ -138,7 +135,7 @@ async function deletePackageVersion(params) {
   }
 
   // Lets also first check to make sure the package exists.
-  const packageExists = await database.getPackageByName(
+  const packageExists = await db.getPackageByName(
     params.packageName,
     true
   );
@@ -160,7 +157,7 @@ async function deletePackageVersion(params) {
   }
 
   // Mark the specified version for deletion, if version is valid
-  const removeVersion = await database.removePackageVersion(
+  const removeVersion = await db.removePackageVersion(
     params.packageName,
     params.versionName
   );

--- a/src/handlers/delete_package_handler.js
+++ b/src/handlers/delete_package_handler.js
@@ -5,7 +5,6 @@
 
 const vcs = require("../vcs.js");
 const logger = require("../logger.js");
-const auth = require("../auth.js");
 
 /**
  * @async
@@ -16,9 +15,9 @@ const auth = require("../auth.js");
  * @property {http_method} - DELETE
  * @property {http_endpoint} - /api/packages/:packageName
  */
-async function deletePackagesName(params, db) {
+async function deletePackagesName(params, db, auth) {
 
-  const user = await auth.verifyAuth(params.auth);
+  const user = await auth.verifyAuth(params.auth, db);
 
   if (!user.ok) {
     return {
@@ -73,9 +72,9 @@ async function deletePackagesName(params, db) {
  * @property {http_method} - DELETE
  * @property {http_endpoint} - /api/packages/:packageName/star
  */
-async function deletePackagesStar(params, db) {
+async function deletePackagesStar(params, db, auth) {
 
-  const user = await auth.verifyAuth(params.auth);
+  const user = await auth.verifyAuth(params.auth, db);
 
   if (!user.ok) {
     return {
@@ -111,7 +110,7 @@ async function deletePackagesStar(params, db) {
  * @property {http_method} - DELETE
  * @property {http_endpoint} - /api/packages/:packageName/versions/:versionName
  */
-async function deletePackageVersion(params, db) {
+async function deletePackageVersion(params, db, auth) {
 
   // Moving this forward to do the least computationally expensive task first.
   // Check version validity
@@ -125,7 +124,7 @@ async function deletePackageVersion(params, db) {
   }
 
   // Verify the user has local and remote permissions
-  const user = await auth.verifyAuth(params.auth);
+  const user = await auth.verifyAuth(params.auth, db);
 
   if (!user.ok) {
     return {

--- a/src/handlers/delete_package_handler.js
+++ b/src/handlers/delete_package_handler.js
@@ -10,8 +10,11 @@ const logger = require("../logger.js");
  * @async
  * @function deletePackagesName
  * @desc Allows the user to delete a repo they have ownership of.
- * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @param {object} res - The `Response` object inherited from the Express endpoint.
+ * @param {object} params - The query parameters
+ * @param {string} params.auth - The API key for the user
+ * @param {string} params.packageName - The name of the package
+ * @param {module} db - An instance of the `database.js` module
+ * @param {module} auth - An instance of the `auth.js` module
  * @property {http_method} - DELETE
  * @property {http_endpoint} - /api/packages/:packageName
  */
@@ -67,8 +70,11 @@ async function deletePackagesName(params, db, auth) {
  * @async
  * @function deletePackageStar
  * @desc Used to remove a star from a specific package for the authenticated usesr.
- * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @param {object} res - The `Response` object inherited from the Express endpoint.
+ * @param {object} params - The query parameters
+ * @param {string} params.auth - The API Key of the user
+ * @param {string} params.packageName - The name of the package
+ * @param {module} db - An instance of the `database.js` module
+ * @param {module} auth - An instance of the `auth.js` module
  * @property {http_method} - DELETE
  * @property {http_endpoint} - /api/packages/:packageName/star
  */
@@ -105,8 +111,12 @@ async function deletePackagesStar(params, db, auth) {
  * @async
  * @function deletePackageVersion
  * @desc Allows a user to delete a specific version of their package.
- * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @param {object} res - The `Response` object inherited from the Express endpoint.
+ * @param {object} params - The query parameters
+ * @param {string} params.auth - The API key of the user
+ * @param {string} params.packageName - The name of the package
+ * @param {string} params.versionName - The version of the package
+ * @param {module} db - An instance of the `database.js` module
+ * @param {module} auth - An instance of the `auth.js` module 
  * @property {http_method} - DELETE
  * @property {http_endpoint} - /api/packages/:packageName/versions/:versionName
  */

--- a/src/handlers/get_package_handler.js
+++ b/src/handlers/get_package_handler.js
@@ -21,12 +21,13 @@ const { URL } = require("node:url");
  * @param {string} params.serviceType - The service type to display
  * @param {string} params.service - The service to display
  * @param {string} params.serviceVersion - The service version to show
+ * @param {module} db - An instance of the database
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/packages
  */
-async function getPackages(params) {
+async function getPackages(params, db) {
 
-  const packages = await database.getSortedPackages(params);
+  const packages = await db.getSortedPackages(params);
 
   if (!packages.ok) {
     logger.generic(

--- a/src/handlers/get_package_handler.js
+++ b/src/handlers/get_package_handler.js
@@ -74,6 +74,7 @@ async function getPackages(params, db) {
  * on Atom.io for now. Although there are plans to have this become automatic later on.
  * @see {@link https://github.com/atom/apm/blob/master/src/featured.coffee|Source Code}
  * @see {@link https://github.com/confused-Techie/atom-community-server-backend-JS/issues/23|Discussion}
+ * @param {module} db - An instance of the `database.js` module
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/packages/featured
  */
@@ -114,6 +115,7 @@ async function getPackagesFeatured(db) {
  * @param {string} params.sort - The method to sort by
  * @param {string} params.direction - The direction to sort with
  * @param {string} params.query - The search query
+ * @param {module} db - An instance of the `database.js` module
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/packages/search
  * @todo Note: This **has** been migrated to the new DB, and is fully functional.
@@ -208,6 +210,7 @@ async function getPackagesSearch(params, db) {
  * @param {object} param - The query parameters
  * @param {string} param.engine - The version of Pulsar to check compatibility with
  * @param {string} param.name - The package name
+ * @param {module} db - An instance of the `database.js` module
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/packages/:packageName
  */
@@ -247,6 +250,7 @@ async function getPackagesDetails(params, db) {
  * Taking only the package wanted, and returning it directly.
  * @param {object} params - The query parameters
  * @param {string} params.packageName - The name of the package
+ * @param {module} db - An instance of the `database.js` module
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/packages/:packageName/stargazers
  */
@@ -292,6 +296,7 @@ async function getPackagesStargazers(params, db) {
  * @param {object} params - The query parameters
  * @param {string} params.packageName - The Package name we care about
  * @param {string} params.versionName - The package version we care about
+ * @param {module} db - An instance of the `database.js` module
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/packages/:packageName/versions/:versionName
  */
@@ -333,8 +338,10 @@ async function getPackagesVersion(params, db) {
  * @function getPackagesVersionTarball
  * @desc Allows the user to get the tarball for a specific package version.
  * Which should initiate a download of said tarball on their end.
- * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @param {object} res - The `Response` object inherited from the Express endpoint.
+ * @param {object} params - The query parameters
+ * @param {string} params.packageName - The name of the package
+ * @param {string} params.versionName - The version of the package
+ * @param {module} db - An instance of the `database.js` module 
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/packages/:packageName/versions/:versionName/tarball
  */

--- a/src/handlers/get_package_handler.js
+++ b/src/handlers/get_package_handler.js
@@ -3,8 +3,6 @@
  * @desc Endpoint Handlers for every GET Request that relates to packages themselves
  */
 
-const common = require("./common_handler.js");
-const query = require("../query.js");
 const logger = require("../logger.js");
 const { server_url } = require("../config.js").getConfig();
 const utils = require("../utils.js");
@@ -16,20 +14,17 @@ const { URL } = require("node:url");
  * @function getPackages
  * @desc Endpoint to return all packages to the user. Based on any filtering
  * theyved applied via query parameters.
- * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @param {object} res - The `Response` object inherited from the Express endpoint.
+ * @param {object} params - The query parameters for this endpoint.
+ * @param {integer} params.page - The page to retreive
+ * @param {string} params.sort - The method to sort by
+ * @param {string} params.direction - The direction to sort with
+ * @param {string} params.serviceType - The service type to display
+ * @param {string} params.service - The service to display
+ * @param {string} params.serviceVersion - The service version to show
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/packages
  */
-async function getPackages(req, res) {
-  const params = {
-    page: query.page(req),
-    sort: query.sort(req),
-    direction: query.dir(req),
-    serviceType: query.serviceType(req),
-    service: query.service(req),
-    serviceVersion: query.serviceVersion(req),
-  };
+async function getPackages(params) {
 
   const packages = await database.getSortedPackages(params);
 
@@ -38,8 +33,10 @@ async function getPackages(req, res) {
       3,
       `getPackages-getSortedPackages Not OK: ${packages.content}`
     );
-    await common.handleError(req, res, packages, 1001);
-    return;
+    return {
+      ok: false,
+      content: packages
+    };
   }
 
   const page = packages.pagination.page;
@@ -59,12 +56,13 @@ async function getPackages(req, res) {
     }&order=${params.direction}>; rel="next"`;
   }
 
-  res.append("Link", link);
-  res.append("Query-Total", packages.pagination.count);
-  res.append("Query-Limit", packages.pagination.limit);
-
-  res.status(200).json(packArray);
-  logger.httpLog(req, res);
+  return {
+    ok: true,
+    link: link,
+    total: packages.pagination.count,
+    limit: packages.pagination.limit,
+    content: packArray
+  };
 }
 
 /**
@@ -76,14 +74,12 @@ async function getPackages(req, res) {
  * on Atom.io for now. Although there are plans to have this become automatic later on.
  * @see {@link https://github.com/atom/apm/blob/master/src/featured.coffee|Source Code}
  * @see {@link https://github.com/confused-Techie/atom-community-server-backend-JS/issues/23|Discussion}
- * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @param {object} res - The `Response` object inherited from the Express endpoint.
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/packages/featured
  */
-async function getPackagesFeatured(req, res) {
+async function getPackagesFeatured() {
   // Returns Package Object Short array.
-  // Supports engine query parameter.
+  // TODO: Does not support engine query parameter as of now
   const packs = await database.getFeaturedPackages();
 
   if (!packs.ok) {
@@ -91,8 +87,10 @@ async function getPackagesFeatured(req, res) {
       3,
       `getPackagesFeatured-getFeaturedPackages Not OK: ${packs.content}`
     );
-    await common.handleError(req, res, packs, 1003);
-    return;
+    return {
+      ok: false,
+      content: packs
+    };
   }
 
   const packObjShort = await utils.constructPackageObjectShort(packs.content);
@@ -100,8 +98,10 @@ async function getPackagesFeatured(req, res) {
   // The endpoint using this function needs an array.
   const packArray = Array.isArray(packObjShort) ? packObjShort : [packObjShort];
 
-  res.status(200).json(packArray);
-  logger.httpLog(req, res);
+  return {
+    ok: true,
+    content: packArray
+  };
 }
 
 /**
@@ -109,21 +109,18 @@ async function getPackagesFeatured(req, res) {
  * @function getPackagesSearch
  * @desc Allows user to search through all packages. Using their specified
  * query parameter.
- * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @param {object} res - The `Response` object inherited from the Express endpoint.
+ * @param {object} params - The query parameters
+ * @param {integer} params.page - The page to retreive
+ * @param {string} params.sort - The method to sort by
+ * @param {string} params.direction - The direction to sort with
+ * @param {string} params.query - The search query
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/packages/search
  * @todo Note: This **has** been migrated to the new DB, and is fully functional.
  * The TODO here is to eventually move this to use the custom built in LCS search,
  * rather than simple search.
  */
-async function getPackagesSearch(req, res) {
-  const params = {
-    sort: query.sort(req),
-    page: query.page(req),
-    direction: query.dir(req),
-    query: query.query(req),
-  };
+async function getPackagesSearch(params) {
 
   // Because the task of implementing the custom search engine is taking longer
   // than expected, this will instead use super basic text searching on the DB side.
@@ -146,16 +143,19 @@ async function getPackagesSearch(req, res) {
       // Because getting not found from the search, means the users
       // search just had no matches, we will specially handle this to return
       // an empty array instead.
-      res.status(200).json([]);
-      logger.httpLog(req, res);
-      return;
+      return {
+        ok: true,
+        content: []
+      };
     }
     logger.generic(
       3,
       `getPackagesSearch-simpleSearch Not OK: ${packs.content}`
     );
-    await common.handleError(req, res, packs, 1007);
-    return;
+    return {
+      ok: false,
+      content: packs
+    };
   }
 
   const page = packs.pagination.page;
@@ -191,12 +191,13 @@ async function getPackagesSearch(req, res) {
     }&sort=${params.sort}&order=${params.direction}>; rel="next"`;
   }
 
-  res.append("Link", link);
-  res.append("Query-Total", packs.pagination.count);
-  res.append("Query-Limit", packs.pagination.limit);
-
-  res.status(200).json(packArray);
-  logger.httpLog(req, res);
+  return {
+    ok: true,
+    link: link,
+    total: packs.pagination.count,
+    limit: packs.pagination.limit,
+    content: packArray
+  };
 }
 
 /**
@@ -204,16 +205,14 @@ async function getPackagesSearch(req, res) {
  * @function getPackagesDetails
  * @desc Allows the user to request a single package object full, depending
  * on the package included in the path parameter.
- * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @param {object} res - The `Response` object inherited from the Express endpoint.
+ * @param {object} param - The query parameters
+ * @param {string} param.engine - The version of Pulsar to check compatibility with
+ * @param {string} param.name - The package name
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/packages/:packageName
  */
-async function getPackagesDetails(req, res) {
-  const params = {
-    engine: query.engine(req.query.engine),
-    name: query.packageName(req),
-  };
+async function getPackagesDetails(params) {
+
   let pack = await database.getPackageByName(params.name, true);
 
   if (!pack.ok) {
@@ -221,8 +220,10 @@ async function getPackagesDetails(req, res) {
       3,
       `getPackagesDetails-getPackageByName Not OK: ${pack.content}`
     );
-    await common.handleError(req, res, pack, 1004);
-    return;
+    return {
+      ok: false,
+      content: pack
+    };
   }
 
   pack = await utils.constructPackageObjectFull(pack.content);
@@ -233,8 +234,10 @@ async function getPackagesDetails(req, res) {
     pack = await utils.engineFilter(pack, params.engine);
   }
 
-  res.status(200).json(pack);
-  logger.httpLog(req, res);
+  return {
+    ok: true,
+    content: pack
+  };
 }
 
 /**
@@ -242,60 +245,66 @@ async function getPackagesDetails(req, res) {
  * @function getPackagesStargazers
  * @desc Endpoint returns the array of `star_gazers` from a specified package.
  * Taking only the package wanted, and returning it directly.
- * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @param {object} res - The `Response` object inherited from the Express endpoint.
+ * @param {object} params - The query parameters
+ * @param {string} params.packageName - The name of the package
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/packages/:packageName/stargazers
  */
-async function getPackagesStargazers(req, res) {
-  const params = {
-    packageName: query.packageName(req),
-  };
+async function getPackagesStargazers(params) {
   // The following can't be executed in user mode because we need the pointer
   const pack = await database.getPackageByName(params.packageName);
 
   if (!pack.ok) {
-    await common.handleError(req, res, pack);
-    return;
+    return {
+      ok: false,
+      content: pack
+    };
   }
 
   const stars = await database.getStarringUsersByPointer(pack.content);
 
   if (!stars.ok) {
-    await common.handleError(req, res, stars);
-    return;
+    return {
+      ok: false,
+      content: stars
+    };
   }
 
   const gazers = await database.getUserCollectionById(stars.content);
 
   if (!gazers.ok) {
-    await common.handleError(req, res, gazers);
-    return;
+    return {
+      ok: false,
+      content: gazers
+    };
   }
 
-  res.status(200).json(gazers.content);
-  logger.httpLog(req, res);
+  return {
+    ok: true,
+    content: gazers.content
+  };
 }
 
 /**
  * @async
  * @function getPackagesVersion
  * @desc Used to retrieve a specific version from a package.
- * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @param {object} res - The `Response` object inherited from the Express endpoint.
+ * @param {object} params - The query parameters
+ * @param {string} params.packageName - The Package name we care about
+ * @param {string} params.versionName - The package version we care about
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/packages/:packageName/versions/:versionName
  */
-async function getPackagesVersion(req, res) {
-  const params = {
-    packageName: query.packageName(req),
-    versionName: query.engine(req.params.versionName),
-  };
+async function getPackagesVersion(params) {
   // Check the truthiness of the returned query engine.
   if (params.versionName === false) {
     // we return a 404 for the version, since its an invalid format
-    await common.notFound(req, res);
-    return;
+    return {
+      ok: false,
+      content: {
+        short: "Not Found",
+      }
+    };
   }
   // Now we know the version is a valid semver.
 
@@ -305,14 +314,18 @@ async function getPackagesVersion(req, res) {
   );
 
   if (!pack.ok) {
-    await common.handleError(req, res, pack);
-    return;
+    return {
+      ok: false,
+      content: pack
+    };
   }
 
   const packRes = await utils.constructPackageObjectJSON(pack.content);
 
-  res.status(200).json(packRes);
-  logger.httpLog(req, res);
+  return {
+    ok: true,
+    content: packRes
+  };
 }
 
 /**
@@ -325,11 +338,8 @@ async function getPackagesVersion(req, res) {
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/packages/:packageName/versions/:versionName/tarball
  */
-async function getPackagesVersionTarball(req, res) {
-  const params = {
-    packageName: query.packageName(req),
-    versionName: query.engine(req.params.versionName),
-  };
+async function getPackagesVersionTarball(params) {
+
   // Now that migration has began we know that each version will have
   // a tarball_url key on it, linking directly to the tarball from gh for that version.
 
@@ -337,8 +347,12 @@ async function getPackagesVersionTarball(req, res) {
   if (params.versionName === false) {
     // since query.engine gives false if invalid, we can just check if its truthy
     // additionally if its false, we know the version will never be found.
-    await common.notFound(req, res);
-    return;
+    return {
+      ok: false,
+      content: {
+        short: "Not Found"
+      }
+    };
   }
 
   // first lets get the package
@@ -348,8 +362,10 @@ async function getPackagesVersionTarball(req, res) {
   );
 
   if (!pack.ok) {
-    await common.handleError(req, res, pack);
-    return;
+    return {
+      ok: false,
+      content: pack
+    };
   }
 
   const save = await database.updatePackageIncrementDownloadByName(
@@ -386,12 +402,14 @@ async function getPackagesVersionTarball(req, res) {
       3,
       `Malformed tarball URL for version ${params.versionName} of ${params.packageName}`
     );
-    await common.handleError(req, res, {
+    return {
       ok: false,
-      short: "Server Error",
-      content: e,
-    });
-    return;
+      content: {
+        ok: false,
+        short: "Server Error",
+        content: e
+      }
+    };
   }
 
   const allowedHostnames = [
@@ -405,17 +423,20 @@ async function getPackagesVersionTarball(req, res) {
     !allowedHostnames.includes(hostname) &&
     process.env.PULSAR_STATUS !== "dev"
   ) {
-    await common.handleError(req, res, {
+    return {
       ok: false,
-      short: "Server Error",
-      content: `Invalid Domain for Download Redirect: ${hostname}`,
-    });
-    return;
+      content: {
+        ok: false,
+        short: "Server Error",
+        content: `Invalid Domain for Download Redirect: ${hostname}`,
+      }
+    };
   }
 
-  res.redirect(tarballURL);
-  logger.httpLog(req, res);
-  return;
+  return {
+    ok: true,
+    content: tarballURL
+  };
 }
 
 module.exports = {

--- a/src/handlers/post_package_handler.js
+++ b/src/handlers/post_package_handler.js
@@ -13,8 +13,11 @@ const utils = require("../utils.js");
  * @desc This endpoint is used to publish a new package to the backend server.
  * Taking the repo, and your authentication for it, determines if it can be published,
  * then goes about doing so.
- * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @param {object} res - The `Response` object inherited from the Express endpoint.
+ * @param {object} params - The query parameters
+ * @param {string} params.repository - The `owner/repo` combo of the remote package
+ * @param {string} params.auth - The API key of the user
+ * @param {module} db - An instance of the `database.js` module
+ * @param {module} auth - An instance of the `auth.js` module
  * @return {string} JSON object of new data pushed into the database, but stripped of
  * sensitive informations like primary and foreign keys.
  * @property {http_method} - POST
@@ -192,8 +195,11 @@ async function postPackages(params, db, auth) {
  * @async
  * @function postPackagesStar
  * @desc Used to submit a new star to a package from the authenticated user.
- * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @param {object} res - The `Response` object inherited from the Express endpoint.
+ * @param {object} params - The query parameters
+ * @param {string} params.auth - The API key of the user
+ * @param {string} params.packageName - The name of the package
+ * @param {module} db - An instance of the `database.js` module
+ * @param {module} auth - An instance of the `auth.js` module
  * @property {http_method} - POST
  * @property {http_endpoint} - /api/packages/:packageName/star
  */
@@ -243,8 +249,12 @@ async function postPackagesStar(params, db, auth) {
  * @function postPackagesVersion
  * @desc Allows a new version of a package to be published. But also can allow
  * a user to rename their application during this process.
- * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @param {object} res - The `Response` object inherited from the Express endpoint.
+ * @param {object} params - The query parameters
+ * @param {boolean} params.rename - Whether or not to preform a rename
+ * @param {string} params.auth - The API key of the user
+ * @param {string} params.packageName - The name of the package
+ * @param {module} db - An instance of the `database.js` module
+ * @param {module} auth - An instance of the `auth.js` module 
  * @property {http_method} - POST
  * @property {http_endpoint} - /api/packages/:packageName/versions
  */

--- a/src/handlers/post_package_handler.js
+++ b/src/handlers/post_package_handler.js
@@ -3,7 +3,6 @@
  * @desc Endpoint Handlers for every POST Request that relates to packages themselves
  */
 
-const vcs = require("../vcs.js");
 const logger = require("../logger.js");
 const utils = require("../utils.js");
 
@@ -18,12 +17,13 @@ const utils = require("../utils.js");
  * @param {string} params.auth - The API key of the user
  * @param {module} db - An instance of the `database.js` module
  * @param {module} auth - An instance of the `auth.js` module
+ * @param {module} vcs - An instance of the `vcs.js` module
  * @return {string} JSON object of new data pushed into the database, but stripped of
  * sensitive informations like primary and foreign keys.
  * @property {http_method} - POST
  * @property {http_endpoint} - /api/packages
  */
-async function postPackages(params, db, auth) {
+async function postPackages(params, db, auth, vcs) {
 
   const user = await auth.verifyAuth(params.auth, db);
   logger.generic(
@@ -254,11 +254,12 @@ async function postPackagesStar(params, db, auth) {
  * @param {string} params.auth - The API key of the user
  * @param {string} params.packageName - The name of the package
  * @param {module} db - An instance of the `database.js` module
- * @param {module} auth - An instance of the `auth.js` module 
+ * @param {module} auth - An instance of the `auth.js` module
+ * @param {module} vcs - An instance of the `vcs.js` module
  * @property {http_method} - POST
  * @property {http_endpoint} - /api/packages/:packageName/versions
  */
-async function postPackagesVersion(params, db, auth) {
+async function postPackagesVersion(params, db, auth, vcs) {
 
   // On renaming:
   // When a package is being renamed, we will expect that packageName will

--- a/src/handlers/post_package_handler.js
+++ b/src/handlers/post_package_handler.js
@@ -6,7 +6,6 @@
 const vcs = require("../vcs.js");
 const logger = require("../logger.js");
 const utils = require("../utils.js");
-const auth = require("../auth.js");
 
 /**
  * @async
@@ -21,9 +20,9 @@ const auth = require("../auth.js");
  * @property {http_method} - POST
  * @property {http_endpoint} - /api/packages
  */
-async function postPackages(params, db) {
+async function postPackages(params, db, auth) {
 
-  const user = await auth.verifyAuth(params.auth);
+  const user = await auth.verifyAuth(params.auth, db);
   logger.generic(
     6,
     `${user.content.username} Attempting to Publish new package`
@@ -198,9 +197,9 @@ async function postPackages(params, db) {
  * @property {http_method} - POST
  * @property {http_endpoint} - /api/packages/:packageName/star
  */
-async function postPackagesStar(params, db) {
+async function postPackagesStar(params, db, auth) {
 
-  const user = await auth.verifyAuth(params.auth);
+  const user = await auth.verifyAuth(params.auth, db);
 
   if (!user.ok) {
     return {
@@ -249,7 +248,7 @@ async function postPackagesStar(params, db) {
  * @property {http_method} - POST
  * @property {http_endpoint} - /api/packages/:packageName/versions
  */
-async function postPackagesVersion(params, db) {
+async function postPackagesVersion(params, db, auth) {
 
   // On renaming:
   // When a package is being renamed, we will expect that packageName will
@@ -258,7 +257,7 @@ async function postPackagesVersion(params, db) {
   // And if they are, we expect that `rename` is true. Because otherwise it will fail.
   // That's the methodology, the logic here just needs to catch up.
 
-  const user = await auth.verifyAuth(params.auth);
+  const user = await auth.verifyAuth(params.auth, db);
 
   if (!user.ok) {
     logger.generic(

--- a/src/handlers/star_handler.js
+++ b/src/handlers/star_handler.js
@@ -5,7 +5,6 @@
 
 const logger = require("../logger.js");
 const utils = require("../utils.js");
-const auth = require("../auth.js");
 
 /**
  * @async
@@ -17,9 +16,9 @@ const auth = require("../auth.js");
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/stars
  */
-async function getStars(params, db) {
+async function getStars(params, db, auth) {
 
-  let user = await auth.verifyAuth(params.auth);
+  let user = await auth.verifyAuth(params.auth, db);
 
   if (!user.ok) {
     logger.generic(3, "getStars auth.verifyAuth() Not OK", {

--- a/src/handlers/star_handler.js
+++ b/src/handlers/star_handler.js
@@ -13,6 +13,8 @@ const utils = require("../utils.js");
  * the authenticated user has stared.
  * @param {object} param - The supported query parameters.
  * @param {string} param.auth - The authentication API token
+ * @param {module} db - An instance of the `database.js` module
+ * @param {module} auth - An instance of the `auth.js` module 
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/stars
  */

--- a/src/handlers/star_handler.js
+++ b/src/handlers/star_handler.js
@@ -4,7 +4,6 @@
  */
 
 const logger = require("../logger.js");
-const database = require("../database.js");
 const utils = require("../utils.js");
 const auth = require("../auth.js");
 
@@ -18,7 +17,7 @@ const auth = require("../auth.js");
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/stars
  */
-async function getStars(params) {
+async function getStars(params, db) {
 
   let user = await auth.verifyAuth(params.auth);
 
@@ -33,7 +32,7 @@ async function getStars(params) {
     };
   }
 
-  let userStars = await database.getStarredPointersByUserID(user.content.id);
+  let userStars = await db.getStarredPointersByUserID(user.content.id);
 
   if (!userStars.ok) {
     logger.generic(3, "getStars database.getStarredPointersByUserID() Not OK", {
@@ -57,7 +56,7 @@ async function getStars(params) {
     };
   }
 
-  let packCol = await database.getPackageCollectionByID(userStars.content);
+  let packCol = await db.getPackageCollectionByID(userStars.content);
 
   if (!packCol.ok) {
     logger.generic(3, "getStars database.getPackageCollectionByID() Not OK", {

--- a/src/handlers/theme_handler.js
+++ b/src/handlers/theme_handler.js
@@ -20,6 +20,7 @@ const { server_url } = require("../config.js").getConfig();
  * on Atom.io for now. Although there are plans to have this become automatic later on.
  * @see {@link https://github.com/atom/apm/blob/master/src/featured.coffee|Source Code}
  * @see {@link https://github.com/confused-Techie/atom-community-server-backend-JS/issues/23|Discussion}
+ * @param {module} db - An instance of the `database.js` module
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/themes/featured
  */
@@ -52,6 +53,7 @@ async function getThemeFeatured(db) {
  * @param {integer} params.page - The page of results to retreive.
  * @param {string} params.sort - The sort method to use.
  * @param {string} params.direction - The direction to sort results.
+ * @param {module} db - An instance of the `database.js` module
  * @returns {object} An HTTP ServerStatus.
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/themes
@@ -107,6 +109,7 @@ async function getThemes(params, db) {
  * @param {string} params.sort - The method to use to sort
  * @param {string} params.direction - The direction to sort
  * @param {string} params.query - The search query to use
+ * @param {module} db - An instance of the `database.js` module 
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/themes/search
  */

--- a/src/handlers/theme_handler.js
+++ b/src/handlers/theme_handler.js
@@ -1,17 +1,15 @@
 /**
  * @module theme_handler
  * @desc Endpoint Handlers relating to themes only.
- * @implements {command_handler}
  * @implements {database}
  * @implements {utils}
  * @implements {logger}
+ * @implements {config}
  */
 
-const common = require("./common_handler.js");
 const database = require("../database.js");
 const utils = require("../utils.js");
 const logger = require("../logger.js");
-const query = require("../query.js");
 const { server_url } = require("../config.js").getConfig();
 
 /**

--- a/src/handlers/theme_handler.js
+++ b/src/handlers/theme_handler.js
@@ -7,7 +7,6 @@
  * @implements {config}
  */
 
-const database = require("../database.js");
 const utils = require("../utils.js");
 const logger = require("../logger.js");
 const { server_url } = require("../config.js").getConfig();
@@ -24,10 +23,10 @@ const { server_url } = require("../config.js").getConfig();
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/themes/featured
  */
-async function getThemeFeatured() {
+async function getThemeFeatured(db) {
   // Returns Package Object Short Array
 
-  let col = await database.getFeaturedThemes();
+  let col = await db.getFeaturedThemes();
 
   if (!col.ok) {
     return {
@@ -57,9 +56,9 @@ async function getThemeFeatured() {
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/themes
  */
-async function getThemes(params) {
+async function getThemes(params, db) {
 
-  const packages = await database.getSortedPackages(params, true);
+  const packages = await db.getSortedPackages(params, true);
 
   if (!packages.ok) {
     logger.generic(
@@ -111,9 +110,9 @@ async function getThemes(params) {
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/themes/search
  */
-async function getThemesSearch(params) {
+async function getThemesSearch(params, db) {
 
-  const packs = await database.simpleSearch(
+  const packs = await db.simpleSearch(
     params.query,
     params.page,
     params.direction,

--- a/src/handlers/update_handler.js
+++ b/src/handlers/update_handler.js
@@ -10,15 +10,15 @@ const common = require("./common_handler.js");
  * @async
  * @function getUpdates
  * @desc Used to retrieve new editor update information.
- * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @param {object} res - The `Response` object inherited from the Express endpoint.
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/updates
  * @todo This function has never been implemented on this system. Since there is currently no
  * update methodology.
  */
-async function getUpdates(req, res) {
-  await common.notSupported(req, res);
+async function getUpdates() {
+  return {
+    ok: false
+  };
 }
 
 module.exports = {

--- a/src/handlers/user_handler.js
+++ b/src/handlers/user_handler.js
@@ -11,7 +11,8 @@ const utils = require("../utils.js");
  * @function getLoginStars
  * @desc Endpoint that returns another users Star Gazers List.
  * @param {object} params - The query parameters for the request
- * @param {string} params.login - The Login API Key
+ * @param {string} params.login - The username
+ * @param {module} db - An instance of the `database.js` module
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/users/:login/stars
  */
@@ -80,6 +81,8 @@ async function getLoginStars(params, db) {
  * @desc Endpoint that returns the currently authenticated Users User Details
  * @param {object} params - The query parameters for this endpoint
  * @param {string} params.auth - The API Key
+ * @param {module} db - An instance of the `database.js` module
+ * @param {module} auth - An instance of the `auth.js` module
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/users
  */
@@ -122,6 +125,7 @@ async function getAuthUser(params, db, auth) {
  * published.
  * @param {object} params - The query parameters
  * @param {string} params.login - The Username we want to look for
+ * @param {module} db - An instance of the `database.js` module 
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/users/:login
  */

--- a/src/handlers/user_handler.js
+++ b/src/handlers/user_handler.js
@@ -4,10 +4,7 @@
  */
 
 const logger = require("../logger.js");
-const common = require("./common_handler.js");
-const database = require("../database.js");
 const utils = require("../utils.js");
-const query = require("../query.js");
 const auth = require("../auth.js");
 
 /**
@@ -19,9 +16,9 @@ const auth = require("../auth.js");
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/users/:login/stars
  */
-async function getLoginStars(params) {
+async function getLoginStars(params, db) {
 
-  let user = await database.getUserByName(params.login);
+  let user = await db.getUserByName(params.login);
 
   if (!user.ok) {
     return {
@@ -30,7 +27,7 @@ async function getLoginStars(params) {
     };
   }
 
-  let pointerCollection = await database.getStarredPointersByUserID(
+  let pointerCollection = await db.getStarredPointersByUserID(
     user.content.id
   );
 
@@ -57,7 +54,7 @@ async function getLoginStars(params) {
     };
   }
 
-  let packageCollection = await database.getPackageCollectionByID(
+  let packageCollection = await db.getPackageCollectionByID(
     pointerCollection.content
   );
 
@@ -129,9 +126,9 @@ async function getAuthUser(params) {
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/users/:login
  */
-async function getUser(params) {
-  
-  let user = await database.getUserByName(params.login);
+async function getUser(params, db) {
+
+  let user = await db.getUserByName(params.login);
 
   if (!user.ok) {
     return {

--- a/src/handlers/user_handler.js
+++ b/src/handlers/user_handler.js
@@ -5,7 +5,6 @@
 
 const logger = require("../logger.js");
 const utils = require("../utils.js");
-const auth = require("../auth.js");
 
 /**
  * @async
@@ -84,9 +83,9 @@ async function getLoginStars(params, db) {
  * @property {http_method} - GET
  * @property {http_endpoint} - /api/users
  */
-async function getAuthUser(params) {
+async function getAuthUser(params, db, auth) {
 
-  const user = await auth.verifyAuth(params.auth);
+  const user = await auth.verifyAuth(params.auth, db);
 
   if (!user.ok) {
     return {

--- a/src/main.js
+++ b/src/main.js
@@ -627,7 +627,22 @@ app.delete("/api/:packType/:packageName", authLimit, async (req, res, next) => {
   switch (req.params.packType) {
     case "packages":
     case "themes":
-      await package_handler.deletePackagesName(req, res);
+      const params = {
+        auth: query.auth(req),
+        packageName: query.packageName(req)
+      };
+
+      let ret = await package_handler.deletePackagesName(params);
+
+      if (!ret.ok) {
+        await common_handler.handleError(req, res, ret.content);
+        return;
+      }
+
+      // We know on success we should just return a statuscode
+      res.status(204).send();
+      logger.httpLog(req, res);
+
       break;
     default:
       next();
@@ -739,7 +754,22 @@ app.delete(
     switch (req.params.packType) {
       case "packages":
       case "themes":
-        await package_handler.deletePackagesStar(req, res);
+        const params = {
+          auth: query.auth(req),
+          packageName: query.packageName(req)
+        };
+
+        let ret = await package_handler.deletePackagesStar(params);
+
+        if (!ret.ok) {
+          await common_handler.handleError(req, res, ret.content);
+          return;
+        }
+
+        // On success we just return status code
+        res.status(201).send();
+        logger.httpLog(req, res);
+        
         break;
       default:
         next();

--- a/src/main.js
+++ b/src/main.js
@@ -769,7 +769,7 @@ app.delete(
         // On success we just return status code
         res.status(201).send();
         logger.httpLog(req, res);
-        
+
         break;
       default:
         next();
@@ -1037,7 +1037,23 @@ app.delete(
     switch (req.params.packType) {
       case "packages":
       case "themes":
-        await package_handler.deletePackageVersion(req, res);
+        const params = {
+          auth: query.auth(req),
+          packageName: query.packageName(req),
+          versionName: query.engine(req.params.versionName)
+        };
+
+        let ret = await package_handler.deletePackageVersion(params);
+
+        if (!ret.ok) {
+          await common_handler.handleError(req, res, ret.content);
+          return;
+        }
+
+        // This is, on success, and empty return
+        res.status(204).send();
+        logger.httpLog(req, res);
+        
         break;
       default:
         next();

--- a/src/main.js
+++ b/src/main.js
@@ -1199,7 +1199,19 @@ app.options("/api/users/:login", genericLimit, async (req, res) => {
  *   @Rtype application/json
  */
 app.get("/api/stars", authLimit, async (req, res) => {
-  await star_handler.getStars(req, res);
+  const params = {
+    auth: query.auth(req)
+  };
+
+  let ret = await star_handler.getStars(params);
+
+  if (!ret.ok) {
+    await common_handler.handleError(req, res, ret.content);
+    return;
+  }
+
+  res.status(200).json(ret.content);
+  logger.httpLog(req, res);
 });
 
 app.options("/api/stars", genericLimit, async (req, res) => {

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ const auth = require("./auth.js");
 const server_version = require("../package.json").version;
 const logger = require("./logger.js");
 const query = require("./query.js");
+const vcs = require("./vcs.js");
 const rateLimit = require("express-rate-limit");
 const { MemoryStore } = require("express-rate-limit");
 const { RATE_LIMIT_AUTH, RATE_LIMIT_GENERIC } =
@@ -323,7 +324,7 @@ app.post("/api/:packType", authLimit, async (req, res, next) => {
         auth: query.auth(req)
       };
 
-      let ret = await package_handler.postPackages(params, database, auth);
+      let ret = await package_handler.postPackages(params, database, auth, vcs);
 
       if (!ret.ok) {
         if (ret.type === "detailed") {
@@ -954,7 +955,7 @@ app.post(
           packageName: query.packageName(req)
         };
 
-        let ret = await package_handler.postPackagesVersion(params, database, auth);
+        let ret = await package_handler.postPackagesVersion(params, database, auth, vcs);
 
         if (!ret.ok) {
           if (ret.type === "detailed") {

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ const package_handler = require("./handlers/package_handler.js");
 const common_handler = require("./handlers/common_handler.js");
 const oauth_handler = require("./handlers/oauth_handler.js");
 const webhook = require("./webhook.js");
+const database = require("./database.js");
 const server_version = require("../package.json").version;
 const logger = require("./logger.js");
 const query = require("./query.js");
@@ -225,7 +226,7 @@ app.get("/api/:packType", genericLimit, async (req, res, next) => {
         serviceType: query.serviceType(req),
         service: query.service(req),
         serviceVersion: query.serviceVersion(req)
-      });
+      }, database);
 
       if (!ret.ok) {
         await common_handler.handleError(req, res, ret.content);

--- a/src/main.js
+++ b/src/main.js
@@ -657,7 +657,7 @@ app.delete("/api/:packType/:packageName", authLimit, async (req, res, next) => {
         packageName: query.packageName(req)
       };
 
-      let ret = await package_handler.deletePackagesName(params, database, auth);
+      let ret = await package_handler.deletePackagesName(params, database, auth, vcs);
 
       if (!ret.ok) {
         await common_handler.handleError(req, res, ret.content);
@@ -1103,7 +1103,7 @@ app.delete(
           versionName: query.engine(req.params.versionName)
         };
 
-        let ret = await package_handler.deletePackageVersion(params, database, auth);
+        let ret = await package_handler.deletePackageVersion(params, database, auth, vcs);
 
         if (!ret.ok) {
           await common_handler.handleError(req, res, ret.content);

--- a/src/main.js
+++ b/src/main.js
@@ -249,7 +249,7 @@ app.get("/api/:packType", genericLimit, async (req, res, next) => {
         page: query.page(req),
         sort: query.sort(req),
         direction: query.dir(req)
-      });
+      }, database);
 
       if (!ret.ok) {
         await common_handler.handleError(req, res, ret.content);
@@ -322,7 +322,7 @@ app.post("/api/:packType", authLimit, async (req, res, next) => {
         auth: query.auth(req)
       };
 
-      let ret = await package_handler.postPackages(params);
+      let ret = await package_handler.postPackages(params, database);
 
       if (!ret.ok) {
         if (ret.type === "detailed") {
@@ -383,7 +383,7 @@ app.options("/api/:packType", genericLimit, async (req, res, next) => {
 app.get("/api/:packType/featured", genericLimit, async (req, res, next) => {
   switch (req.params.packType) {
     case "packages": {
-      let ret = await package_handler.getPackagesFeatured();
+      let ret = await package_handler.getPackagesFeatured(database);
 
       if (!ret.ok) {
         await common_handler.handleError(req, res, ret.content);
@@ -395,7 +395,7 @@ app.get("/api/:packType/featured", genericLimit, async (req, res, next) => {
       break;
     }
     case "themes": {
-      let ret = await theme_handler.getThemeFeatured();
+      let ret = await theme_handler.getThemeFeatured(database);
 
       if (!ret.ok) {
         await common_handler.handleError(req, res, ret.content);
@@ -485,7 +485,7 @@ app.get("/api/:packType/search", genericLimit, async (req, res, next) => {
         page: query.page(req),
         direction: query.dir(req),
         query: query.query(req)
-      });
+      }, database);
 
       if (!ret.ok) {
         await common_handler.handleError(req, res, ret.content);
@@ -509,7 +509,7 @@ app.get("/api/:packType/search", genericLimit, async (req, res, next) => {
         query: query.query(req)
       };
 
-      let ret = await theme_handler.getThemesSearch(params);
+      let ret = await theme_handler.getThemesSearch(params, database);
 
       if (!ret.ok) {
         await common_handler.handleError(req, res, ret.content);
@@ -590,7 +590,7 @@ app.get("/api/:packType/:packageName", genericLimit, async (req, res, next) => {
         name: query.packageName(req)
       };
 
-      let ret = await package_handler.getPackagesDetails(params);
+      let ret = await package_handler.getPackagesDetails(params, database);
 
       if (!ret.ok) {
         await common_handler.handleError(req, res, ret.content);
@@ -655,7 +655,7 @@ app.delete("/api/:packType/:packageName", authLimit, async (req, res, next) => {
         packageName: query.packageName(req)
       };
 
-      let ret = await package_handler.deletePackagesName(params);
+      let ret = await package_handler.deletePackagesName(params, database);
 
       if (!ret.ok) {
         await common_handler.handleError(req, res, ret.content);
@@ -736,7 +736,7 @@ app.post(
           packageName: query.packageName(req)
         };
 
-        let ret = await package_handler.postPackagesStar(params);
+        let ret = await package_handler.postPackagesStar(params, database);
 
         if (!ret.ok) {
           await common_handler.handleError(req, res, ret.content);
@@ -795,7 +795,7 @@ app.delete(
           packageName: query.packageName(req)
         };
 
-        let ret = await package_handler.deletePackagesStar(params);
+        let ret = await package_handler.deletePackagesStar(params, database);
 
         if (!ret.ok) {
           await common_handler.handleError(req, res, ret.content);
@@ -867,7 +867,7 @@ app.get(
         const params = {
           packageName: query.packageName(req)
         };
-        let ret = await package_handler.getPackagesStargazers(params);
+        let ret = await package_handler.getPackagesStargazers(params, database);
 
         if (!ret.ok) {
           await common_handler.handleError(req, res, ret.content);
@@ -953,7 +953,7 @@ app.post(
           packageName: query.packageName(req)
         };
 
-        let ret = await package_handler.postPackagesVersion(params);
+        let ret = await package_handler.postPackagesVersion(params, database);
 
         if (!ret.ok) {
           if (ret.type === "detailed") {
@@ -1038,7 +1038,7 @@ app.get(
           versionName: query.engine(req.params.versionName)
         };
 
-        let ret = await package_handler.getPackagesVersion(params);
+        let ret = await package_handler.getPackagesVersion(params, database);
 
         if (!ret.ok) {
           await common_handler.handleError(req, res, ret.content);
@@ -1101,7 +1101,7 @@ app.delete(
           versionName: query.engine(req.params.versionName)
         };
 
-        let ret = await package_handler.deletePackageVersion(params);
+        let ret = await package_handler.deletePackageVersion(params, database);
 
         if (!ret.ok) {
           await common_handler.handleError(req, res, ret.content);
@@ -1180,7 +1180,7 @@ app.get(
           versionName: query.engine(req.params.versionName)
         };
 
-        let ret = await package_handler.getPackagesVersionTarball(params);
+        let ret = await package_handler.getPackagesVersionTarball(params, database);
 
         if (!ret.ok) {
           await common_handler.handleError(req, res, ret.content);
@@ -1327,7 +1327,7 @@ app.get("/api/users/:login/stars", genericLimit, async (req, res) => {
     login: query.login(req)
   };
 
-  let ret = await user_handler.getLoginStars(params);
+  let ret = await user_handler.getLoginStars(params, database);
 
   if (!ret.ok) {
     await common_handler.handleError(req, res, ret.content);
@@ -1430,7 +1430,7 @@ app.get("/api/users/:login", genericLimit, async (req, res) => {
     login: query.login(req)
   };
 
-  let ret = await user_handler.getUser(params);
+  let ret = await user_handler.getUser(params, database);
 
   if (!ret.ok) {
     await common_handler.handleError(req, res, ret.content);
@@ -1472,7 +1472,7 @@ app.get("/api/stars", authLimit, async (req, res) => {
     auth: query.auth(req)
   };
 
-  let ret = await star_handler.getStars(params);
+  let ret = await star_handler.getStars(params, database);
 
   if (!ret.ok) {
     await common_handler.handleError(req, res, ret.content);

--- a/src/main.js
+++ b/src/main.js
@@ -1095,7 +1095,19 @@ app.options(
  *  @Rdesc If the login does not exist, a 404 is returned.
  */
 app.get("/api/users/:login/stars", genericLimit, async (req, res) => {
-  await user_handler.getLoginStars(req, res);
+  const params = {
+    login: query.login(req)
+  };
+
+  let ret = await user_handler.getLoginStars(params);
+
+  if (!ret.ok) {
+    await common_handler.handleError(req, res, ret.content);
+    return;
+  }
+
+  res.status(200).json(ret.content);
+  logger.httpLog(req, res);
 });
 
 app.options("/api/users/:login/stars", genericLimit, async (req, res) => {
@@ -1135,7 +1147,24 @@ app.get("/api/users", authLimit, async (req, res) => {
   );
   res.header("Access-Control-Allow-Origin", "https://web.pulsar-edit.dev");
   res.header("Access-Control-Allow-Credentials", true);
-  await user_handler.getAuthUser(req, res);
+
+  const params = {
+    auth: query.auth(req)
+  };
+
+
+  let ret = await user_handler.getAuthUser(params);
+
+  if (!ret.ok) {
+    await common_handler.handleError(req, res, ret.content);
+    return;
+  }
+
+  // TODO: This was set within the function previously, needs to be determined if this is needed
+  res.set({"Access-Control-Allow-Credentials": true });
+
+  res.status(200).json(ret.content);
+  logger.httpLog(req, res);
 });
 
 app.options("/api/users", async (req, res) => {
@@ -1169,7 +1198,19 @@ app.options("/api/users", async (req, res) => {
  *   @Rtype application/json
  */
 app.get("/api/users/:login", genericLimit, async (req, res) => {
-  await user_handler.getUser(req, res);
+  const params = {
+    login: query.login(req)
+  };
+
+  let ret = await user_handler.getUser(params);
+
+  if (!ret.ok) {
+    await common_handler.handleError(req, res, ret.content);
+    return;
+  }
+
+  res.status(200).json(ret.content);
+  logger.httpLog(req, res);
 });
 
 app.options("/api/users/:login", genericLimit, async (req, res) => {
@@ -1234,7 +1275,14 @@ app.options("/api/stars", genericLimit, async (req, res) => {
  *   @Rdesc Atom update feed, following the format expected by Squirrel.
  */
 app.get("/api/updates", genericLimit, async (req, res) => {
-  await update_handler.getUpdates(req, res);
+  let ret = await update_handler.getUpdates();
+
+  if (!ret.ok) {
+    await common_handler.notSupported(req, res);
+    return;
+  }
+
+  // TODO: There is no else until this endpoint is implemented.
 });
 
 app.options("/api/updates", genericLimit, async (req, res) => {

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ const common_handler = require("./handlers/common_handler.js");
 const oauth_handler = require("./handlers/oauth_handler.js");
 const webhook = require("./webhook.js");
 const database = require("./database.js");
+const auth = require("./auth.js");
 const server_version = require("../package.json").version;
 const logger = require("./logger.js");
 const query = require("./query.js");
@@ -322,7 +323,7 @@ app.post("/api/:packType", authLimit, async (req, res, next) => {
         auth: query.auth(req)
       };
 
-      let ret = await package_handler.postPackages(params, database);
+      let ret = await package_handler.postPackages(params, database, auth);
 
       if (!ret.ok) {
         if (ret.type === "detailed") {
@@ -655,7 +656,7 @@ app.delete("/api/:packType/:packageName", authLimit, async (req, res, next) => {
         packageName: query.packageName(req)
       };
 
-      let ret = await package_handler.deletePackagesName(params, database);
+      let ret = await package_handler.deletePackagesName(params, database, auth);
 
       if (!ret.ok) {
         await common_handler.handleError(req, res, ret.content);
@@ -736,7 +737,7 @@ app.post(
           packageName: query.packageName(req)
         };
 
-        let ret = await package_handler.postPackagesStar(params, database);
+        let ret = await package_handler.postPackagesStar(params, database, auth);
 
         if (!ret.ok) {
           await common_handler.handleError(req, res, ret.content);
@@ -795,7 +796,7 @@ app.delete(
           packageName: query.packageName(req)
         };
 
-        let ret = await package_handler.deletePackagesStar(params, database);
+        let ret = await package_handler.deletePackagesStar(params, database, auth);
 
         if (!ret.ok) {
           await common_handler.handleError(req, res, ret.content);
@@ -953,7 +954,7 @@ app.post(
           packageName: query.packageName(req)
         };
 
-        let ret = await package_handler.postPackagesVersion(params, database);
+        let ret = await package_handler.postPackagesVersion(params, database, auth);
 
         if (!ret.ok) {
           if (ret.type === "detailed") {
@@ -1101,7 +1102,7 @@ app.delete(
           versionName: query.engine(req.params.versionName)
         };
 
-        let ret = await package_handler.deletePackageVersion(params, database);
+        let ret = await package_handler.deletePackageVersion(params, database, auth);
 
         if (!ret.ok) {
           await common_handler.handleError(req, res, ret.content);
@@ -1381,7 +1382,7 @@ app.get("/api/users", authLimit, async (req, res) => {
   };
 
 
-  let ret = await user_handler.getAuthUser(params);
+  let ret = await user_handler.getAuthUser(params, database, auth);
 
   if (!ret.ok) {
     await common_handler.handleError(req, res, ret.content);
@@ -1472,7 +1473,7 @@ app.get("/api/stars", authLimit, async (req, res) => {
     auth: query.auth(req)
   };
 
-  let ret = await star_handler.getStars(params, database);
+  let ret = await star_handler.getStars(params, database, auth);
 
   if (!ret.ok) {
     await common_handler.handleError(req, res, ret.content);

--- a/src/main.js
+++ b/src/main.js
@@ -235,7 +235,7 @@ app.get("/api/:packType", genericLimit, async (req, res, next) => {
       res.append("Link", ret.link);
       res.append("Query-Total", ret.total);
       res.append("Query-Limit", ret.limit);
-      
+
       res.status(200).json(ret.content);
       logger.httpLog(req, res);
 
@@ -423,7 +423,27 @@ app.get("/api/:packType/search", genericLimit, async (req, res, next) => {
       await package_handler.getPackagesSearch(req, res);
       break;
     case "themes":
-      await theme_handler.getThemesSearch(req, res);
+      const params = {
+        sort: query.sort(req),
+        page: query.page(req),
+        direction: query.dir(req),
+        query: query.query(req)
+      };
+
+      let ret = await theme_handler.getThemesSearch(params);
+
+      if (!ret.ok) {
+        await common_handler.handleError(req, res, ret.content);
+        return;
+      }
+
+      // Since we know this is a paginated endpoint we must handle that here
+      res.append("Link", ret.link);
+      res.append("Query-Total", ret.total);
+      res.append("Query-Limit", ret.limit);
+
+      res.status(200).json(ret.content);
+      logger.httpLog(req, res);
       break;
     default:
       next();

--- a/test/handlers/get_package_handler/getPackages.test.js
+++ b/test/handlers/get_package_handler/getPackages.test.js
@@ -47,4 +47,38 @@ describe("Handles unexpected database returns properly", () => {
     expect(res.content.length).toBe(0);
   });
 
+  test("Returns all proper pagination keys", async () => {
+    const res = await getPackageHandler.getPackages(
+      {
+        page: 1,
+        sort: "relevance",
+        direction: "desc",
+        serviceType: "",
+        service: "",
+        serviceVersion: ""
+      },
+      {
+        getSortedPackages: () => {
+          return {
+            ok: true,
+            content: [],
+            pagination: {
+              count: 0,
+              page: 1,
+              total: 1,
+              limit: 10
+            }
+          };
+        }
+      }
+    );
+
+    expect(res.ok).toBeTruthy();
+    expect(typeof res.link).toBe("string");
+    expect(res.link.includes("desc")).toBeTruthy();
+    expect(res.total).toBe(0);
+    expect(res.limit).toBe(10);
+
+  });
+
 });

--- a/test/handlers/get_package_handler/getPackages.test.js
+++ b/test/handlers/get_package_handler/getPackages.test.js
@@ -1,0 +1,50 @@
+const getPackageHandler = require("../../../src/handlers/get_package_handler.js");
+
+describe("Handles unexpected database returns properly", () => {
+
+  test("Database call fails", async () => {
+    const res = await getPackageHandler.getPackages({}, {
+      getSortedPackages: () => {
+        return {
+          ok: false,
+          content: "Fake error"
+        }
+      }
+    });
+
+    expect(res.ok).toBeFalsy();
+    expect(res.content.content).toBe("Fake error");
+  });
+
+  test("Database call returns an empty array", async () => {
+    const res = await getPackageHandler.getPackages(
+      {
+        page: 1,
+        sort: "relevance",
+        direction: "desc",
+        serviceType: "",
+        service: "",
+        serviceVersion: ""
+      },
+      {
+        getSortedPackages: () => {
+          return {
+            ok: true,
+            content: [],
+            pagination: {
+              count: 0,
+              page: 1,
+              total: 1,
+              limit: 10
+            }
+          };
+        }
+      }
+    );
+
+    expect(res.ok).toBeTruthy();
+    expect(Array.isArray(res.content)).toBeTruthy();
+    expect(res.content.length).toBe(0);
+  });
+
+});

--- a/test/handlers/post_package_handler/postPackages.test.js
+++ b/test/handlers/post_package_handler/postPackages.test.js
@@ -118,3 +118,29 @@ describe("Handles an Repository and package name appropriately", () => {
   });
 
 });
+
+describe("Properly returns failed ownership check", () => {
+
+  test("When VCS Returns an error", async () => {
+    const authPass = () => {
+      return { ok: true, content: { username: "fake" } };
+    };
+    const dbPackageNameAvailability = () => {
+      return { ok: true };
+    };
+    const ownership = () => {
+      return { ok: false, content: "Fake VCS error" };
+    };
+
+    const res = await postPackageHandler.postPackages(
+      { repository: "pulsar-edit/pulsar" },
+      { packageNameAvailability: dbPackageNameAvailability },
+      { verifyAuth: authPass },
+      { ownership: ownership }
+    );
+
+    expect(res.ok).toBeFalsy();
+    expect(res.content.content).toBe("Fake VCS error");
+  });
+
+});

--- a/test/handlers/post_package_handler/postPackages.test.js
+++ b/test/handlers/post_package_handler/postPackages.test.js
@@ -14,7 +14,8 @@ describe("Handles invalid auth", () => {
             content: "Fake auth failure"
           };
         }
-      }
+      },
+      {}
     );
 
     expect(res.ok).toBeFalsy();
@@ -31,7 +32,8 @@ describe("Handles an Repository and package name appropriately", () => {
       {},
       {
         verifyAuth: () => { return { ok: true, content: { username: "fake"} }; }
-      }
+      },
+      {}
     );
 
     expect(res.ok).toBeFalsy();
@@ -49,7 +51,8 @@ describe("Handles an Repository and package name appropriately", () => {
     const res = await postPackageHandler.postPackages(
       { repository: "just-a-long-string" },
       {},
-      { verifyAuth: authPass }
+      { verifyAuth: authPass },
+      {}
     );
 
     expect(res.ok).toBeFalsy();
@@ -65,7 +68,8 @@ describe("Handles an Repository and package name appropriately", () => {
     const res = await postPackageHandler.postPackages(
       { repository: "pulsar-edit/slot-pulsa" },
       {},
-      { verifyAuth: authPass }
+      { verifyAuth: authPass },
+      {}
     );
 
     expect(res.ok).toBeFalsy();
@@ -84,7 +88,8 @@ describe("Handles an Repository and package name appropriately", () => {
     const res = await postPackageHandler.postPackages(
       { repository: "pulsar-edit/pulsar" },
       { packageNameAvailability: dbPackageNameAvailability },
-      { verifyAuth: authPass }
+      { verifyAuth: authPass },
+      {}
     );
 
     expect(res.ok).toBeFalsy();
@@ -102,7 +107,8 @@ describe("Handles an Repository and package name appropriately", () => {
     const res = await postPackageHandler.postPackages(
       { repository: "pulsar-edit/pulsar" },
       { packageNameAvailability: dbPackageNameAvailability },
-      { verifyAuth: authPass }
+      { verifyAuth: authPass },
+      {}
     );
 
     expect(res.ok).toBeFalsy();

--- a/test/handlers/post_package_handler/postPackages.test.js
+++ b/test/handlers/post_package_handler/postPackages.test.js
@@ -1,0 +1,60 @@
+const postPackageHandler = require("../../../src/handlers/post_package_handler.js");
+
+describe("Handles invalid auth", () => {
+
+  test("When auth fails", async () => {
+    const res = await postPackageHandler.postPackages(
+      {},
+      {},
+      {
+        // This is the fake auth module
+        verifyAuth: () => {
+          return {
+            ok: false,
+            content: "Fake auth failure"
+          };
+        }
+      }
+    );
+
+    expect(res.ok).toBeFalsy();
+    expect(res.content.content).toBe("Fake auth failure");
+  });
+
+});
+
+describe("Handles an invalid Repository", () => {
+
+  test("When the repository is empty", async () => {
+    const res = await postPackageHandler.postPackages(
+      { repository: "" },
+      {},
+      {
+        verifyAuth: () => { return { ok: true, content: { username: "fake"} }; }
+      }
+    );
+
+    expect(res.ok).toBeFalsy();
+    expect(res.content.short).toBe("Bad Repo");
+  });
+
+  test("When the repository is invalid", async () => {
+    const authPass = () => {
+      return {
+        ok: true,
+        content: { username: "fake" }
+      }
+    };
+
+    const res = await postPackageHandler.postPackages(
+      { repository: "just-a-long-string" },
+      {},
+      { verifyAuth: authPass }
+    );
+
+    expect(res.ok).toBeFalsy();
+    expect(res.content.short).toBe("Bad Repo");
+
+  });
+
+});


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This PR mainly focuses on decoupling HTTP handling from the logic of the backend. This makes not only the backend easier to reason through, easier to contribute to (by the way of not having to know ExpressJS APIs or logic for everything), but also can greatly make testing even easier.

This is done, by again relying on ServerStatusObjects from the functions called by `main.js` instead of handling HTTP returns within functions.

This also means that to test these functions we can call then as normal functions and rely on the data returned. Rather than create mock ExpressJS `req` and `res` objects and inspect their data after the function to determine behavior, and also means we no longer have to call the endpoints via `supertest` to determine behavior.

Additionally, this PR put a focus on passing modules, rather than requiring them.
While this change is much less noticeable, the idea *again* is to be able to test much more easily. As mocks are messy, difficult to reason with, and require a bit of setup and teardown per usage, we can instead pass functions as needed and have much much greater control over the data supplied and consumed within these tests, much more easily than the same with mocks.

---

On passing as formal arguments rather than requiring, the basic idea should be that any module that deals with a codebase boundary (as defined by `ARCHITECTURE.md`, such as database calls, superagent calls, the VCS service, and auth service) should be passed instead of required. So that way instead of having to mock the module being required we can pass whatever we want, and craft any functions and data returns we prefer. This potentially means being able to directly return whatever data we want from database calls, rather than have to inject more and more test data into our test database. It also means much easier error checking as we can return purposefully failed database calls, which can never be reproduced honestly in our current testing strategy.

There was some thought given to instead of passing each module as a formal argument, we instead passed an object containing the modules required per function, e.g.:

```javascript
async function getPackages(params, mods) {
  await mods.db.getPackages();
}
```

But it was thought this could create an effect of having to many layers to each parameter, since already knowing what keys are available within the `params` object requires either:

1. Accurate parameter documentation within the JSDoc comment above the function
2. Reading the source code of `main.js` to determine exactly what is being passed

So to avoid doing this twice, and with something like modules, the tradeoff of having more modules didn't seem like to big of an issue.

Some documentation must be updated soon to describe the best practices here, since that can be the best way to ensure uniformity with how this is done. Such as passing the formal parameters in this exact order: `(params, database, auth)` rather than another.