### PR TITLE
Use `callStack` everywhere

### DIFF
--- a/src/controllers/getOwnersOwnerName.js
+++ b/src/controllers/getOwnersOwnerName.js
@@ -36,7 +36,11 @@ module.exports = {
   },
 
   async logic(params, context) {
+    const callStack = new context.callStack();
+
     const packages = await context.database.getSortedPackages(params);
+
+    callStack.addCall("db.getSortedPackages", packages);
 
     if (!packages.ok) {
       const sso = new context.sso();
@@ -44,7 +48,7 @@ module.exports = {
       return sso
         .notOk()
         .addContent(packages)
-        .addCalls("db.getSortedPackages", packages);
+        .assignCalls(callStack);
     }
 
     const packObjShort = await context.models.constructPackageObjectShort(

--- a/src/controllers/getPackagesPackageNameVersionsVersionName.js
+++ b/src/controllers/getPackagesPackageNameVersionsVersionName.js
@@ -47,6 +47,7 @@ module.exports = {
    * @returns {sso}
    */
   async logic(params, context) {
+    const callStack = new context.callStack();
     // Check the truthiness of the returned query engine
     if (params.versionName === false) {
       const sso = new context.sso();
@@ -64,13 +65,15 @@ module.exports = {
       params.versionName
     );
 
+    callStack.addCall("db.getPackageVersionByNameAndVersion", pack);
+
     if (!pack.ok) {
       const sso = new context.sso();
 
       return sso
         .notOk()
         .addContent(pack)
-        .addCalls("db.getPackageVersionByNameAndVersion", pack);
+        .assignCalls(callStack);
     }
 
     const packRes = await context.models.constructPackageObjectJSON(

--- a/src/controllers/getUsersLoginStars.js
+++ b/src/controllers/getUsersLoginStars.js
@@ -30,17 +30,23 @@ module.exports = {
     },
   },
   async logic(params, context) {
+    const callStack = new context.callStack();
+
     const user = await context.database.getUserByName(params.login);
+
+    callStack.addCall("db.getUserByName", user);
 
     if (!user.ok) {
       const sso = new context.sso();
 
-      return sso.notOk().addContent(user).addCalls("db.getUserByName", user);
+      return sso.notOk().addContent(user).assignCalls(callStack);
     }
 
     let pointerCollection = await context.database.getStarredPointersByUserID(
       user.content.id
     );
+
+    callStack.addCall("db.getStarredPointersByUserID", pointerCollection);
 
     if (!pointerCollection.ok) {
       const sso = new context.sso();
@@ -48,8 +54,7 @@ module.exports = {
       return sso
         .notOk()
         .addContent(pointerCollection)
-        .addCalls("db.getUserByName", user)
-        .addCalls("db.getStarredPointersByUserID", pointerCollection);
+        .assignCalls(callStack);
     }
 
     // Since even if the pointerCollection is okay, it could be empty. Meaning the user
@@ -71,15 +76,15 @@ module.exports = {
       pointerCollection.content
     );
 
+    callStack.addCall("db.getPackageCollectionByID", packageCollection);
+
     if (!packageCollection.ok) {
       const sso = new context.sso();
 
       return sso
         .notOk()
         .addContent(packageCollection)
-        .addCalls("db.getUserByName", user)
-        .addCalls("db.getStarredPointersByUserID", pointerCollection)
-        .addCalls("db.getPackageCollectionByID", packageCollection);
+        .assignCalls(callStack);
     }
 
     packageCollection = await utils.constructPackageObjectShort(


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This PR extends #241 by now using this new `callStack` just about everywhere.

Although with #240 still in review, I made sure not to touch `getPackagesPackageName` and `postPackages` as those callStack signatures change through that PR, and I didn't want to create any conflicts.

But in short, all this PR does it make it easier to trace errors occurring on the backend, and for any reported errors, at a glance we can quickly see and read the path that request took through the code, and what failed.
