### PR TITLE
Fix typo in busy-signal github repo

### DIFF
--- a/docs/reference/Admin_Actions.md
+++ b/docs/reference/Admin_Actions.md
@@ -114,7 +114,7 @@ To reflect this status, `busy-signal` will additionally receive the [`Outdated`]
 To install `busy-signal` for end users, it's recommended to run the following command:
 
 ```shell
-pulsar -p install https://github.com/steelbreain/busy-signal
+pulsar -p install https://github.com/steelbrain/busy-signal
 ```
 
 ## 2023 - April 22


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [ ] Have you ran tests against this code?
* [x] This PR contains zero code changes.

### Description of the Change

This commit fixes a small typo that prevents the command to install busy-signal from running.
