### PR TITLE
Add `owner` to build packageObject output

### DIFF
--- a/src/PackageObject.js
+++ b/src/PackageObject.js
@@ -207,6 +207,7 @@ class PackageObject {
     // And should be considered our master reference for the Package Object Short Data Structure
     let obj = {
       name: this.name,
+      owner: this.owner,
       repository: this.repository,
       downloads: this.downloads,
       stargazers_count: this.stargazers_count,
@@ -233,6 +234,7 @@ class PackageObject {
     // Should be considered the master Package Object Full data structure
     let obj = {
       name: this.name,
+      owner: this.owner,
       repository: this.repository,
       downloads: this.downloads,
       stargazers_count: this.stargazers_count,


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [ ] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This PR adds the `owner` value to the built `PackageObject` output
