### PR TITLE
Fix inability to combine different criteria in package search

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "node ./src/server.js",
     "test": "cross-env NODE_ENV=test PULSAR_STATUS=dev jest --selectProjects Integration-Tests Unit-Tests --runInBand",
     "test:unit": "cross-env NODE_ENV=test PULSAR_STATUS=dev jest --selectProjects Unit-Tests",
-    "test:integration": "cross-env NODE_ENV=test PULSAR_STATUS=dev jest --selectProjects Integration-Tests",
+    "test:integration": "cross-env NODE_ENV=test PULSAR_STATUS=dev jest --selectProjects Integration-Tests --runInBand",
     "start:dev": "cross-env PULSAR_STATUS=dev node ./src/dev_server.js",
     "lint": "prettier --check -u -w .",
     "complex": "cr --newmi --config .complexrc .",

--- a/src/controllers/getPackages.js
+++ b/src/controllers/getPackages.js
@@ -4,7 +4,15 @@
 
 module.exports = {
   docs: {
-    summary: "List all packages"
+    summary: "List all packages",
+    responses: {
+      200: {
+        description: "An array of packages.",
+        content: {
+          "application/json": "$packageObjectShortArray"
+        }
+      }
+    }
   },
   endpoint: {
     method: "GET",

--- a/src/controllers/getPackagesFeatured.js
+++ b/src/controllers/getPackagesFeatured.js
@@ -7,7 +7,7 @@ module.exports = {
     summary: "Returns all featured packages. Previously undocumented endpoint.",
     responses: {
       200: {
-        description: "An array of features packages.",
+        description: "An array of featured packages.",
         content: {
           "application/json": "$packageObjectShortArray"
         }

--- a/tests/http/getPackages.test.js
+++ b/tests/http/getPackages.test.js
@@ -1,0 +1,165 @@
+const endpoint = require("../../src/controllers/getPackages.js");
+const database = require("../../src/database.js");
+const context = require("../../src/context.js");
+
+describe("Behaves as expected", () => {
+
+  beforeAll(async () => {
+    await database.insertNewPackage({
+      name: "get-packages-test",
+      repository: {
+        url: "https://github.com/unique_user/package-backend",
+        type: "git"
+      },
+      owner: "unique_user",
+      creation_method: "Test Package",
+      releases: {
+        latest: "1.1.0"
+      },
+      readme: "This is a readme!",
+      metadata: {
+        name: "get-packages-test",
+        "providedServices": {
+          "refactor": {
+            "versions": {
+              "0.0.1": "provideRefactor"
+            }
+          }
+        }
+      },
+      versions: {
+        "1.1.0": {
+          dist: {
+            tarball: "download-url",
+            sha: "1234"
+          },
+          name: "get-packages-test",
+          "providedServices": {
+            "refactor": {
+              "versions": {
+                "0.0.1": "provideRefactor"
+              }
+            }
+          }
+        },
+        "1.0.0": {
+          dist: {
+            tarball: "download-url",
+            sha: "1234"
+          },
+          name: "get-packages-test",
+          "providedServices": {
+            "refactor": {
+              "versions": {
+                "0.0.1": "provideRefactor"
+              }
+            }
+          }
+        }
+      }
+    });
+
+    await database.insertNewPackage({
+      name: "calculator-light-ui",
+      repository: {
+        url: "https://github.com/savetheclocktower/calculator-light-ui",
+        type: "git"
+      },
+      owner: "savetheclocktower",
+      creation_method: "Test Package",
+      releases: {
+        latest: "9.0.0"
+      },
+      readme: "This is a second readme!",
+      metadata: {
+        name: "get-packages-test",
+        "providedServices": {
+          "another": {
+            "versions": {
+              "0.1.1": "provideanother"
+            }
+          }
+        }
+      },
+      versions: {
+        "9.0.0": {
+          dist: {
+            tarball: "download-url",
+            sha: "5678"
+          },
+          name: "get-packages-test",
+          "providedServices": {
+            "another": {
+              "versions": {
+                "0.1.1": "provideanother"
+              }
+            }
+          }
+        }
+      }
+    });
+  });
+
+  afterAll(async () => {
+    await database.removePackageByName("get-packages-test", true);
+    await database.removePackageByName("calculator-light-ui", true);
+  });
+
+  test("Allows filtering by owner field", async () => {
+    let sso = await endpoint.logic({
+      engine: false,
+      owner: "unique_user",
+      page: 1,
+      sort: 'downloads',
+      direction: 'desc',
+      serviceVersion: false,
+      fileExtension: false
+    }, context);
+
+    expect(sso.ok).toBe(true);
+    expect(sso.content.length).toBe(1);
+    expect(sso.content[0].name).toBe("get-packages-test");
+    expect(sso.content[0].owner).toBe("unique_user");
+    expect(sso).toMatchEndpointSuccessObject(endpoint);
+  });
+
+  test("Allows filtering by services field", async () => {
+    let sso = await endpoint.logic({
+      engine: false,
+      service: "refactor",
+      serviceType: "providedServices",
+      page: 1,
+      sort: 'downloads',
+      direction: 'desc',
+      serviceVersion: false,
+      fileExtension: false
+    }, context);
+
+    expect(sso.ok).toBe(true);
+    expect(sso.content.length).toBe(1);
+    expect(sso.content[0].name).toBe("get-packages-test");
+    expect(sso.content[0].owner).toBe("unique_user");
+    expect(sso).toMatchEndpointSuccessObject(endpoint);
+  });
+
+  test("Allows filtering by both owner and services", async () => {
+    let sso = await endpoint.logic({
+      engine: false,
+      owner: "unique_user",
+      service: "refactor",
+      serviceType: "providedServices",
+      page: 1,
+      sort: 'downloads',
+      direction: 'desc',
+      serviceVersion: false,
+      fileExtension: false
+    }, context);
+
+    expect(sso.ok).toBe(true);
+    expect(sso.content.length).toBe(1);
+    expect(sso.content[0].name).toBe("get-packages-test");
+    expect(sso.content[0].owner).toBe("unique_user");
+    expect(sso).toMatchEndpointSuccessObject(endpoint);
+  });
+
+});

--- a/tests/http/getThemesFeatured.test.js
+++ b/tests/http/getThemesFeatured.test.js
@@ -26,7 +26,7 @@ describe("Behaves as expected", () => {
       // We know a currently featured package is 'atom-material-ui'
       name: "atom-material-ui",
       repository: {
-        url: "https://github.com/confused-Techie/package-backend",
+        url: "https://github.com/confused-Techie/atom-material-ui",
         type: "git"
       },
       owner: "confused-Techie",

--- a/tests/http/getThemesSearch.test.js
+++ b/tests/http/getThemesSearch.test.js
@@ -31,7 +31,7 @@ describe("Behaves as expected", () => {
     await database.insertNewPackage({
       name: "atom-material-syntax",
       repository: {
-        url: "https://github.com/confused-Techie/package-backend",
+        url: "https://github.com/confused-Techie/atom-material-syntax",
         type: "git"
       },
       owner: "confused-Techie",


### PR DESCRIPTION
### Requirements 

* [ ] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

Here's what happens if you try to filter by both package ownership _and_ service providing/consuming:

https://web.pulsar-edit.dev/packages?owner=savetheclocktower&serviceType=consumed&service=refactor

It's because of how the various clauses are structured in `getSortedPackages`. We don't plan for the possibility of more than one clause at the same time.

The fix was simple enough — once I figured out how to compose the various `WHERE` clauses — but testing it was a nightmare, ultimately because of the fact that Jest runs tests in parallel. I've added the `--runInBand` parameter to the `test:integration` task because without it I was getting flaky test outcomes. When the tests are run in parallel, various temporary database records might be commingling with others, and that causes some tests to fail _sometimes_.