### PR TITLE
Fix empty search pagination

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -1387,11 +1387,7 @@ async function simpleSearch(term, page, dir, sort, themes = false) {
       OFFSET ${offset};
     `;
 
-    if (command.count === 0) {
-      return { ok: false, content: "No packages found.", short: "Not Found" };
-    }
-
-    const resultCount = command[0].query_result_count;
+    const resultCount = command[0]?.query_result_count ?? 0;
     const quotient = Math.trunc(resultCount / limit);
     const remainder = resultCount % limit;
     const totalPages = quotient + (remainder > 0 ? 1 : 0);

--- a/src/handlers/get_package_handler.js
+++ b/src/handlers/get_package_handler.js
@@ -143,6 +143,9 @@ async function getPackagesSearch(params, db) {
       // Because getting not found from the search, means the users
       // search just had no matches, we will specially handle this to return
       // an empty array instead.
+      // TODO: Re-evaluate if this is needed. The empty result
+      // returning 'Not Found' has been resolved via the DB.
+      // But this check still might come in handy, so it'll be left in.
       return {
         ok: true,
         content: [],

--- a/test/database.integration.test.js
+++ b/test/database.integration.test.js
@@ -66,6 +66,38 @@ describe("getPackageByName", () => {
   });
 });
 
+describe("Get Sorted Packages", () => {
+  test("Should return good pagination when there are no results", async () => {
+    const obj = await database.getSortedPackages({
+      page: 1,
+      sort: "relevance",
+      service: "consumed",
+      serviceType: "does-not-exist",
+      direction: "desc"
+    });
+    expect(obj.ok).toBeTruthy();
+    expect(Array.isArray(obj.content)).toBeTruthy();
+    expect(obj.content.length).toBe(0);
+    expect(obj.pagination.count).toBe(0);
+    expect(obj.pagination.page).toBe(0);
+    expect(obj.pagination.total).toBe(0);
+  });
+});
+
+describe("Get Package Search", () => {
+  test("Should return good pagination when there are no results", async () => {
+    const obj = await database.simpleSearch(
+      "will-never-match-a-search", 1, "desc", "relevance"
+    );
+    expect(obj.ok).toBeTruthy();
+    expect(Array.isArray(obj.content)).toBeTruthy();
+    expect(obj.content.length).toBe(0);
+    expect(obj.pagination.count).toBe(0);
+    expect(obj.pagination.page).toBe(0);
+    expect(obj.pagination.total).toBe(0);
+  });
+});
+
 describe("Package Lifecycle Tests", () => {
   // Below are what we will call lifecycle tests.
   // That is tests that will test multiple actions against the same package,

--- a/test/handlers/get_package_handler/getPackages.test.js
+++ b/test/handlers/get_package_handler/getPackages.test.js
@@ -82,3 +82,39 @@ describe("Handles unexpected database returns properly", () => {
     expect(res.limit).toBe(10);
   });
 });
+
+describe("Get Packages returns proper Pagination", () => {
+
+  test("When there are no results", async () => {
+    const res = await getPackageHandler.getPackages(
+      {
+        page: 1,
+        sort: "relevance",
+        direction: "desc",
+        serviceType: "consumed",
+        service: "does-not-exist"
+      },
+      {
+        getSortedPackages: () => {
+          return {
+            ok: true,
+            content: [],
+            pagination: {
+              count: 0,
+              page: 0,
+              total: 0,
+              limit: 30
+            }
+          };
+        },
+      }
+    );
+
+    expect(res.ok).toBeTruthy();
+    expect(Array.isArray(res.content)).toBeTruthy();
+    expect(res.content.length).toBe(0);
+    expect(res.limit).toBe(30);
+    expect(res.total).toBe(0);
+  });
+
+});

--- a/test/handlers/get_package_handler/getPackagesSearch.test.js
+++ b/test/handlers/get_package_handler/getPackagesSearch.test.js
@@ -1,0 +1,36 @@
+const getPackageHandler = require("../../../src/handlers/get_package_handler.js");
+
+describe("Searching Packages Returns Pagination properly", () => {
+
+  test("When there are no results for a search", async () => {
+    const res = await getPackageHandler.getPackagesSearch(
+      {
+        page: 1,
+        sort: "relevance",
+        direction: "desc",
+        query: "word"
+      },
+      {
+        simpleSearch: () => {
+          return {
+            ok: true,
+            content: [],
+            pagination: {
+              count: 0,
+              page: 0,
+              total: 0,
+              limit: 30
+            }
+          };
+        },
+      }
+    );
+
+    expect(res.ok).toBeTruthy();
+    expect(Array.isArray(res.content)).toBeTruthy();
+    expect(res.content.length).toBe(0);
+    expect(res.limit).toBe(30);
+    expect(res.total).toBe(0);
+  });
+
+});


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This PR mainly removes a now outdated check for an empty search return, which following the fail early principals in this repo, would cause it to fail before building the pagination data.

Which resulted in invalid pagination data being sent to clients.

Following the behavior of `get_package_handler.js ::getPackages()` that check has been removed.

Additionally, the safety around collecting the result count, again following suit with what we see in `getSortedPackages()` we ensure to fail to `0` when a DB query doesn't return an item count.

Beyond that additional tests have been added to gain coverage on this aspect, and ensure against regressions.

Resolves [`pulsar-edit/package-frontend#104`](https://github.com/pulsar-edit/package-frontend/issues/104)
