### PR TITLE
Admin Actions: 2024 - January 30

### DIFF
--- a/docs/reference/Admin_Actions.md
+++ b/docs/reference/Admin_Actions.md
@@ -18,7 +18,7 @@ As this package is now permanently broken, and archived, it'll receive the [`Arc
 
 The community package `linter-remark` has been discovered to be broken. The source code contains an [error](https://github.com/pulsar-edit/package-backend/issues/212). This package's source code has since been archived as of June 18, 2022. So it is now impossible for this package to ever receive an update to resolve its issue.
 
-As this package is now permanently broken, and archived, it'll receive both the [`Archived`](./badge-spec.md#archived) and [`Broken`](./badge-spec.md#broken) badges to reflect it's status.
+As this package is now permanently broken, and archived, it'll receive both the [`Archived`](./badge-spec.md#archived) and [`Broken`](./badge-spec.md#broken) badges to reflect its status.
 
 ### atom-ternjs
 

--- a/docs/reference/Admin_Actions.md
+++ b/docs/reference/Admin_Actions.md
@@ -32,7 +32,7 @@ So this package will receive the [`Deprecated`](./badge-spec.md#deprecated) badg
 
 ### compare-files
 
-The community package `compare-files` has been discovered to be broken. The source code contains an [error](https://github.com/atom-compare-files/atom-compare-files/issues) that was originally reported before Pulsar had ever been created. This package's source code has since been archived as of January 21, 2019. So it is now impossible for this package to ever receive an update to resolve it's issue.
+The community package `compare-files` has been discovered to be broken. The source code contains an [error](https://github.com/atom-compare-files/atom-compare-files/issues) that was originally reported before Pulsar had ever been created. This package's source code has since been archived as of January 21, 2019. So it is now impossible for this package to ever receive an update to resolve its issue.
 
 As this package is now permanently broken, and archived, it'll receive both the [`Archived`](./badge-spec.md#archived) and [`Broken`](./badge-spec.md#broken) badges to reflect it's status.
 

--- a/docs/reference/Admin_Actions.md
+++ b/docs/reference/Admin_Actions.md
@@ -12,7 +12,7 @@ The community package `linter-shellcheck` has been discovered to be broken. The 
 
 But the package has been forked to the [`pulsar-cooperative`](https://github.com/pulsar-cooperative) organization. This forked package is now recommended to download.
 
-As this package is now permanently broken, and archived, it'll receive both the [`Archived`](./badge-spec.md#archived) and [`Broken`](./badge-spec.md#broken), as well as [`Deprecated`](./badge-spec.md#deprecated) badges to reflect it's status, with installation of [`linter-shellcheck-pulsar`](https://web.pulsar-edit.dev/packages/linter-shellcheck-pulsar) instead recommended.
+As this package is now permanently broken, and archived, it'll receive the [`Archived`](./badge-spec.md#archived), [`Broken`](./badge-spec.md#broken) and [`Deprecated`](./badge-spec.md#deprecated) badges to reflect its status, with installation of [`linter-shellcheck-pulsar`](https://web.pulsar-edit.dev/packages/linter-shellcheck-pulsar) instead recommended.
 
 ### linter-remark
 

--- a/docs/reference/Admin_Actions.md
+++ b/docs/reference/Admin_Actions.md
@@ -34,7 +34,7 @@ So this package will receive the [`Deprecated`](./badge-spec.md#deprecated) badg
 
 The community package `compare-files` has been discovered to be broken. The source code contains an [error](https://github.com/atom-compare-files/atom-compare-files/issues) that was originally reported before Pulsar had ever been created. This package's source code has since been archived as of January 21, 2019. So it is now impossible for this package to ever receive an update to resolve its issue.
 
-As this package is now permanently broken, and archived, it'll receive both the [`Archived`](./badge-spec.md#archived) and [`Broken`](./badge-spec.md#broken) badges to reflect it's status.
+As this package is now permanently broken, and archived, it'll receive both the [`Archived`](./badge-spec.md#archived) and [`Broken`](./badge-spec.md#broken) badges to reflect its status.
 
 ### deep-purple-syntax
 

--- a/docs/reference/Admin_Actions.md
+++ b/docs/reference/Admin_Actions.md
@@ -8,7 +8,7 @@ With that said this document will serve as the ongoing history of administrative
 
 ### linter-shellcheck
 
-The community package `linter-shellcheck` has been discovered to be broken. The source code contains an [error](https://github.com/AtomLinter/linter-shellcheck/issues/160). This package's source code has since been archived as of August 7, 2023. So it is now impossible for this package to ever receive an update to resolve it's issue.
+The community package `linter-shellcheck` has been discovered to be broken. The source code contains an [error](https://github.com/AtomLinter/linter-shellcheck/issues/160). This package's source code has since been archived as of August 7, 2023. So it is now impossible for this package to ever receive an update to resolve its issue.
 
 But the package has been forked to the [`pulsar-cooperative`](https://github.com/pulsar-cooperative) organization. This forked package is now recommended to download.
 

--- a/docs/reference/Admin_Actions.md
+++ b/docs/reference/Admin_Actions.md
@@ -4,6 +4,56 @@ When you consider that most backend services are a black box of code and decisio
 
 With that said this document will serve as the ongoing history of administrative actions that must be taken against the backend.
 
+## 2024 - January 30
+
+### linter-shellcheck
+
+The community package `linter-shellcheck` has been discovered to be broken. The source code contains an [error](https://github.com/AtomLinter/linter-shellcheck/issues/160). This package's source code has since been archived as of August 7, 2023. So it is now impossible for this package to ever receive an update to resolve it's issue.
+
+But the package has been forked to the [`pulsar-cooperative`](https://github.com/pulsar-cooperative) organization. This forked package is now recommended to download.
+
+As this package is now permanently broken, and archived, it'll receive both the [`Archived`](./badge-spec.md#archived) and [`Broken`](./badge-spec.md#broken), as well as [`Deprecated`](./badge-spec.md#deprecated) badges to reflect it's status, with installation of [`linter-shellcheck-pulsar`](https://web.pulsar-edit.dev/packages/linter-shellcheck-pulsar) instead recommended.
+
+### linter-remark
+
+The community package `linter-remark` has been discovered to be broken. The source code contains an [error](https://github.com/pulsar-edit/package-backend/issues/212). This package's source code has since been archived as of June 18, 2022. So it is now impossible for this package to ever receive an update to resolve it's issue.
+
+As this package is now permanently broken, and archived, it'll receive both the [`Archived`](./badge-spec.md#archived) and [`Broken`](./badge-spec.md#broken) badges to reflect it's status.
+
+### atom-ternjs
+
+The community package [`atom-ternjs`](https://web.pulsar-edit.dev/packages/atom-ternjs) has been reported to be broken.
+
+This package was the first to be ported the [`pulsar-cooperative`](https://github.com/pulsar-cooperative) organization, in the effort to help alleviate the ownership burden of broken community packages.
+
+This forked package is now recommended to download.
+
+So this package will receive the [`Deprecated`](./badge-spec.md#deprecated) badge, with installation of [`pulsar-ternjs`](https://web.pulsar-edit.dev/packages/pulsar-ternjs) instead recommended.
+
+### compare-files
+
+The community package `compare-files` has been discovered to be broken. The source code contains an [error](https://github.com/atom-compare-files/atom-compare-files/issues) that was originally reported before Pulsar had ever been created. This package's source code has since been archived as of January 21, 2019. So it is now impossible for this package to ever receive an update to resolve it's issue.
+
+As this package is now permanently broken, and archived, it'll receive both the [`Archived`](./badge-spec.md#archived) and [`Broken`](./badge-spec.md#broken) badges to reflect it's status.
+
+### deep-purple-syntax
+
+The community package `deep-purple-syntax` has been found to have been removed from GitHub, meaning the package is no longer downloadable.
+
+As this package is broken in such a way that it cannot be fixed, it will be removed from the backend while keeping the reserved name to avoid any Supply Chain Attacks targeting this package.
+
+### darcula-darker-syntax
+
+Much like our previous entry of `pulsar-gpp-compiler` the maintainer of `darcula-darker-syntax` while working on their package had accidentally deleted the entire package. At this point in time they did request to have the name unreserved so that they could republish their package under the same name.
+
+Keeping in line with the same requirements, to avoid any kind of Supply Chain Vulnerability being available to our users we had to ensure that there were **zero** ever downloads of this package. Since this package was publishing originally within 30 days, we were able to do this via the server logs. The following was determined absolutely:
+
+1. The user requesting this service had sufficient permission to the effected repository.
+2. No major, malicious changes had occurred in the codebase, which could signal a GitHub user's account had been compromised.
+3. That absolutely 0 downloads have ever occurred of this package.
+
+After confirming the above details without a shadow of a doubt, we were able to unreserve the package name to allow the author to publish their package under that name again.
+
 ## 2023 - September 4
 
 ### pulsar-gpp-compiler

--- a/docs/reference/Admin_Actions.md
+++ b/docs/reference/Admin_Actions.md
@@ -16,7 +16,7 @@ As this package is now permanently broken, and archived, it'll receive the [`Arc
 
 ### linter-remark
 
-The community package `linter-remark` has been discovered to be broken. The source code contains an [error](https://github.com/pulsar-edit/package-backend/issues/212). This package's source code has since been archived as of June 18, 2022. So it is now impossible for this package to ever receive an update to resolve it's issue.
+The community package `linter-remark` has been discovered to be broken. The source code contains an [error](https://github.com/pulsar-edit/package-backend/issues/212). This package's source code has since been archived as of June 18, 2022. So it is now impossible for this package to ever receive an update to resolve its issue.
 
 As this package is now permanently broken, and archived, it'll receive both the [`Archived`](./badge-spec.md#archived) and [`Broken`](./badge-spec.md#broken) badges to reflect it's status.
 

--- a/docs/reference/badge_spec.md
+++ b/docs/reference/badge_spec.md
@@ -1,7 +1,7 @@
 # Pulsar Package's Badges
 
 Badges communicate additional information to you about a package.
-Pulsar Maintainers communicate details about packages via badges when a community package maintainer can't or wont't, in the hope of making the usage of the [Pulsar Package Registry (PPR)](./glossary.md) as simple and easy as possible. Think of Pulsar Package Badges being similar to how NPM emits warnings when installing certain packages, or how users on GitHub can receive badges on their GitHub profile.
+Pulsar Maintainers communicate details about packages via badges when a community package maintainer can't or won't, in the hope of making the usage of the [Pulsar Package Registry (PPR)](./glossary.md) as simple and easy as possible. Think of Pulsar Package Badges being similar to how NPM emits warnings when installing certain packages, or how users on GitHub can receive badges on their GitHub profile.
 
 Below is the specification for a badge, the data it may contain, the valid values that may be placed in an enum, and what should be done with it.
 
@@ -15,6 +15,7 @@ The following schema is required of any `generic` badge type:
     "type": "<type_enum>",
     "title": "<string>",
     "text": "<string>",
+    "alt": "<string>",
     "link": "<string>"
   }
 ]
@@ -28,6 +29,7 @@ Any `badge` object may contain the following properties:
 * `title`: This is a **required** property. Specifying the title of the badge. Such as `Deprecated`. This value is a strict enum, with only the values specified below being allowed.
 * `text`: This is an **optional** property. Specifying further information about this badge. That may be hidden either based on a user setting or by context.
 * `link`: This is an **optional** property. Providing a link for the user to be directed to, that may contain further information about the badge.
+* `alt`: This is an **optional** property. Only having a use for when the badge type is 'Deprecated'. It's usage should be the name of an alternative package for users to install.
 * `type`: This is a **required** property. Instructing what type of badge this is. The type of badge should be used to determine any icons used alongside the badge, as well as any color or styling the badge will receive when displayed by the client. The valid `type`s currently available are as follows:
   - `warn`: This should be used to indicate something that the user **must** be aware of.
   - `info`: This should be used to point out information that is neutral in the user receiving.
@@ -41,8 +43,9 @@ The following are some valid examples of badges:
   {
     "type": "warn",
     "title": "Deprecated",
-    "text": "This package is out of date and should not be used.",
-    "link": "https://github.com/pulsar-edit/pulsar/issues/1"
+    "text": "Installation of fork recommended",
+    "link": "https://github.com/pulsar-edit/pulsar/issues/1",
+    "alt": "package-fork-name"
   },
   {
     "type": "info",
@@ -78,6 +81,8 @@ The `Made for Pulsar!` badge is meant to be a badge of achievement, showing that
 
 ### Broken
 
+> Known to be non-functional
+
 The `Broken` badge is used to indicate that the package available on the PPR does not work at all in its current form, on any supported platform. Either requiring manual changes to the source code, or otherwise being unrealistic to fix from the users perspective.
 
 This package likely emits warnings immediately, or may even cause the editor to crash as a whole. Installation of these packages is not recommended by the Pulsar team, and instead it is encouraged to work with the original maintainer to get these packages working, or otherwise the community is encouraged to maintain and manage a fork of said package.
@@ -85,6 +90,8 @@ This package likely emits warnings immediately, or may even cause the editor to 
 If a community member does decide to maintain a fork of a package with a `Broken` badge, it's recommended to make the Pulsar team or Pulsar Backend team (such as by opening an issue on this repo) aware of this, so any warnings and links on the original package can be changed to recommend installation of your functional fork.
 
 ### Archived
+
+> Source Code has been archived
 
 The `Archived` badge is used to indicate that this package has been archived on GitHub (Or other VCS host). This does not mean that the package doesn't work, or has any kind of issue, it only means that if there does become issues with this package then support is most likely not going to exist.
 
@@ -96,6 +103,12 @@ The `Archived` badge should only be used as a neutral badge, to not cause any ki
 
 ### Deprecated
 
+> Installation of fork recommended
+
 The `Deprecated` badge is used to indicate that this package, which is [`Broken`](#broken) has a working fork published to the PPR. It is recommended that users install the forked version of this package instead, to avoid the broken behavior of the original package.
 
 Pointing out this forked package does not constitute a recommendation from Pulsar, only drawing attention to the fact that it is possible to have a bug free experience with a more up to date version of the package.
+
+### Bundled
+
+The `Bundled` badge is used to indicate that this package comes with every Pulsar installation. There is no need to download this package manually, and instead should be updated by grabbing a newer version of Pulsar if one exists.

--- a/scripts/tools/add-badge.js
+++ b/scripts/tools/add-badge.js
@@ -21,6 +21,7 @@ let sqlStorage;
   - title: <enum|required> The title of the badge (outdated, broken, archived)
   - text: <string|optional> The text content of the badge (no periods, fewest words possible)
   - link: <string|optional> A link for the badge (link to admin actions log)
+  - alt: <string|optional> The alternate name to add for deprecated packages.
 */
 let badgeConfig = {
   type: "",
@@ -69,6 +70,10 @@ async function main() {
   }
   if (badgeConfig.link && badgeConfig.link.length < 1) {
     console.error("Zero lengthed entry of Badge Config link!");
+    process.exit(100);
+  }
+  if (badgeConfig.alt && badgeConfig.alt.length < 1) {
+    console.error("Zero lengthed entry of Badge Config alt!");
     process.exit(100);
   }
 


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [ ] Have you ran tests against this code?
* [X] This PR contains zero code changes.

### Description of the Change

This PR adds new admin actions that have occurred.

Additionally, this PR defines the `Bundled` badge spec which is being linked to when visiting bundled packages in the PPR. 
Also this PR adds a new key to the badge specification of `alt`. This key useful only when a badge is `Deprecated` can be used to add the name of the new package that's recommended to install. This may prove to be useful if we want to help users navigate to the new package easier than having to visit the link, read the admin actions, and find the link to the new package manually. 

In the future we may want to investigate if we add this logic automatically to the frontend, to help link to these packages.