### PR TITLE
Add new `/api/owners/:ownerName` Endpoint

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,9 +23,9 @@ const config = {
         "<rootDir>/tests/helpers/global.setup.jest.js"
       ],
       testMatch: [
-        "<rootDir>/tests/database/**.test.js",
         "<rootDir>/tests/http/**.test.js",
-        "<rootDir>/tests/vcs/**.test.js"
+        "<rootDir>/tests/vcs/**.test.js",
+        "<rootDir>/tests/database/**.test.js",
       ]
     },
     {

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,9 +23,9 @@ const config = {
         "<rootDir>/tests/helpers/global.setup.jest.js"
       ],
       testMatch: [
-        "<rootDir>/tests/http/**.test.js",
-        "<rootDir>/tests/vcs/**.test.js",
         "<rootDir>/tests/database/**.test.js",
+        "<rootDir>/tests/http/**.test.js",
+        "<rootDir>/tests/vcs/**.test.js"
       ]
     },
     {

--- a/src/controllers/endpoints.js
+++ b/src/controllers/endpoints.js
@@ -32,4 +32,5 @@ module.exports = [
   require("./postPackagesPackageNameStar.js"),
   require("./getUsersLoginStars.js"),
   require("./getUsersLogin.js"),
+  require("./getOwnersOwnerName.js"),
 ];

--- a/src/controllers/getOwnersOwnerName.js
+++ b/src/controllers/getOwnersOwnerName.js
@@ -28,7 +28,7 @@ module.exports = {
   },
 
   async logic(params, context) {
-    const packages = await context.database.getSortedPackages(params, true);
+    const packages = await context.database.getSortedPackages(params);
 
     if (!packages.ok) {
       const sso = new context.sso();

--- a/src/controllers/getOwnersOwnerName.js
+++ b/src/controllers/getOwnersOwnerName.js
@@ -1,0 +1,54 @@
+module.exports = {
+  docs: {
+    summary: "List all packages published under a single owner.",
+    responses: {
+      200: {
+        description: "A paginated response of packages.",
+        content: {
+          "application/json": "$packageObjectShortArray"
+        }
+      }
+    }
+  },
+  endpoint: {
+    method: "GET",
+    paths: [ "/api/owners/:ownerName" ],
+    rateLimit: "generic",
+    successStatus: 200,
+    options: {
+      Allow: "GET",
+      "X-Content-Type-Options": "nosniff"
+    }
+  },
+  params: {
+    page: (context, req) => { return context.query.page(req); },
+    sort: (context, req) => { return context.query.sort(req); },
+    direction: (context, req) => { return context.query.dir(req); },
+    owner: (context, req) => { return context.query.owner(req); }
+  },
+
+  async logic(params, context) {
+    const packages = await context.database.getSortedPackages(params, true);
+
+    if (!packages.ok) {
+      const sso = new context.sso();
+
+      return sso.notOk().addContent(packages).addCalls("db.getSortedPackages", packages);
+    }
+
+    const packObjShort = await context.utils.constructPackageObjectShort(
+      packages.content
+    );
+
+    const packArray = Array.isArray(packObjShort) ? packObjShort : [ packObjShort ];
+
+    const ssoP = new context.ssoPaginate();
+
+    ssoP.resultCount = packages.pagination.count;
+    ssoP.totalPages = packages.pagination.total;
+    ssoP.limit = packages.pagination.limit;
+    ssoP.buildLink(`${context.config.server_url}/api/owners/${params.owner}`, packages.pagination.page, params);
+
+    return ssoP.isOk().addContent(packArray);
+  }
+};

--- a/src/query.js
+++ b/src/query.js
@@ -298,13 +298,17 @@ function service(req) {
  *   nonexistent. Returns the user name otherwise.
  */
 function owner (req) {
-  if (!stringValidation(req.query.owner)) {
+  // Owner accepts the owner as an argument for things like search,
+  // as well as a path, for the endpoint `/api/owners/:ownerName`
+  let prov = req.query.owner ?? req.params.ownerName;
+
+  if (!stringValidation(prov)) {
     return false;
   }
-  if (req.query.owner.length === 0) {
+  if (prov.length === 0) {
     return false;
   }
-  return req.query.owner;
+  return prov;
 }
 
 /**

--- a/src/query.js
+++ b/src/query.js
@@ -300,7 +300,7 @@ function service(req) {
 function owner (req) {
   // Owner accepts the owner as an argument for things like search,
   // as well as a path, for the endpoint `/api/owners/:ownerName`
-  let prov = req.query.owner ?? req.params.ownerName;
+  let prov = req.query.owner ?? req.params?.ownerName ?? null;
 
   if (!stringValidation(prov)) {
     return false;

--- a/tests/http/getOwnersOwnerName.test.js
+++ b/tests/http/getOwnersOwnerName.test.js
@@ -16,7 +16,10 @@ describe("Behaves as expected", () => {
 
   test("Returns empty array with no matching results", async () => {
     const sso = await endpoint.logic({
-      owner: "i-dont-exist"
+      owner: "i-dont-exist",
+      page: "1",
+      sort: "downloads",
+      direction: "desc"
     }, context);
 
     expect(sso.ok).toBe(false);

--- a/tests/http/getOwnersOwnerName.test.js
+++ b/tests/http/getOwnersOwnerName.test.js
@@ -1,0 +1,65 @@
+const endpoint = require("../../src/controllers/getOwnerOwnerName.js");
+const database = require("../../src/database.js");
+const context = require("../../src/context.js");
+
+describe("Behaves as expected", () => {
+  test("Calls the correct function", async () => {
+    const localContext = context;
+    const spy = jest.spyOn(localContext.database, "getSortedPackages");
+
+    await endpoint.logic({}, localContext);
+
+    expect(spy).toBeCalledTimes(1);
+
+    spy.mockClear();
+  });
+
+  test("Returns empty array with no matching results", async () => {
+    const sso = await endpoint.logic({
+      owner: "i-dont-exist"
+    }, context);
+
+    expect(sso.ok).toBe(false);
+    expect(sso.content).toBeArray();
+    expect(sso.content.length).toBe(0);
+  });
+
+  test("Returns package with matching owner entry", async () => {
+    await database.insertNewPackage({
+      name: "get-owner-test",
+      respository: {
+        url: "https://github.com/pulsar-edit/pulsar",
+        type: "git"
+      },
+      owner: "pulsar-edit",
+      creation_method: "Test Package",
+      releases: {
+        latest: "1.0.0"
+      },
+      readme: "This is a readme!",
+      metdata: {
+        name: "get-owner-test"
+      },
+      versions: {
+        "1.0.0": {
+          dist: {
+            tarball: "download-url",
+            sha: "1234"
+          },
+          name: "get-owner-test"
+        }
+      }
+    });
+
+    const sso = await endpoint.logic({
+      owner: "pulsar-edit"
+    }, context);
+
+    expect(sso.ok).toBe(true);
+    expect(sso.content[0].name).toBe("get-owner-test");
+    expect(sso.content).toBeArray();
+    expect(sso.content.length).toBe(0);
+    expect(sso).toMatchEndpointSuccessObject(endpoint);
+    await database.removePackageByName("get-owner-test", true);
+  });
+});

--- a/tests/http/getOwnersOwnerName.test.js
+++ b/tests/http/getOwnersOwnerName.test.js
@@ -60,7 +60,7 @@ describe("Behaves as expected", () => {
       sort: "downloads",
       direction: "desc"
     }, context);
-
+console.log(sso);
     expect(sso.ok).toBe(true);
     expect(sso.content[0].name).toBe("get-owner-test");
     expect(sso.content).toBeArray();

--- a/tests/http/getOwnersOwnerName.test.js
+++ b/tests/http/getOwnersOwnerName.test.js
@@ -22,7 +22,7 @@ describe("Behaves as expected", () => {
       direction: "desc"
     }, context);
 
-    expect(sso.ok).toBe(false);
+    expect(sso.ok).toBe(true);
     expect(sso.content).toBeArray();
     expect(sso.content.length).toBe(0);
   });
@@ -55,7 +55,10 @@ describe("Behaves as expected", () => {
     });
 
     const sso = await endpoint.logic({
-      owner: "pulsar-edit"
+      owner: "pulsar-edit",
+      page: "1",
+      sort: "downloads",
+      direction: "desc"
     }, context);
 
     expect(sso.ok).toBe(true);

--- a/tests/http/getOwnersOwnerName.test.js
+++ b/tests/http/getOwnersOwnerName.test.js
@@ -30,7 +30,7 @@ describe("Behaves as expected", () => {
   test("Returns package with matching owner entry", async () => {
     await database.insertNewPackage({
       name: "get-owner-test",
-      respository: {
+      repository: {
         url: "https://github.com/pulsar-edit/pulsar",
         type: "git"
       },
@@ -40,7 +40,7 @@ describe("Behaves as expected", () => {
         latest: "1.0.0"
       },
       readme: "This is a readme!",
-      metdata: {
+      metadata: {
         name: "get-owner-test"
       },
       versions: {
@@ -56,7 +56,7 @@ describe("Behaves as expected", () => {
 
     const sso = await endpoint.logic({
       owner: "pulsar-edit",
-      page: "1",
+      page: 1,
       sort: "downloads",
       direction: "desc"
     }, context);
@@ -64,8 +64,9 @@ describe("Behaves as expected", () => {
     expect(sso.ok).toBe(true);
     expect(sso.content[0].name).toBe("get-owner-test");
     expect(sso.content).toBeArray();
-    expect(sso.content.length).toBe(0);
+    expect(sso.content.length).toBe(1);
     expect(sso).toMatchEndpointSuccessObject(endpoint);
+
     await database.removePackageByName("get-owner-test", true);
   });
 });

--- a/tests/http/getOwnersOwnerName.test.js
+++ b/tests/http/getOwnersOwnerName.test.js
@@ -1,4 +1,4 @@
-const endpoint = require("../../src/controllers/getOwnerOwnerName.js");
+const endpoint = require("../../src/controllers/getOwnersOwnerName.js");
 const database = require("../../src/database.js");
 const context = require("../../src/context.js");
 

--- a/tests/http/getOwnersOwnerName.test.js
+++ b/tests/http/getOwnersOwnerName.test.js
@@ -31,10 +31,10 @@ describe("Behaves as expected", () => {
     await database.insertNewPackage({
       name: "get-owner-test",
       repository: {
-        url: "https://github.com/pulsar-edit/pulsar",
+        url: "https://github.com/pulsar-cooperative/get-owner-test",
         type: "git"
       },
-      owner: "pulsar-edit",
+      owner: "pulsar-cooperative",
       creation_method: "Test Package",
       releases: {
         latest: "1.0.0"
@@ -55,12 +55,12 @@ describe("Behaves as expected", () => {
     });
 
     const sso = await endpoint.logic({
-      owner: "pulsar-edit",
+      owner: "pulsar-cooperative",
       page: 1,
       sort: "downloads",
       direction: "desc"
     }, context);
-console.log(sso);
+
     expect(sso.ok).toBe(true);
     expect(sso.content[0].name).toBe("get-owner-test");
     expect(sso.content).toBeArray();


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This PR adds a new `/api/owners/:ownerName` endpoint, allowing this to be the dedicated filter to discovering other packages published by a particular owner.

It's worth mentioning that the query parameter of `owner` on `/api/packages` will still work, and it's behavior is totally unmodified from here.
