### PR TITLE
Check name availability via name within `package.json`

### DIFF
--- a/src/controllers/postPackages.js
+++ b/src/controllers/postPackages.js
@@ -150,7 +150,7 @@ module.exports = {
       // not being available at this name
       const sso = new context.sso();
 
-      return sso.noOk().addShort("package_exists")
+      return sso.notOk().addShort("package_exists")
                        .addCalls("auth.verifyAuth", user)
                        .addCalls("vcs.ownership", gitowner)
                        .addCalls("vcs.newPackageData", newPack)

--- a/tests/http/postPackages.test.js
+++ b/tests/http/postPackages.test.js
@@ -82,38 +82,74 @@ describe("POST /api/packages Behaves as expected", () => {
         }
       };
     };
+    localContext.vcs.ownership = () => {
+      return {
+        ok: true,
+        content: "admin"
+      };
+    };
+    localContext.vcs.newPackageData = () => {
+      return {
+        ok: true,
+        content: {
+          name: "post-pkg-test-pkg-exists",
+          repository: {
+            url: "https://github.com/confused-Techie/post-pkg-test-pkg-exists",
+            type: "git"
+          },
+          owner: 'confused-Techie',
+          downloads: 0,
+          stargazers_count: 0,
+          creation_method: "Test Package",
+          releases: {
+            latest: "1.0.0"
+          },
+          readme: "This is a readme!",
+          metadata: { name: "post-pkg-test-pkg-exists" },
+          versions: {
+            "1.0.0": {
+              dist: {
+                tarball: "download-url",
+                sha: "1234"
+              },
+              name: "post-pkg-test-pkg-exists"
+            }
+          }
+        }
+      };
+    };
 
     await database.insertNewPackage({
-      name: "post-packages-test-package",
+      name: "post-pkg-test-pkg-exists",
       repository: {
-        url: "https://github.com/confused-Techie/package-backend",
+        url: "https://github.com/confused-Techie/post-pkg-test-pkg-exists",
         type: "git"
       },
       creation_method: "Test Package",
       owner: 'confused-Techie',
       releases: { latest: "1.1.0" },
       readme: "This is a readme!",
-      metadata: { name: "post-packages-test-package" },
+      metadata: { name: "post-pkg-test-pkg-exists" },
       versions: {
         "1.1.0": {
           dist: {
             tarball: "download-url",
             sha: "1234"
           },
-          name: "post-packages-test-package"
+          name: "post-pkg-test-pkg-exists"
         }
       }
     });
 
     const sso = await endpoint.logic({
-      repository: "confused-Techie/post-packages-test-package",
+      repository: "confused-Techie/post-pkg-test-pkg-exists",
       auth: "valid-token"
     }, localContext);
 
     expect(sso.ok).toBe(false);
     expect(sso.short).toBe("package_exists");
 
-    await database.removePackageByName("post-packages-test-package", true);
+    await database.removePackageByName("post-pkg-test-pkg-exists", true);
   });
 
   test("Successfully publishes a new package", async () => {
@@ -180,7 +216,7 @@ describe("POST /api/packages Behaves as expected", () => {
       repository: "confused-Techie/post-pkg-test-pkg-name",
       auth: "valid-token"
     }, localContext);
-
+    
     expect(sso.ok).toBe(true);
     expect(sso.content.name).toBe("post-pkg-test-pkg-name");
     expect(sso.content.releases.latest).toBe("1.0.0");


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [ ] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

Previously, the backend would use the name of the repository for the initial name availability check, as well as would use this later on when checking that publication was successful.

But the repo name is under no obligation to match the name of the package, and in the cases where it doesn't this logic quickly breaks down, to not properly determining if the actual package name is available, as well as will fail on checking if the package was successfully published
