### PR TITLE
Make Searches Filterable

### DIFF
--- a/src/controllers/getPackagesSearch.js
+++ b/src/controllers/getPackagesSearch.js
@@ -40,6 +40,21 @@ module.exports = {
     filter: (context, req) => {
       return context.query.filter(req);
     },
+    fileExtension: (context, req) => {
+      return context.query.fileExtension(req);
+    },
+    serviceType: (context, req) => {
+      return context.query.serviceType(req);
+    },
+    service: (context, req) => {
+      return context.query.service(req);
+    },
+    serviceVersion: (context, req) => {
+      return context.query.serviceVersion(req);
+    },
+    owner: (context, req) => {
+      return context.query.owner(req);
+    },
   },
 
   /**
@@ -58,13 +73,7 @@ module.exports = {
     // This is only an effort to get this working quickly and should be changed later.
     // This also means for now, the default sorting method will be downloads, not relevance.
 
-    const packs = await context.database.simpleSearch(
-      params.query,
-      params.page,
-      params.direction,
-      params.sort,
-      params.filter === "theme"
-    );
+    const packs = await context.database.getSortedPackages(params);
 
     if (!packs.ok) {
       if (packs.short === "not_found") {
@@ -82,7 +91,7 @@ module.exports = {
 
       const sso = new context.sso();
 
-      return sso.notOk().addContent(packs).addCalls("db.simpleSearch", packs);
+      return sso.notOk().addContent(packs).addCalls("db.getSortedPackages", packs);
     }
 
     const newPacks = await context.utils.constructPackageObjectShort(

--- a/src/controllers/getThemesSearch.js
+++ b/src/controllers/getThemesSearch.js
@@ -40,18 +40,16 @@ module.exports = {
   },
 
   async logic(params, context) {
-    const packs = await context.database.simpleSearch(
-      params.query,
-      params.page,
-      params.direction,
-      params.sort,
+
+    const packs = await context.database.getSortedPackages(
+      params,
       true
     );
 
     if (!packs.ok) {
       const sso = new context.sso();
 
-      return sso.notOk().addContent(packs).addCalls("db.simpleSearch", packs);
+      return sso.notOk().addContent(packs).addCalls("db.getSortedPackages", packs);
     }
 
     const newPacks = await context.utils.constructPackageObjectShort(

--- a/tests/database/database.test.js
+++ b/tests/database/database.test.js
@@ -87,23 +87,6 @@ describe("Get Sorted Packages", () => {
   });
 });
 
-describe("Get Package Search", () => {
-  test("Should return good pagination when there are no results", async () => {
-    const obj = await database.simpleSearch(
-      "will-never-match-a-search",
-      1,
-      "desc",
-      "relevance"
-    );
-    expect(obj.ok).toBeTruthy();
-    expect(Array.isArray(obj.content)).toBeTruthy();
-    expect(obj.content.length).toBe(0);
-    expect(obj.pagination.count).toBe(0);
-    expect(obj.pagination.page).toBe(0);
-    expect(obj.pagination.total).toBe(0);
-  });
-});
-
 describe("Package Lifecycle Tests", () => {
   // Below are what we will call lifecycle tests.
   // That is tests that will test multiple actions against the same package,

--- a/tests/http/getPackagesSearch.test.js
+++ b/tests/http/getPackagesSearch.test.js
@@ -65,4 +65,50 @@ describe("Behaves as expected", () => {
     expect(sso.content[0].name).toBe("get-packages-search-theme-test");
     expect(sso).toMatchEndpointSuccessObject(endpoint);
   });
+
+  test("Successfully searches and filters by supported extensions", async () => {
+    await database.applyFeatures(
+      {
+        hasSnippets: false,
+        hasGrammar: true,
+        supportedLanguages: ["js", "ts"]
+      },
+      "get-packages-search-test",
+      "1.0.0"
+    );
+
+    let sso = await endpoint.logic(
+      {
+        sort: "downloads",
+        page: 1,
+        direction: "desc",
+        query: "get packages search",
+        filter: "package",
+        fileExtension: "js"
+      },
+      context
+    );
+
+    expect(sso.ok).toBe(true);
+    expect(sso.content.length).toBe(1);
+    expect(sso.content[0].name).toBe("get-packages-search-test");
+    expect(sso).toMatchEndpointSuccessObject(endpoint);
+
+    // Now if we exclude the package via the supported file extensions
+    let ssoEmpty = await endpoint.logic(
+      {
+        sort: "downloads",
+        page: 1,
+        direction: "desc",
+        query: "get packages search",
+        filter: "package",
+        fileExtension: "sql"
+      },
+      context
+    );
+
+    expect(ssoEmpty.ok).toBe(true);
+    expect(ssoEmpty.content.length).toBe(0);
+
+  });
 });

--- a/tests/http/getThemesSearch.test.js
+++ b/tests/http/getThemesSearch.test.js
@@ -7,7 +7,7 @@ const genPackage = require("../helpers/package.jest.js");
 describe("Behaves as expected", () => {
   test("Calls the correct function", async () => {
     const localContext = context;
-    const spy = jest.spyOn(localContext.database, "simpleSearch");
+    const spy = jest.spyOn(localContext.database, "getSortedPackages");
 
     await endpoint.logic({}, localContext);
 
@@ -63,7 +63,7 @@ describe("Behaves as expected", () => {
     // Moved to last position, since it modifies our shallow copied context
     const localContext = context;
     localContext.database = {
-      simpleSearch: () => {
+      getSortedPackages: () => {
         return { ok: false, content: "Test Error" };
       },
     };


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This PR introduces the ability to utilize all valid query parameters of `/api/packages` on `/api/packages/search`.

This now means you can search for a package name while also:
* Showing results that support a specific file extension
* Showing results that are either consumers or providers of a specific service
* Showing results that are consumers or providers of a specific service and version
* Showing results results of a specific owner

While of course still being able to:
* Sort the packages in the desired direction
* Get the specific page
* Sort the packages in a particular direction

Of course, if preferred, you are still able to get a full list of packages without any search. 

This means this is a fully backwards compatible method of adding far more capabilities to the package searching.

---

Technical Notes:

* This PR expands the work done by @savetheclocktower of utilizing `_Clause()` functions within `getSortedPackages()` to elegantly and easily extend the accepted functionality of the function. Using this I was able to add the `query` query parameter to the function.
* As it's no longer used the original `simpleSearch()` function has been removed in favour of `getSortedPackages()`.

---

Closes #214 