### PR TITLE
Add filter support to `/api/packages/search`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start:dev": "cross-env PULSAR_STATUS=dev node ./src/dev_server.js",
     "lint": "prettier --check -u -w .",
     "complex": "cr --newmi --config .complexrc .",
-    "js-docs": "jsdoc2md -c ./jsdoc.conf.js ./src/*.js ./src/handlers/*.js ./docs/resources/jsdoc_typedef.js > ./docs/reference/Source_Documentation.md",
+    "js-docs": "jsdoc2md -c ./jsdoc.conf.js ./src/*.js ./src/controllers/*.js ./src/query_parameters/*.js ./docs/resources/jsdoc_typedef.js > ./docs/reference/Source_Documentation.md",
     "contributors:add": "all-contributors add",
     "migrations": "pg-migrations apply --directory ./scripts/migrations",
     "ignore": "compactignore",

--- a/src/controllers/getPackagesSearch.js
+++ b/src/controllers/getPackagesSearch.js
@@ -4,7 +4,15 @@
 
 module.exports = {
   docs: {
-    summary: "Searches all packages."
+    summary: "Searches all packages.",
+    responses: {
+      200: {
+        description: "Any array of packages.",
+        content: {
+          "application/json": "$packageObjectShortArray"
+        }
+      }
+    }
   },
   endpoint: {
     method: "GET",
@@ -20,7 +28,8 @@ module.exports = {
     sort: (context, req) => { return context.query.sort(req); },
     page: (context, req) => { return context.query.page(req); },
     direction: (context, req) => { return context.query.direction(req); },
-    query: (context, req) => { return context.query.query(req); }
+    query: (context, req) => { return context.query.query(req); },
+    filter: (context, req) => { return context.query.filter(req); }
   },
 
   /**
@@ -43,9 +52,9 @@ module.exports = {
       params.query,
       params.page,
       params.direction,
-      params.sort
+      params.sort,
+      (params.filter === "theme")
     );
-
 
     if (!packs.ok) {
       if (packs.short === "not_found") {

--- a/src/query_parameters/filter.js
+++ b/src/query_parameters/filter.js
@@ -1,0 +1,34 @@
+module.exports = {
+  schema: {
+    name: "filter",
+    in: "query",
+    schema: {
+      type: "string",
+      enum: [
+        "package",
+        "theme"
+      ],
+      default: "pacakge"
+    },
+    required: false,
+    allowEmptyValue: false,
+    example: "package",
+    description: "Deprecated method to display packages or themes. Use `/api/themes/search` or `/api/packages/search` instead."
+  },
+  logic: (req) => {
+    const def = "package";
+    const valid = [ "theme", "package" ];
+
+    const prov = req.query.filter;
+
+    if (typeof prov !== "string") {
+      return def;
+    }
+
+    if (!valid.includes(prov)) {
+      return def;
+    }
+
+    return prov;
+  }
+};

--- a/src/query_parameters/index.js
+++ b/src/query_parameters/index.js
@@ -9,6 +9,7 @@ const auth = require("./auth.js");
 const direction = require("./direction.js");
 const engine = require("./engine.js");
 const fileExtension = require("./fileExtension.js");
+const filter = require("./filter.js");
 const login = require("./login.js");
 const owner = require("./owner.js");
 const packageName = require("./packageName.js");
@@ -29,6 +30,7 @@ module.exports = {
     direction: direction.logic,
     engine: engine.logic,
     fileExtension: fileExtension.logic,
+    filter: filter.logic,
     login: login.logic,
     owner: owner.logic,
     packageName: packageName.logic,
@@ -48,6 +50,7 @@ module.exports = {
     direction: direction.schema,
     engine: engine.schema,
     fileExtension: fileExtension.schema,
+    filter: filter.schema,
     login: login.schema,
     owner: owner.schema,
     packageName: packageName.schema,

--- a/tests/http/getPackagesSearch.test.js
+++ b/tests/http/getPackagesSearch.test.js
@@ -1,0 +1,98 @@
+const endpoint = require("../../src/controllers/getPackagesSearch.js");
+const database = require("../../src/database.js");
+const context = require("../../src/context.js");
+
+describe("Behaves as expected", () => {
+
+  beforeAll(async () => {
+    await database.insertNewPackage({
+      name: "get-packages-search-theme-test",
+      repository: {
+        url: "https://github.com/getPackagesSearch/get-packages-search-theme-test",
+        type: "git"
+      },
+      owner: "getPackagesSearch",
+      creation_method: "Test Package",
+      releases: {
+        latest: "1.0.0"
+      },
+      readme: "This is a readme!",
+      metadata: {
+        name: "get-packages-search-theme-test",
+        theme: "syntax"
+      },
+      versions: {
+        "1.0.0": {
+          dist: {
+            tarball: "download-url",
+            sha: "1234"
+          },
+          name: "get-packages-search-theme-test"
+        }
+      }
+    });
+
+    await database.insertNewPackage({
+      name: "get-packages-search-test",
+      repository: {
+        url: "https://github.com/getPackagesSearch/get-packages-search-test",
+        type: "git"
+      },
+      owner: "getPackagesSearch",
+      creation_method: "Test Package",
+      releases: {
+        latest: "1.0.0"
+      },
+      readme: "This is a readme!",
+      metadata: {
+        name: "get-packages-search-test"
+      },
+      versions: {
+        "1.0.0": {
+          dist: {
+            tarball: "download-url",
+            sha: "1234"
+          },
+          name: "get-packages-search-test"
+        }
+      }
+    });
+
+  });
+
+  afterAll(async () => {
+    await database.removePackageByName("get-packages-search-theme-test");
+    await database.removePackageByName("get-packages-search-test");
+  });
+
+  test("Successfully searches", async () => {
+    let sso = await endpoint.logic({
+      sort: "downloads",
+      page: 1,
+      direction: "desc",
+      query: "get packages search",
+      filter: "package"
+    }, context);
+
+    expect(sso.ok).toBe(true);
+    expect(sso.content.length).toBe(2);
+    expect(sso.content[0].name).toBe("get-packages-search-test");
+    expect(sso.content[1].name).toBe("get-packages-search-theme-test");
+    expect(sso).toMatchEndpointSuccessObject(endpoint);
+  });
+
+  test("Successfully searches and filters by theme", async () => {
+    let sso = await endpoint.logic({
+      sort: "downloads",
+      page: 1,
+      direction: "desc",
+      query: "get packages search",
+      filter: "theme"
+    }, context);
+
+    expect(sso.ok).toBe(true);
+    expect(sso.content.length).toBe(1);
+    expect(sso.content[0].name).toBe("get-packages-search-theme-test");
+    expect(sso).toMatchEndpointSuccessObject(endpoint);
+  });
+});


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

Closes #204 

This PR adds `filter` support. Which is an undocumented, previously unknown query parameter that allows filtering of packages and themes on the endpoint `/api/packages/search`.

While this behavior is already mirrored on the `/api/themes/search`, as we can see on #204 it appears that `ppm` has been using the until now unknown query parameter `filter` instead. This PR then allows `ppm` to begin working as soon as it is merged, without any necessary changes to `pulsar`.