### PR TITLE
Remove PPI from Admin Actions Log

### DIFF
--- a/docs/reference/Admin_Actions.md
+++ b/docs/reference/Admin_Actions.md
@@ -272,8 +272,8 @@ The below packages were never repackaged due to this:
 * aml-workbench
 * an-color-picker
 * ancient-syntax
-* andrew-brovan-amazingly-non-dysfunctional-package
-* andrew-brovan-awesome-word-count-package
+* <REDACTED>-amazingly-non-dysfunctional-package (Note PPI has been removed and replaced with 'REDACTED' for this package.)
+* <REDACTED>-awesome-word-count-package (Note PPI has been removed and replaced with 'REDACTED' for this package.)
 * angular2-webpack-component-generator
 * animate-css
 * anuny-dark-syntax


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [ ] Have you ran tests against this code?
* [X] This PR contains zero code changes.

### Description of the Change

At the request of the unverified owner of a previous package, their PPI has been removed from the Admin Actions, as PPI was included within the title of a package.

The offending PPI has been replaced with `<REDACTED>`
