### PR TITLE
Refactor Package Constructs

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -15,4 +15,9 @@ module.exports = {
   ssoPaginate: require("./models/ssoPaginate.js"),
   ssoRedirect: require("./models/ssoRedirect.js"),
   ssoHTML: require("./models/ssoHTML.js"),
+  models: {
+    constructPackageObjectFull: require("./models/constructPackageObjectFull.js"),
+    constructPackageObjectShort: require("./models/constructPackageObjectShort.js"),
+    constructPackageObjectJSON: require("./models/constructPackageObjectJSON.js"),
+  }
 };

--- a/src/controllers/getOwnersOwnerName.js
+++ b/src/controllers/getOwnersOwnerName.js
@@ -47,7 +47,7 @@ module.exports = {
         .addCalls("db.getSortedPackages", packages);
     }
 
-    const packObjShort = await context.utils.constructPackageObjectShort(
+    const packObjShort = await context.models.constructPackageObjectShort(
       packages.content
     );
 

--- a/src/controllers/getPackages.js
+++ b/src/controllers/getPackages.js
@@ -72,7 +72,7 @@ module.exports = {
         .addCalls("db.getSortedPackages", packages);
     }
 
-    const packObjShort = await context.utils.constructPackageObjectShort(
+    const packObjShort = await context.models.constructPackageObjectShort(
       packages.content
     );
 

--- a/src/controllers/getPackagesFeatured.js
+++ b/src/controllers/getPackagesFeatured.js
@@ -45,7 +45,7 @@ module.exports = {
         .addCalls("db.getFeaturedPackages", packs);
     }
 
-    const packObjShort = await context.utils.constructPackageObjectShort(
+    const packObjShort = await context.models.constructPackageObjectShort(
       packs.content
     );
 

--- a/src/controllers/getPackagesPackageName.js
+++ b/src/controllers/getPackagesPackageName.js
@@ -54,7 +54,7 @@ module.exports = {
       return sso.notOk().addContent(pack).addCalls("db.getPackageByName", pack);
     }
 
-    pack = await context.utils.constructPackageObjectFull(pack.content);
+    pack = await context.models.constructPackageObjectFull(pack.content);
 
     if (params.engine !== false) {
       // query.engine returns false if no valid query param is found.

--- a/src/controllers/getPackagesPackageNameVersionsVersionName.js
+++ b/src/controllers/getPackagesPackageNameVersionsVersionName.js
@@ -5,6 +5,14 @@
 module.exports = {
   docs: {
     summary: "Get the details of a specific package version.",
+    responses: {
+      200: {
+        description: "The `package.json` among other details of the package.",
+        content: {
+          "application/json": "$packageObjectJSON"
+        }
+      }
+    }
   },
   endpoint: {
     method: "GET",
@@ -64,7 +72,7 @@ module.exports = {
         .addCalls("db.getPackageVersionByNameAndVersion", pack);
     }
 
-    const packRes = await context.utils.constructPackageObjectJSON(
+    const packRes = await context.models.constructPackageObjectJSON(
       pack.content
     );
 

--- a/src/controllers/getPackagesPackageNameVersionsVersionNameTarball.js
+++ b/src/controllers/getPackagesPackageNameVersionsVersionNameTarball.js
@@ -8,13 +8,11 @@ module.exports = {
   docs: {
     summary:
       "Previously undocumented endpoint. Allows for installation of a package.",
-    responses: [
-      {
-        302: {
-          description: "Redirect to the GitHub tarball URL.",
-        },
-      },
-    ],
+    responses: {
+      302: {
+        description: "Redirect to the GitHub tarball URL."
+      }
+    }
   },
   endpoint: {
     method: "GET",

--- a/src/controllers/getPackagesSearch.js
+++ b/src/controllers/getPackagesSearch.js
@@ -85,7 +85,7 @@ module.exports = {
       return sso.notOk().addContent(packs).addCalls("db.simpleSearch", packs);
     }
 
-    const newPacks = await context.utils.constructPackageObjectShort(
+    const newPacks = await context.models.constructPackageObjectShort(
       packs.content
     );
 

--- a/src/controllers/getStars.js
+++ b/src/controllers/getStars.js
@@ -88,7 +88,7 @@ module.exports = {
         .addCalls("db.getPackageCollectionByID", packCol);
     }
 
-    let newCol = await context.utils.constructPackageObjectShort(
+    let newCol = await context.models.constructPackageObjectShort(
       packCol.content
     );
 

--- a/src/controllers/getThemes.js
+++ b/src/controllers/getThemes.js
@@ -56,7 +56,7 @@ module.exports = {
         .addCalls("db.getSortedPackages", packages);
     }
 
-    const packObjShort = await context.utils.constructPackageObjectShort(
+    const packObjShort = await context.models.constructPackageObjectShort(
       packages.content
     );
 

--- a/src/controllers/getThemesFeatured.js
+++ b/src/controllers/getThemesFeatured.js
@@ -37,7 +37,7 @@ module.exports = {
       return sso.notOk().addContent(col).addCalls("db.getFeaturedThemes", col);
     }
 
-    const newCol = await context.utils.constructPackageObjectShort(col.content);
+    const newCol = await context.models.constructPackageObjectShort(col.content);
 
     const sso = new context.sso();
 

--- a/src/controllers/getThemesSearch.js
+++ b/src/controllers/getThemesSearch.js
@@ -54,7 +54,7 @@ module.exports = {
       return sso.notOk().addContent(packs).addCalls("db.simpleSearch", packs);
     }
 
-    const newPacks = await context.utils.constructPackageObjectShort(
+    const newPacks = await context.models.constructPackageObjectShort(
       packs.content
     );
 

--- a/src/controllers/postPackages.js
+++ b/src/controllers/postPackages.js
@@ -219,7 +219,7 @@ module.exports = {
         .addCalls("db.getPackageByName", newDbPack);
     }
 
-    const packageObjectFull = await context.utils.constructPackageObjectFull(
+    const packageObjectFull = await context.models.constructPackageObjectFull(
       newDbPack.content
     );
 

--- a/src/controllers/postPackagesPackageNameStar.js
+++ b/src/controllers/postPackagesPackageNameStar.js
@@ -73,7 +73,7 @@ module.exports = {
         .addCalls("db.getPackageByName", pack);
     }
 
-    pack = await context.utils.constructPackageObjectFull(pack.content);
+    pack = await context.models.constructPackageObjectFull(pack.content);
 
     const sso = new context.sso();
 

--- a/src/models/constructPackageObjectFull.js
+++ b/src/models/constructPackageObjectFull.js
@@ -1,0 +1,63 @@
+/**
+ * @async
+ * @function constructPackageObjectFull
+ * @desc Takes the raw return of a full row from database.getPackageByName() and
+ * constructs a standardized package object full from it.
+ * This should be called only on the data provided by database.getPackageByName(),
+ * otherwise the behavior is unexpected.
+ * @param {object} pack - The anticipated raw SQL return that contains all data
+ * to construct a Package Object Full.
+ * @returns {object} A properly formatted and converted Package Object Full.
+ * @see {@link https://github.com/confused-Techie/atom-backend/blob/main/docs/returns.md#package-object-full}
+ * @see {@link https://github.com/confused-Techie/atom-backend/blob/main/docs/queries.md#retrieve-single-package--package-object-full}
+ */
+const logger = require("../logger.js");
+const { server_url } = require("../config.js").getConfig();
+
+module.exports =
+async function constructPackageObjectFull(pack) {
+  const parseVersions = (vers) => {
+    let retVer = {};
+
+    for (const v of vers) {
+      retVer[v.semver] = v.meta;
+      retVer[v.semver].license = v.license;
+      retVer[v.semver].engines = v.engines;
+      retVer[v.semver].dist = {
+        tarball: `${server_url}/api/packages/${pack.name}/versions/${v.semver}/tarball`,
+      };
+    }
+
+    return retVer;
+  };
+
+  // We need to copy the metadata of the latest version in order to avoid an
+  // auto-reference in the versions array that leads to a freeze in JSON stringify stage.
+  //let newPack = structuredClone(pack?.versions[0]?.meta ?? {});
+  let newPack = pack.data;
+  newPack.name = pack.name;
+  newPack.downloads = pack.downloads;
+  newPack.owner = pack.owner;
+  newPack.stargazers_count = pack.stargazers_count;
+  newPack.versions = parseVersions(pack.versions);
+  // database.getPackageByName() sorts the JSON array versions in descending order,
+  // so no need to find the latest semver, it's the first one (index 0).
+  newPack.releases = { latest: pack?.versions[0]?.semver ?? "" };
+
+  if (!Array.isArray(newPack.badges)) {
+    // A package that has yet to receive any permenant badges
+    newPack.badges = [];
+  }
+
+  // Apply any custom deliver time badges
+  if (pack.creation_method === "User Made Package") {
+    newPack.badges.push({
+      title: "Made for Pulsar!",
+      type: "success",
+    });
+  }
+
+  logger.generic(6, "Built Package Object Full without Error");
+
+  return newPack;
+}

--- a/src/models/constructPackageObjectJSON.js
+++ b/src/models/constructPackageObjectJSON.js
@@ -1,0 +1,46 @@
+/**
+ * @async
+ * @function constructPackageObjectJSON
+ * @desc Takes the return of getPackageVersionByNameAndVersion and returns
+ * a recreation of the package.json with a modified dist.tarball key, pointing
+ * to this server for download.
+ * @param {object} pack - The expected raw SQL return of `getPackageVersionByNameAndVersion`
+ * @returns {object} A properly formatted Package Object Mini.
+ * @see {@link https://github.com/confused-Techie/atom-backend/blob/main/docs/returns.md#package-object-mini}
+ */
+
+const logger = require("../logger.js");
+const { server_url } = require("../config.js").getConfig();
+
+module.exports =
+async function constructPackageObjectJSON(pack) {
+  const parseVersionObject = (v) => {
+    let newPack = v.meta;
+    if (newPack.sha) {
+      delete newPack.sha;
+    }
+    if (newPack.tarball_url) {
+      delete newPack.tarball_url;
+    }
+    newPack.dist ??= {};
+    newPack.dist.tarball = `${server_url}/api/packages/${v.meta.name}/versions/${v.semver}/tarball`;
+    newPack.engines = v.engines;
+    logger.generic(6, "Single Package Object JSON finished without Error");
+    return newPack;
+  };
+
+  if (!Array.isArray(pack)) {
+    const newPack = parseVersionObject(pack);
+
+    logger.generic(6, "Single Package Object JSON finished without Error");
+    return newPack;
+  }
+
+  let arrPack = [];
+  for (const p of pack) {
+    arrPack.push(parseVersionObject(p));
+  }
+
+  logger.generic(66, "Array Package Object JSON finished without Error");
+  return arrPack;
+}

--- a/src/models/constructPackageObjectShort.js
+++ b/src/models/constructPackageObjectShort.js
@@ -1,0 +1,80 @@
+/**
+ * @async
+ * @function constructPackageObjectShort
+ * @desc Takes a single or array of rows from the db, and returns a JSON
+ * construction of package object shorts
+ * @param {object} pack - The anticipated raw SQL return that contains all data
+ * to construct a Package Object Short.
+ * @returns {object|array} A properly formatted and converted Package Object Short.
+ * @see {@link https://github.com/confused-Techie/atom-backend/blob/main/docs/returns.md#package-object-short}
+ * @see {@link https://github.com/confused-Techie/atom-backend/blob/main/docs/queries.md#retrieve-many-sorted-packages--package-object-short}
+ */
+
+const logger = require("../logger.js");
+
+module.exports =
+async function constructPackageObjectShort(pack) {
+  const parsePackageObject = (p) => {
+    let newPack = p.data;
+    newPack.downloads = p.downloads;
+    newPack.stargazers_count = p.stargazers_count;
+    newPack.releases = {
+      latest: p.semver,
+    };
+
+    if (!Array.isArray(newPack.badges)) {
+      // A package that has yet to receive any permenant badges
+      newPack.badges = [];
+    }
+
+    // Apply any custom deliver time badges
+    if (p.creation_method === "User Made Package") {
+      newPack.badges.push({ title: "Made for Pulsar!", type: "success" });
+    }
+
+    // Remove keys that aren't intended to exist in a Package Object Short
+    delete newPack.versions;
+
+    newPack.owner = p.owner;
+    return newPack;
+  };
+
+  if (Array.isArray(pack)) {
+    if (pack.length === 0) {
+      // Sometimes it seems an empty array will be passed here, in that case we will protect against
+      // manipulation of `undefined` objects
+      logger.generic(
+        5,
+        "Package Object Short Constructor Protected against 0 Length Array"
+      );
+
+      return pack;
+    }
+
+    let retPacks = [];
+    for (const p of pack) {
+      retPacks.push(parsePackageObject(p));
+    }
+
+    logger.generic(6, "Array Package Object Short Constructor without Error");
+    return retPacks;
+  }
+
+  // Not an array
+  if (
+    pack.data === undefined ||
+    pack.downloads === undefined ||
+    pack.stargazers_count === undefined ||
+    pack.semver === undefined
+  ) {
+    logger.generic(
+      5,
+      "Package Object Short Constructor Protected against Undefined Required Values"
+    );
+
+    return {};
+  }
+
+  logger.generic(6, "Single Package Object Short Constructor without Error");
+  return parsePackageObject(pack);
+}

--- a/tests/http/deletePackagesPackageNameVersionsVersionName.test.js
+++ b/tests/http/deletePackagesPackageNameVersionsVersionName.test.js
@@ -104,7 +104,7 @@ describe("DELETE /api/packages/:packageName/versions/:versionName", () => {
 
     expect(currentPackageData.ok).toBe(true);
 
-    currentPackageData = await context.utils.constructPackageObjectFull(
+    currentPackageData = await context.models.constructPackageObjectFull(
       currentPackageData.content
     );
 

--- a/tests/http/postPackages.test.js
+++ b/tests/http/postPackages.test.js
@@ -240,7 +240,7 @@ describe("POST /api/packages Behaves as expected", () => {
 
     expect(packByVer.ok).toBe(true);
 
-    packByVer = await context.utils.constructPackageObjectJSON(
+    packByVer = await context.models.constructPackageObjectJSON(
       packByVer.content
     );
 

--- a/tests/models/packageObjectJSON.js
+++ b/tests/models/packageObjectJSON.js
@@ -1,0 +1,46 @@
+module.exports = {
+  schema: {
+    description: "The `package.json` of a package with an added `dist.tarball` object.",
+    type: "object",
+    required: [
+      "name",
+      "version",
+      "engines",
+      "dist"
+    ],
+    properties: {
+      name: { type: "string" },
+      version: { type: "object" },
+      engines: { type: "object" },
+      dist: { type: "object" }
+    }
+  },
+  example: {
+    // This is the full return of `language-robots-txt`
+    // Notice how some extra information may exist, that is present in the package's
+    // `package.json`, the schema and test only references required fields
+    name: "language-robots-txt",
+    author: "confused-Techie",
+    license: "MIT",
+    scripts: {
+      test: "pulsar --test spec"
+    },
+    version: "1.0.8",
+    keywords: [ "text-mate", "pulsar-package", "pulsar-edit" ],
+    repository: "https://github.com/confused-Techei/language-robots-txt",
+    description: "Robots.txt Syntax Highlighting in Pulsar",
+    dist: {
+      tarball: "https://api.pulsar-edit.dev/api/packages/language-robots-txt/versions/1.0.8/tarball"
+    }
+  },
+  test: Joi.object({
+    name: Joi.string().required(),
+    version: Joi.string().required(),
+    engines: Joi.object({
+      atom: Joi.string().required()
+    }).required(),
+    dist: Joi.object({
+      tarball: Joi.string().required()
+    }).required(),
+  }).required(),
+};

--- a/tests/unit/controllers/getStars.test.js
+++ b/tests/unit/controllers/getStars.test.js
@@ -107,7 +107,7 @@ describe("Returns as expected", () => {
         return { ok: true, content: {} };
       },
     };
-    localContext.utils = {
+    localContext.models = {
       constructPackageObjectShort: () => {
         return { item: "is_a_package" };
       },

--- a/tests/unit/models/constructPackageObjectFull.test.js
+++ b/tests/unit/models/constructPackageObjectFull.test.js
@@ -1,0 +1,64 @@
+const pof = require("../../../src/models/constructPackageObjectFull.js");
+const schema = require("../../models/packageObjectFull.js").test;
+
+describe("Parses Data, as expected to be returned by the Database", () => {
+
+  test("Correctly Parses normal data", async () => {
+    const data = {
+      pointer: "1234",
+      name: "test-package",
+      created: "2024-01-20T00:47:00.981Z",
+      updated: "2024-01-20T00:47:00.981Z",
+      creation_method: "Test Package",
+      downloads: "25",
+      data: {
+        name: "test-package",
+        owner: "pulsar-edit",
+        readme: "This is a readme!",
+        metadata: {
+          name: "test-package",
+          license: "MIT",
+          version: "1.0.0"
+        },
+        releases: { latest: "1.0.0" },
+        versions: {
+          "1.0.0": {
+            sha: "1234",
+            name: "test-package",
+            version: "1.0.0",
+            tarball_url: "https://nowhere.com"
+          }
+        },
+        repository: {
+          url: "https://github.com/pulsar-edit/test-package",
+          type: "git"
+        },
+        creation_method: "Test Package"
+      },
+      owner: "pulsar-edit",
+      stargazers_count: "1",
+      versions: [
+        {
+          id: 10,
+          meta: {
+            sha: "1234",
+            name: "test-package",
+            version: "1.0.0",
+            tarball_url: "https://nowhere.com"
+          },
+          engine: { atom: "*" },
+          semver: "1.0.0",
+          license: "MIT",
+          package: "1234",
+          hasGrammar: false,
+          hasSnippets: false,
+          supportedLanguages: null
+        }
+      ]
+    };
+
+    const parsed = await pof(data);
+
+    expect(parsed).toMatchSchema(schema);
+  });
+});

--- a/tests/unit/models/constructPackageObjectJSON.test.js
+++ b/tests/unit/models/constructPackageObjectJSON.test.js
@@ -1,0 +1,23 @@
+const poj = require("../../../src/models/constructPackageObjectJSON.js");
+const schema = require("../../models/packageObjectJSON.js").test;
+
+describe("Parses Data, as expected to be returned by the Database", () => {
+
+  test("Correctly Parses normal data", async () => {
+    const data = {
+      semver: "1.0.0",
+      license: "MIT",
+      engines: { atom: "*" },
+      meta: {
+        sha: "1234",
+        name: "package-test",
+        version: "1.0.0",
+        tarball_url: "https://nowhere.com"
+      }
+    };
+
+    const parsed = await poj(data);
+
+    expect(parsed).toMatchSchema(schema);
+  });
+});

--- a/tests/unit/models/constructPackageObjectShort.test.js
+++ b/tests/unit/models/constructPackageObjectShort.test.js
@@ -1,0 +1,46 @@
+const pos = require("../../../src/models/constructPackageObjectShort.js");
+const schema = require("../../models/packageObjectShort.js").test;
+
+describe("Parses Data, as expected to be returned by the Database", () => {
+
+  test("Correctly Parses normal data", async () => {
+    const data = {
+      name: "test-package",
+      data: {
+        name: "test-package",
+        owner: "pulsar-edit",
+        readme: "This is a readme!",
+        metadata: {
+          name: "test-package",
+          license: "MIT",
+          version: "1.0.0"
+        },
+        releases: { latest: "1.0.0" },
+        versions: {
+          "1.0.0": {
+            sha: "1234",
+            name: "test-package",
+            version: "1.0.0",
+            tarball_url: "https://nowhere.com"
+          }
+        },
+        repository: {
+          url: "https://github.com/pulsar-edit/test-package",
+          type: "git"
+        },
+        creation_method: "Test Package"
+      },
+      downloads: "0",
+      owner: "pulsar-edit",
+      stargazers_count: "0",
+      semver: "1.0.0",
+      created: "2024-01-20T00:46:57.014Z",
+      updated: "2024-01-20T00:46:57.014Z",
+      creation_method: "Test Package"
+    };
+
+    const parsed = await pos(data);
+
+    expect(parsed).toMatchSchema(schema);
+  });
+});


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This PR focuses on the important topic of Package Constructs. These Package Constructs are the functions that are in total control of what the data that's returned to users looks like. Which includes:

* Package Object Full
* Package Object Short
* Package Object JSON

This PR moves them out of the `utils` file into the dedicated `models` directory, as what now should be done. Additionally I've gone ahead and added new tests for these constructions, as they are never tested directly (until now), while I've also found and resolved a bug of `tarball_url` being incorrectly included in `Package Object JSON` objects.
