### PR TITLE
Add support for any valid repository declaration during publication

### DIFF
--- a/src/controllers/postPackages.js
+++ b/src/controllers/postPackages.js
@@ -93,7 +93,7 @@ module.exports = {
     }
 
     // Check repository format validity.
-    if (params.repository === "" || typeof params.repository !== "string") {
+    if (params.repository === false) {
       // repository format is invalid
       const sso = new context.sso();
 

--- a/src/controllers/postPackages.js
+++ b/src/controllers/postPackages.js
@@ -1,6 +1,7 @@
 /**
  * @module postPackages
  */
+const parseGithubURL = require("parse-github-url");
 
 module.exports = {
   docs: {
@@ -105,7 +106,8 @@ module.exports = {
     // Currently though the repository is in `owner/repo` format,
     // meanwhile needed functions expects just `repo`
 
-    const repo = params.repository.split("/")[1]?.toLowerCase();
+    const repo = parseGithubURL(params.repository)?.name.toLowerCase();
+    const ownerRepo = parseGithubURL(params.repository)?.repo;
 
     if (repo === undefined) {
       const sso = new context.sso();
@@ -133,7 +135,7 @@ module.exports = {
     // has permissions to this package
     const gitowner = await context.vcs.ownership(
       user.content,
-      params.repository
+      ownerRepo
     );
 
     callStack.addCall("vcs.ownership", gitowner);
@@ -148,7 +150,7 @@ module.exports = {
     // TODO: Stop hardcoding `git` as service
     const newPack = await context.vcs.newPackageData(
       user.content,
-      params.repository,
+      ownerRepo,
       "git"
     );
 
@@ -190,16 +192,15 @@ module.exports = {
     // Now to check if this package is a bundled package (since they don't exist on the db)
     const isBundled = context.bundled.isNameBundled(newPack.content.name);
 
+    callStack.addCall("bundled.isNameBundled", isBundled);
+
     if (isBundled.ok && isBundled.content) {
       const sso = new context.sso();
 
       return sso
         .notOk()
         .addShort("package_exists")
-        .addCalls("auth.verifyAuth", user)
-        .addCalls("vcs.ownership", gitowner)
-        .addCalls("vcs.newPackageData", newPack)
-        .addCalls("bundled.isNameBundled", isBundled);
+        .assignCalls(callStack);
     }
 
     // Now with valid package data, we can insert them into the DB
@@ -247,7 +248,7 @@ module.exports = {
     sso.featureDetection = {
       user: user.content,
       service: "git", // TODO stop hardcoding git
-      ownerRepo: params.repository,
+      ownerRepo: ownerRepo,
     };
 
     return sso.isOk().addContent(packageObjectFull);

--- a/src/query_parameters/repository.js
+++ b/src/query_parameters/repository.js
@@ -2,7 +2,7 @@
  * @function repo
  * @desc Parses the 'repository' query parameter, returning it if valid, otherwise returning ''.
  * @param {object} req - The `Request` object inherited from the Express endpoint.
- * @returns {string} Returning the valid 'repository' query parameter, or '' if invalid.
+ * @returns {string} Returning the valid 'repository' query parameter, or false if invalid.
  */
 const parseGithubURL = require("parse-github-url");
 
@@ -22,13 +22,13 @@ module.exports = {
     const prov = req.query.repository;
 
     if (prov === undefined) {
-      return "";
+      return false;
     }
 
     const parsed = parseGithubURL(prov);
 
     if (typeof parsed.owner !== "string" || typeof parsed.name !== "string") {
-      return "";
+      return false;
     }
 
     const re = /^[^._ ][^ ]{0,213}$/;
@@ -38,7 +38,7 @@ module.exports = {
     //  - cannot contain a space
 
     if (parsed.owner.match(re) === null || parsed.name.match(re) === null) {
-      return "";
+      return false;
     }
 
     return prov;

--- a/src/query_parameters/repository.js
+++ b/src/query_parameters/repository.js
@@ -31,7 +31,7 @@ module.exports = {
       return "";
     }
 
-    const re = /^[^._ ][^ ]{0,213}&/;
+    const re = /^[^._ ][^ ]{0,213}$/;
     // Ensure both the name and owner:
     //  - less than or equal to 214 characters
     //  - cannot begin with a dot or an underscore

--- a/src/query_parameters/repository.js
+++ b/src/query_parameters/repository.js
@@ -4,6 +4,7 @@
  * @param {object} req - The `Request` object inherited from the Express endpoint.
  * @returns {string} Returning the valid 'repository' query parameter, or '' if invalid.
  */
+const parseGithubURL = require("parse-github-url");
 
 module.exports = {
   schema: {
@@ -24,14 +25,22 @@ module.exports = {
       return "";
     }
 
-    const re = /^[-a-zA-Z\d][-\w.]{0,213}\/[-a-zA-Z\d][-\w.]{0,213}$/;
+    const parsed = parseGithubURL(prov);
 
-    // Ensure req is in the format "owner/repo" and
-    // owner and repo observe the following rules:
-    // - less than or equal to 214 characters
-    // - only URL safe characters (letters, digits, dashes, underscores and/or dots)
-    // - cannot begin with a dot or an underscore
-    // - cannot contain a space.
-    return prov.match(re) !== null ? prov : "";
+    if (typeof parsed.owner !== "string" || typeof parsed.name !== "string") {
+      return "";
+    }
+
+    const re = /^[^._ ][^ ]{0,213}&/;
+    // Ensure both the name and owner:
+    //  - less than or equal to 214 characters
+    //  - cannot begin with a dot or an underscore
+    //  - cannot contain a space
+
+    if (parsed.owner.match(re) === null || parsed.name.match(re) === null) {
+      return "";
+    }
+
+    return prov;
   },
 };

--- a/tests/http/postPackages.test.js
+++ b/tests/http/postPackages.test.js
@@ -36,7 +36,7 @@ describe("POST /api/packages Behaves as expected", () => {
 
     const sso = await endpoint.logic(
       {
-        repository: "",
+        repository: false,
         auth: "valid-token",
       },
       localContext
@@ -63,7 +63,7 @@ describe("POST /api/packages Behaves as expected", () => {
 
     const sso = await endpoint.logic(
       {
-        repository: "bad-format",
+        repository: false,
         auth: "valid-token",
       },
       localContext

--- a/tests/unit/query.test.js
+++ b/tests/unit/query.test.js
@@ -106,6 +106,7 @@ const repositoryCases = [
   [{ query: { repository: "owner/repo" } }, "owner/repo"],
   [{ query: {} }, ""],
   [{ query: { repository: "InvalidRepo" } }, ""],
+  [{ query: { repository: "git@github.com:ndr-brt/pulsar-p5js" } }, "git@github.com:ndr-brt/pulsar-p5js"],
 ];
 
 describe("Verify Repo Query Returns", () => {

--- a/tests/unit/query.test.js
+++ b/tests/unit/query.test.js
@@ -104,8 +104,8 @@ describe("Verify Auth Query Returns", () => {
 
 const repositoryCases = [
   [{ query: { repository: "owner/repo" } }, "owner/repo"],
-  [{ query: {} }, ""],
-  [{ query: { repository: "InvalidRepo" } }, ""],
+  [{ query: {} }, false],
+  [{ query: { repository: "InvalidRepo" } }, false],
   [{ query: { repository: "git@github.com:ndr-brt/pulsar-p5js" } }, "git@github.com:ndr-brt/pulsar-p5js"],
 ];
 


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

Previously the repository parameter validation was rather strict, using custom regex that would only accept a repository declared as `owner/repo` format. But since the parameter is taken directly from a user's `package.json` `repository` key, there's many different formats this could exist as.

To ensure we support any valid format for a repository, I've moved this parameter away from the custom regex (there is still some custom regex to validate characters used and length limits, as those aren't present in the upstream module) to instead use `parse-github-url` and validate what that module says are the `owner` and `repo` from the provided URL.

Additionally, with this change I've ensured the publish endpoint can support any valid repository as well with the same module.
