### PR TITLE
Fix skip non-semver tag names, instead of crashing

### DIFF
--- a/src/models/constructNewPackagePublishData.js
+++ b/src/models/constructNewPackagePublishData.js
@@ -63,7 +63,7 @@ module.exports = function constructNewPackagePublishData(opts = {}) {
 
   for (let i = 0; i < opts.tags.length; i++) {
     let curVer = semver.clean(opts.tags[i].name);
-    if (curVer !== LATEST_VER) {
+    if (curVer && curVer !== LATEST_VER) {
       out.versions[curVer] = buildAbsentVer(curVer, opts);
     }
   }


### PR DESCRIPTION
As discussed in discord:
If a tag name is not a valid semver number, it gets cleaned to `null`. I propose to just skip offending tag names.
Please check if it has other consequences, I don't know.

Alternatively, the check could be made more explicit:
```diff
     let curVer = semver.clean(opts.tags[i].name);
-    if (curVer && curVer !== LATEST_VER) {
+    if (curVer !== null && curVer !== LATEST_VER) {
       out.versions[curVer] = buildAbsentVer(curVer, opts);
     }
```