### PR TITLE
Update `bundled.json` for displaying built in package details

### DIFF
--- a/scripts/tools/update-bundled.js
+++ b/scripts/tools/update-bundled.js
@@ -16,11 +16,6 @@ const REPOS = [
     isPulsar: true,
   },
   {
-    name: "snippets",
-    url: "https://github.com/pulsar-edit/snippets",
-    isPulsar: false,
-  },
-  {
     name: "github",
     url: "https://github.com/pulsar-edit/github",
     isPulsar: false,

--- a/src/bundled_packages/bundled.json
+++ b/src/bundled_packages/bundled.json
@@ -293,7 +293,9 @@
           "title": "File Blacklist",
           "description": "Suggestions will not be provided for files matching this list, e.g. `*.md` for Markdown files. To blacklist more than one file extension, use comma as a separator, e.g. `*.md, *.txt` (both Markdown and text files).",
           "type": "array",
-          "default": [".*"],
+          "default": [
+            ".*"
+          ],
           "items": {
             "type": "string"
           },
@@ -368,7 +370,10 @@
           "description": "With 'Cursor' the suggestion list appears at the cursor's position. With 'Word' it appears at the beginning of the word that's being completed.",
           "type": "string",
           "default": "Word",
-          "enum": ["Word", "Cursor"],
+          "enum": [
+            "Word",
+            "Cursor"
+          ],
           "order": 15
         },
         "suppressActivationForEditorClasses": {
@@ -465,7 +470,9 @@
       "main": "./lib/autoflow",
       "description": "Format the current selection to have lines no longer than 80 characters.\n\nThis packages uses the config value of `editor.preferredLineLength` when set.",
       "activationCommands": {
-        "atom-text-editor": ["autoflow:reflow-selection"]
+        "atom-text-editor": [
+          "autoflow:reflow-selection"
+        ]
       },
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
@@ -530,7 +537,11 @@
       "theme": "syntax",
       "version": "1.6.0",
       "description": "Base16 dark theme developed for Atom, repurposed for Pulsar",
-      "keywords": ["base16", "dark", "syntax"],
+      "keywords": [
+        "base16",
+        "dark",
+        "syntax"
+      ],
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
       "engines": {
@@ -545,7 +556,11 @@
       "theme": "syntax",
       "version": "1.6.0",
       "description": "Base16 light theme developed for Atom, repurposed for Pulsar",
-      "keywords": ["base16", "light", "syntax"],
+      "keywords": [
+        "base16",
+        "light",
+        "syntax"
+      ],
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
       "engines": {
@@ -616,7 +631,11 @@
         "pairsWithExtraNewline": {
           "description": "Automatically add a newline between the pair when enter is pressed.",
           "type": "array",
-          "default": ["()", "[]", "{}"],
+          "default": [
+            "()",
+            "[]",
+            "{}"
+          ],
           "items": {
             "type": "string"
           }
@@ -652,7 +671,9 @@
       "main": "./lib/command-palette-package",
       "description": "Find and run available commands using `cmd-shift-p` (macOS) or `ctrl-shift-p` (Linux/Windows).",
       "activationCommands": {
-        "atom-workspace": ["command-palette:toggle"]
+        "atom-workspace": [
+          "command-palette:toggle"
+        ]
       },
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
@@ -874,7 +895,11 @@
         "projectSearchResultsPaneSplitDirection": {
           "type": "string",
           "default": "none",
-          "enum": ["none", "right", "down"],
+          "enum": [
+            "none",
+            "right",
+            "down"
+          ],
           "title": "Direction to open results pane",
           "description": "Direction to split the active pane when showing project search results. If 'none', the results will be shown in the active pane."
         },
@@ -1059,7 +1084,9 @@
       "description": "Jump to a specific editor line number with `ctrl-g`.",
       "license": "MIT",
       "activationCommands": {
-        "atom-text-editor": ["go-to-line:toggle"]
+        "atom-text-editor": [
+          "go-to-line:toggle"
+        ]
       },
       "repository": "https://github.com/pulsar-edit/pulsar",
       "engines": {
@@ -1093,12 +1120,13 @@
         "showOnRightSideOfStatusBar": {
           "type": "boolean",
           "default": true,
-          "description": "Show the active pane item's language on the right side of Pulsar's status bar, instead of the left."
+          "description": "Show the active pane item’s language on the right side of Pulsar’s status bar, instead of the left."
         },
         "hideDuplicateTextMateGrammars": {
           "type": "boolean",
           "default": true,
-          "description": "Hides the TextMate grammar when there is an existing Tree-sitter grammar"
+          "title": "Hide Duplicate Grammars",
+          "description": "Hides non-preferred grammars when there is more than one grammar. When checked, whichever grammar is preferred for a given scope name (TextMate or Tree-sitter) will be the only one shown. When unchecked, all grammars will always be shown in the list, regardless of the user’s settings."
         }
       }
     }
@@ -1186,7 +1214,9 @@
       "version": "0.60.20",
       "name": "language-c",
       "description": "Atom language support for C/C++",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "main": "lib/main",
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
@@ -1266,7 +1296,11 @@
       "private": true,
       "description": "C# language support for Atom",
       "repository": "https://github.com/pulsar-edit/pulsar",
-      "keywords": ["C#", "csharp", ".Net"],
+      "keywords": [
+        "C#",
+        "csharp",
+        ".Net"
+      ],
       "license": "MIT",
       "engines": {
         "atom": ">0.50.0"
@@ -1278,7 +1312,9 @@
     "metadata": {
       "name": "language-css",
       "description": "CSS support in Atom",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "version": "0.45.4",
       "engines": {
         "atom": "*",
@@ -1348,7 +1384,9 @@
       "name": "language-go",
       "description": "Go language support in Atom",
       "main": "lib/main",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "version": "0.47.3",
       "license": "MIT",
       "engines": {
@@ -1380,7 +1418,9 @@
       "main": "lib/main",
       "version": "0.53.1",
       "description": "HTML language support in Atom",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "engines": {
         "atom": "*",
         "node": ">=14"
@@ -1474,7 +1514,9 @@
       "main": "lib/main",
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "dependencies": {
         "tree-sitter-javascript": "0.19.0",
         "tree-sitter-jsdoc": "0.19.0",
@@ -1696,7 +1738,9 @@
         "node": ">=12"
       },
       "description": "Python language support in Atom",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
       "dependencies": {
@@ -1723,7 +1767,9 @@
       "name": "language-ruby",
       "version": "0.73.0",
       "description": "Ruby language support in Atom",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "engines": {
         "atom": "*",
         "node": ">=12"
@@ -1772,7 +1818,11 @@
       "name": "language-rust-bundled",
       "version": "0.1.1",
       "description": "Rust support for Pulsar",
-      "keywords": ["language", "grammar", "rust"],
+      "keywords": [
+        "language",
+        "grammar",
+        "rust"
+      ],
       "main": "lib/main.js",
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
@@ -1802,15 +1852,28 @@
     "metadata": {
       "name": "language-sass",
       "version": "0.62.2",
+      "main": "lib/main",
       "description": "Sass/SCSS language support in Atom",
       "license": "MIT",
       "engines": {
         "atom": "*",
-        "node": "*"
+        "node": ">=12"
       },
       "repository": "https://github.com/pulsar-edit/pulsar",
       "devDependencies": {
         "dedent": "^0.7.0"
+      },
+      "consumedServices": {
+        "hyperlink.injection": {
+          "versions": {
+            "0.1.0": "consumeHyperlinkInjection"
+          }
+        },
+        "todo.injection": {
+          "versions": {
+            "0.1.0": "consumeTodoInjection"
+          }
+        }
       }
     }
   },
@@ -1821,7 +1884,9 @@
       "version": "0.28.2",
       "main": "lib/main",
       "description": "ShellScript language support in Atom",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "engines": {
         "atom": "*",
         "node": ">=12"
@@ -1945,7 +2010,9 @@
       "name": "language-typescript",
       "version": "0.6.4",
       "description": "TypeScript language support in Atom",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "engines": {
         "atom": ">=1.19.1",
         "node": ">=12"
@@ -2097,7 +2164,11 @@
           "description": "Line ending to use for new files",
           "type": "string",
           "default": "OS Default",
-          "enum": ["OS Default", "LF", "CRLF"]
+          "enum": [
+            "OS Default",
+            "LF",
+            "CRLF"
+          ]
         }
       }
     }
@@ -2115,7 +2186,9 @@
         "atom": "*"
       },
       "activationCommands": {
-        "atom-workspace": ["link:open"]
+        "atom-workspace": [
+          "link:open"
+        ]
       },
       "dependencies": {
         "underscore-plus": "^1.7.0"
@@ -2123,7 +2196,7 @@
     }
   },
   "markdown-preview": {
-    "readme": "# Markdown Preview package\r\n\r\nShow the rendered HTML markdown to the right of the current editor using <kbd>ctrl-shift-m</kbd>.\r\n\r\nIt is currently enabled for `.markdown`, `.md`, `.mdown`, `.mkd`, `.mkdown`, `.ron`, and `.txt` files.\r\n\r\n![markdown-preview](https://cloud.githubusercontent.com/assets/378023/10013086/24cad23e-6149-11e5-90e6-663009210218.png)\r\n\r\n## Customize\r\n\r\nBy default Markdown Preview uses the colors of the active syntax theme. Enable `Use GitHub.com style` in the __package settings__ to make it look closer to how markdown files get rendered on github.com.\r\n\r\n![markdown-preview GitHub style](https://cloud.githubusercontent.com/assets/378023/10013087/24ccc7ec-6149-11e5-97ea-53a842a715ea.png)\r\n\r\nTo customize even further, the styling can be overridden in your `styles.less` file. For example:\r\n\r\n```css\r\n.markdown-preview.markdown-preview {\r\n  background-color: #444;\r\n}\r\n```\r\n\r\n## Syntax Highlighting Language Identifier\r\n\r\nWhile a verbose specification of Markdown, mostly, ensures the content of Markdown will look the same everywhere it's shipped, the same isn't true of code block language identifiers.\r\n\r\nA \"code block language identifier\" is the string you use to tell the Markdown renderer what code is inside a code block of your Markdown document.\r\n\r\nNearly every Markdown rendering system supports different strings to specify your language than each other. `Markdown-Preview` has implemented several valid Language Identifier systems to help ensure that your Markdown will look the same no matter where you publish it!\r\n\r\nIn the settings, you can select from a list of different popular Language Identification systems that can then be used in your code blocks. This means that they will still be valid when shipping them to whatever platform of your choice.\r\n\r\nCurrently, `Markdown-Preview` supports the following:\r\n\r\n  * Linguist: Used by GitHub (Previously the default and only language identification system)\r\n  * Chroma: Used by CodeBerg/Gitea/Hugo/Goldmark\r\n  * Rouge: Used by GitLab/Jekyll\r\n  * HighlightJS: Used by Markdown-IT/Pulsar Package Website\r\n\r\n\r\nOf course, not all Markdown content is destined to be shared, `Markdown-Preview` even lets you specify custom Language Identifiers to be used within your Markdown code blocks.\r\n\r\nThe setting `Custom Syntax Highlighting Language Identifiers` lets you define a list of custom language identifiers that match up to languages available within your Pulsar installation\r\n\r\nFor example, if you wanted to highlight your code like JavaScript by just using `j` as your Code Block language Identifier and `p` to use Python Syntax Highlighting, you could add the following to this setting:\r\n\r\n```\r\nj: source.js, p: source.python\r\n```\r\n\r\nAnd that's it, now anytime you use that language identifier it will be highlighted exactly the way you want. Of course your preference of language identification system will still be used, in addition to your custom list.\r\n",
+    "readme": "# Markdown Preview package\r\n\r\nShow the rendered HTML markdown to the right of the current editor using <kbd>ctrl-shift-m</kbd>.\r\n\r\nIt is currently enabled for `.markdown`, `.md`, `.mdown`, `.mkd`, `.mkdown`, `.ron`, and `.txt` files.\r\n\r\n![markdown-preview](https://cloud.githubusercontent.com/assets/378023/10013086/24cad23e-6149-11e5-90e6-663009210218.png)\r\n\r\n## Customize\r\n\r\nBy default Markdown Preview uses the colors of the active syntax theme. Enable **Use GitHub.com Style** in the __package settings__ to make it look closer to how markdown files get rendered on github.com.\r\n\r\n![markdown-preview GitHub style](https://cloud.githubusercontent.com/assets/378023/10013087/24ccc7ec-6149-11e5-97ea-53a842a715ea.png)\r\n\r\nWhen **Use GitHub.com Style** is selected, you can further customize the theme of the Markdown preview with the **GitHub.com Style Mode** setting. Since the GitHub website has a light theme and a dark theme, `markdown-preview` allows you to choose which theme to use when previewing your files. By default, it will use whatever mode is preferred by your system, but you can opt into “Light” or “Dark” to force it to use a particular theme.\r\n\r\nNo matter which theme you use, you can apply further customizations in your `styles.less` file. For example:\r\n\r\n```css\r\n.markdown-preview pre {\r\n  background-color: #444;\r\n}\r\n```\r\n\r\n## Language identifiers in fenced code blocks\r\n\r\nA detailed Markdown specification helps to ensure that Markdown is displayed consistently across multiple parsers. Sadly, the same isn’t true of code block language identifiers — the strings you use to tell the renderer what sort of code is inside a code block.\r\n\r\nThe CommonMark specification [explicitly avoids standardizing these identifiers](https://spec.commonmark.org/0.31.2/#info-string):\r\n\r\n> The first word of the info string is typically used to specify the language of the code sample, and rendered in the class attribute of the code tag. However, this spec does not mandate any particular treatment of the info string.\r\n\r\nThere are several valid ways to infer specific languages from language identifiers such as `js`, `less`, `coffee`,  and `c`. This package supports the following systems, configured via the **Syntax Highlighting Language Identifiers** setting:\r\n\r\n  * [Linguist](https://github.com/github-linguist/linguist): Used by GitHub (previously the default and only language identification system).\r\n  * [Chroma](https://github.com/alecthomas/chroma): Used by CodeBerg/Gitea/Hugo/Goldmark.\r\n  * [Rouge](https://github.com/rouge-ruby/rouge): Used by GitLab/Jekyll.\r\n  * [HighlightJS](https://highlightjs.org/): Used in a number of places, but most relevantly on the [Pulsar Package Registry](https://web.pulsar-edit.dev/) website.\r\n\r\nIf none of these systems meets your needs, you may specify custom language identifiers. This may not be as portable as the systems described above, but it will at least produce the desired outcome on your own system.\r\n\r\nThe setting **Custom Syntax Highlighting Language Identifiers** lets you define a list of custom language identifiers that match up to languages available within your Pulsar installation.\r\n\r\nFor example, if you wanted to map `j` to JavaScript and `p` to Python, you’d add the following text to the **Custom Syntax Highlighting Language Identifiers** field:\r\n\r\n```\r\nj: source.js, p: source.python\r\n```\r\n\r\nNow `markdown-preview` will understand what to do with fenced code blocks that begin with <code>\\`\\`\\`j</code> or <code>\\`\\`\\`p</code>. These custom identifiers will work alongside whatever system you’ve chosen with **Syntax Highlighting Language Identifiers**, but will supersede that system in the event of conflict.\r\n",
     "metadata": {
       "name": "markdown-preview",
       "version": "0.160.2",
@@ -2132,14 +2205,21 @@
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
       "engines": {
-        "atom": "*"
+        "atom": "*",
+        "node": ">=12"
+      },
+      "scripts": {
+        "generate-github-markdown-css": "node scripts/generate-github-markdown-css.js"
       },
       "dependencies": {
         "cheerio": "^1.0.0-rc.3",
+        "dedent": "^1.5.3",
         "dompurify": "^2.0.17",
         "emoji-images": "^0.1.1",
         "fs-plus": "^3.0.0",
+        "github-markdown-css": "^5.5.1",
         "marked": "5.0.3",
+        "morphdom": "^2.7.2",
         "underscore-plus": "^1.0.0",
         "yaml-front-matter": "^4.1.1"
       },
@@ -2152,25 +2232,30 @@
       "configSchema": {
         "breakOnSingleNewline": {
           "type": "boolean",
+          "order": 1,
           "default": false,
           "description": "In Markdown, a single newline character doesn't cause a line break in the generated HTML. In GitHub Flavored Markdown, that is not true. Enable this config option to insert line breaks in rendered HTML for single newlines in Markdown source."
         },
         "liveUpdate": {
           "type": "boolean",
+          "order": 2,
           "default": true,
           "description": "Re-render the preview as the contents of the source changes, without requiring the source buffer to be saved. If disabled, the preview is re-rendered only when the buffer is saved to disk."
         },
         "openPreviewInSplitPane": {
+          "order": 3,
           "type": "boolean",
           "default": true,
           "description": "Open the preview in a split pane. If disabled, the preview is opened in a new tab in the same pane."
         },
         "allowUnsafeProtocols": {
+          "order": 4,
           "type": "boolean",
           "default": false,
           "description": "Allow HTML attributes to use protocols normally considered unsafe such as `file://` and absolute paths on Windows."
         },
         "grammars": {
+          "order": 0,
           "type": "array",
           "default": [
             "source.gfm",
@@ -2183,12 +2268,36 @@
           "description": "List of scopes for languages for which previewing is enabled. See [this README](https://github.com/pulsar-edit/spell-check#readme) for more information on finding the correct scope for a specific language."
         },
         "useGitHubStyle": {
-          "title": "Use GitHub.com style",
+          "order": 5,
+          "title": "Use GitHub.com Style",
           "type": "boolean",
           "default": false,
           "description": "Use the same CSS styles for preview as the ones used on GitHub.com."
         },
+        "gitHubStyleMode": {
+          "order": 6,
+          "title": "GitHub.com Style Mode",
+          "type": "string",
+          "default": "auto",
+          "description": "Whether to use light-mode GitHub CSS, dark-mode GitHub CSS, or system default (based on your operating system preferences). Has no effect unless **Use GitHub.com Style** is enabled.",
+          "enum": [
+            {
+              "value": "auto",
+              "description": "System Default"
+            },
+            {
+              "value": "light",
+              "description": "Light"
+            },
+            {
+              "value": "dark",
+              "description": "Dark"
+            }
+          ]
+        },
         "syntaxHighlightingLanguageIdentifier": {
+          "order": 7,
+          "title": "Syntax Highlighting Language Identifiers",
           "description": "Syntax Highlighting System to use for code block language identification. See [the README](https://github.com/pulsar-edit/pulsar/tree/master/packages/markdown-preview#readme) for details.",
           "type": "string",
           "default": "linguist",
@@ -2212,14 +2321,14 @@
           ]
         },
         "customSyntaxHighlightingLanguageIdentifiers": {
-          "description": "Custom comma seperated list of Syntax Language Identifiers to map to any language. See [the README](https://github.com/pulsar-edit/pulsar/tree/master/packages/markdown-preview#readme) for usage.",
+          "description": "Comma-separated list of syntax language identifiers to map to any language. See [the README](https://github.com/pulsar-edit/pulsar/tree/master/packages/markdown-preview#readme) for usage.",
           "type": "string",
           "default": ""
         },
         "useOriginalParser": {
-          "description": "Wether to use the original Markdown Parser, or the new Pulsar one.",
+          "description": "When checked, will use the original Markdown parser for `markdown-preview` (`marked`). When unchecked, will use the new Markdown parser built into Pulsar (`markdown-it`).",
           "type": "boolean",
-          "default": "true"
+          "default": true
         }
       }
     }
@@ -2271,7 +2380,11 @@
       "theme": "syntax",
       "version": "1.8.4",
       "description": "A dark syntax theme",
-      "keywords": ["dark", "blue", "syntax"],
+      "keywords": [
+        "dark",
+        "blue",
+        "syntax"
+      ],
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
       "engines": {
@@ -2286,7 +2399,11 @@
       "theme": "ui",
       "version": "1.12.5",
       "description": "Pulsar One dark UI theme",
-      "keywords": ["dark", "adaptive", "ui"],
+      "keywords": [
+        "dark",
+        "adaptive",
+        "ui"
+      ],
       "license": "MIT",
       "repository": "https://github.com/pulsar-edit/pulsar",
       "main": "lib/main",
@@ -2299,7 +2416,19 @@
           "description": "Change the font size for the UI.",
           "type": "integer",
           "default": 12,
-          "enum": [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+          "enum": [
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20
+          ],
           "order": 1
         },
         "tabSizing": {
@@ -2307,7 +2436,11 @@
           "description": "In Even mode all tabs will be the same size. Great for quickly closing many tabs. In Maximum mode the tabs will expand to take up the full width. In Minimum mode the tabs will only take as little space as needed and also show longer file names.",
           "type": "string",
           "default": "Even",
-          "enum": ["Even", "Maximum", "Minimum"],
+          "enum": [
+            "Even",
+            "Maximum",
+            "Minimum"
+          ],
           "order": 2
         },
         "tabCloseButton": {
@@ -2315,7 +2448,10 @@
           "description": "Choose the position of the close button shown in tabs.",
           "type": "string",
           "default": "Right",
-          "enum": ["Left", "Right"],
+          "enum": [
+            "Left",
+            "Right"
+          ],
           "order": 3
         },
         "hideDockButtons": {
@@ -2341,7 +2477,10 @@
       "theme": "syntax",
       "version": "1.8.4",
       "description": "One light syntax theme developed for Atom, repurposed for Pulsar",
-      "keywords": ["light", "syntax"],
+      "keywords": [
+        "light",
+        "syntax"
+      ],
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
       "engines": {
@@ -2356,7 +2495,11 @@
       "theme": "ui",
       "version": "1.12.5",
       "description": "One light UI theme developed for Atom, repurposed for Pulsar",
-      "keywords": ["light", "adaptive", "ui"],
+      "keywords": [
+        "light",
+        "adaptive",
+        "ui"
+      ],
       "license": "MIT",
       "repository": "https://github.com/pulsar-edit/pulsar",
       "main": "lib/main",
@@ -2369,7 +2512,19 @@
           "description": "Change the font size for the UI.",
           "type": "integer",
           "default": 12,
-          "enum": [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+          "enum": [
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20
+          ],
           "order": 1
         },
         "tabSizing": {
@@ -2377,7 +2532,11 @@
           "description": "In Even mode all tabs will be the same size. Great for quickly closing many tabs. In Maximum mode the tabs will expand to take up the full width. In Minimum mode the tabs will only take as little space as needed and also show longer file names.",
           "type": "string",
           "default": "Even",
-          "enum": ["Even", "Maximum", "Minimum"],
+          "enum": [
+            "Even",
+            "Maximum",
+            "Minimum"
+          ],
           "order": 2
         },
         "tabCloseButton": {
@@ -2385,7 +2544,10 @@
           "description": "Choose the position of the close button shown in tabs.",
           "type": "string",
           "default": "Right",
-          "enum": ["Left", "Right"],
+          "enum": [
+            "Left",
+            "Right"
+          ],
           "order": 3
         },
         "hideDockButtons": {
@@ -2475,7 +2637,10 @@
         "packageSyntax": {
           "default": "javascript",
           "type": "string",
-          "enum": ["coffeescript", "javascript"],
+          "enum": [
+            "coffeescript",
+            "javascript"
+          ],
           "description": "The syntax to generate packages with."
         }
       }
@@ -2585,6 +2750,40 @@
       },
       "deserializers": {
         "SettingsView": "createSettingsView"
+      }
+    }
+  },
+  "snippets": {
+    "readme": "# Snippets package\r\n\r\nExpand snippets matching the current prefix with <kbd>tab</kbd> in Pulsar.\r\n\r\nTo add your own snippets, select the _Pulsar > Snippets..._ menu option if you're using macOS, or the _File > Snippets..._ menu option if you're using Windows, or the _Edit > Snippets..._ menu option if you are using Linux.\r\n\r\n## Snippet Format\r\n\r\nSnippets files are stored in a package's `snippets/` folder and also loaded from `~/.pulsar/snippets.cson`. They can be either `.json` or `.cson` file types.\r\n\r\n```coffee\r\n'.source.js':\r\n  'console.log':\r\n    'prefix': 'log'\r\n    'command': 'insert-console-log'\r\n    'body': 'console.log(${1:\"crash\"});$2'\r\n```\r\n\r\nThe outermost keys are the selectors where these snippets should be active, prefixed with a period (`.`) (details below).\r\n\r\nThe next level of keys are the snippet names. Because this is object notation, each snippet must have a different name.\r\n\r\nUnder each snippet name is a `body` to insert when the snippet is triggered.\r\n\r\n`$` followed by a number are the tabs stops which can be cycled between by pressing <kbd>Tab</kbd> once a snippet has been triggered.\r\n\r\nThe above example adds a `console.log` snippet to JavaScript files that would expand to:\r\n\r\n```js\r\nconsole.log(\"crash\");\r\n```\r\n\r\nThe string `\"crash\"` would be initially selected and pressing tab again would place the cursor after the `;`\r\n\r\nA snippet specifies how it can be triggered. Thus it must provide **at least one** of the following keys:\r\n\r\n### The ‘prefix’ key\r\n\r\nIf a `prefix` is defined, it specifies a string that can trigger the snippet. In the above example, typing `log` (as its own word) and then pressing <kbd>Tab</kbd> would replace `log` with the string `console.log(\"crash\")` as described above.\r\n\r\nPrefix completions can be suggested if partially typed thanks to the `autocomplete-snippets` package.\r\n\r\n### The ‘command’ key\r\n\r\nIf a `command` is defined, it specifies a command name that can trigger the snippet. That command can be invoked from the command palette or mapped to a keyboard shortcut via your `keymap.cson`.\r\n\r\nIf a package called `some-package` had defined that snippet, it would be available in the keymap as `some-package:insert-console-log`, or in the command palette as **Some Package: Insert Console Log**.\r\n\r\nIf you defined the `console.log` snippet described above in your own `snippets.cson`, it could be referenced in a keymap file as `snippets:insert-console-log`, or in the command palette as **Snippets: Insert Console Log**.\r\n\r\nInvoking the command would insert the snippet at the cursor, replacing any text that may be selected.\r\n\r\nSnippet command names must be unique. They can’t conflict with each other, nor can they conflict with any other commands that have been defined. If there is such a conflict, you’ll see an error notification describing the problem.\r\n\r\n### Optional parameters\r\n\r\nThese parameters are meant to provide extra information about your snippet to [autocomplete-plus](https://github.com/atom/autocomplete-plus/wiki/Provider-API).\r\n\r\n* `leftLabel` will add text to the left part of the autocomplete results box.\r\n* `leftLabelHTML` will overwrite what's in `leftLabel` and allow you to use a bit of CSS such as `color`.\r\n* `rightLabelHTML`. By default, in the right part of the results box you will see the name of the snippet. When using `rightLabelHTML` the name of the snippet will no longer be displayed, and you will be able to use a bit of CSS.\r\n* `description` will add text to a description box under the autocomplete results list.\r\n* `descriptionMoreURL` URL to the documentation of the snippet.\r\n\r\n![autocomplete-description](http://i.imgur.com/cvI2lOq.png)\r\n\r\nExample:\r\n```coffee\r\n'.source.js':\r\n  'console.log':\r\n    'prefix': 'log'\r\n    'body': 'console.log(${1:\"crash\"});$2'\r\n    'description': 'Output data to the console'\r\n    'rightLabelHTML': '<span style=\"color:#ff0\">JS</span>'\r\n```\r\n\r\n### Determining the correct scope for a snippet\r\n\r\nThe outmost key of a snippet is the “scope” that you want the descendent snippets to be available in. The key should be prefixed with a period (`text.html.basic` → `.text.html.basic`). You can find out the correct scope by opening the Settings (<kbd>cmd-,</kbd> on macOS) and selecting the corresponding *Language [xxx]* package. For example, here’s the settings page for `language-html`:\r\n\r\n![Screenshot of Language Html settings](https://cloud.githubusercontent.com/assets/1038121/5137632/126beb66-70f2-11e4-839b-bc7e84103f67.png)\r\n\r\nIf it's difficult to determine the package handling the file type in question (for example, for `.md`-documents), you can use another approach:\r\n\r\n1. Put your cursor in a file in which you want the snippet to be available.\r\n2. Open the [Command Palette](https://github.com/pulsar-edit/command-palette)\r\n(<kbd>cmd-shift-p</kbd> or <kbd>ctrl-shift-p</kbd>).\r\n3. Run the `Editor: Log Cursor Scope` command.\r\n\r\nThis will trigger a notification which will contain a list of scopes. The first scope that's listed is the scope for that language. Here are some examples: `source.coffee`, `text.plain`, `text.html.basic`.\r\n\r\n## Snippet syntax\r\n\r\nThis package supports a subset of the features of TextMate snippets, [documented here](http://manual.macromates.com/en/snippets), as well as most features described in the [LSP specification][lsp] and [supported by VSCode][vscode].\r\n\r\nThe following features from TextMate snippets are not yet supported:\r\n\r\n* Interpolated shell code can’t reliably be supported cross-platform, and is probably a bad idea anyway. No other editors that support snippets have adopted this feature, and Pulsar won’t either.\r\n\r\nThe following features from VSCode snippets are not yet supported:\r\n\r\n* “Choice” syntax like `${1|one,two,three|}` requires that the autocomplete engine pop up a menu to offer the user a choice between the available placeholder options. This may be supported in the future, but right now Pulsar effectively converts this to `${1:one}`, treating the first choice as a conventional placeholder.\r\n\r\n### Variables\r\n\r\nPulsar snippets support all of the variables mentioned in the [LSP specification][lsp], plus many of the variables [supported by VSCode][vscode].\r\n\r\nVariables can be referenced with `$`, either without braces (`$CLIPBOARD`) or with braces (`${CLIPBOARD}`). Variables can also have fallback values (`${CLIPBOARD:http://example.com}`), simple flag-based transformations (`${CLIPBOARD:/upcase}`), or `sed`-style transformations (`${CLIPBOARD/ /_/g}`).\r\n\r\nOne of the most useful is `TM_SELECTED_TEXT`, which represents whatever text was selected when the snippet was invoked. (Naturally, this can only happen when a snippet is invoked via command or key shortcut, rather than by typing in a <kbd>Tab</kbd> trigger.)\r\n\r\nOthers that can be useful:\r\n\r\n* `TM_FILENAME`: The name of the current file (`foo.rb`).\r\n* `TM_FILENAME_BASE`: The name of the current file, but without its extension (`foo`).\r\n* `TM_FILEPATH`: The entire path on disk to the current file.\r\n* `TM_CURRENT_LINE`: The entire current line that the cursor is sitting on.\r\n* `TM_CURRENT_WORD`: The entire word that the cursor is within or adjacent to, as interpreted by `cursor.getCurrentWordBufferRange`.\r\n* `CLIPBOARD`: The current contents of the clipboard.\r\n* `CURRENT_YEAR`, `CURRENT_MONTH`, et cetera: referneces to the current date and time in various formats.\r\n* `LINE_COMMENT`, `BLOCK_COMMENT_START`, `BLOCK_COMMENT_END`: uses the correct comment delimiters for whatever language you’re in.\r\n\r\nAny variable that has no value — for instance, `TM_FILENAME` on an untitled document, or `LINE_COMMENT` in a CSS file — will resolve to an empty string.\r\n\r\n#### Variable transformation flags\r\n\r\nPulsar supports the three flags defined in the [LSP snippets specification][lsp] and two other flags that are [implemented in VSCode][vscode]:\r\n\r\n* `/upcase` (`foo` → `FOO`)\r\n* `/downcase` (`BAR` → `bar`)\r\n* `/capitalize` (`lorem ipsum dolor` → `Lorem ipsum dolor`) *(first letter uppercased; rest of input left intact)*\r\n* `/camelcase` (`foo bar` → `fooBar`, `lorem-ipsum.dolor` → `loremIpsumDolor`)\r\n* `/pascalcase` (`foo bar` → `FooBar`, `lorem-ipsum.dolor` → `LoremIpsumDolor`)\r\n\r\nIt also supports two other common transformations:\r\n\r\n* `/snakecase` (`foo bar` → `foo_bar`, `lorem-ipsum.dolor` → `lorem_ipsum_dolor`)\r\n* `/kebabcase` (`foo bar` → `foo-bar`, `lorem-ipsum.dolor` → `lorem-ipsum-dolor`)\r\n\r\nThese transformation flags can also be applied on backreferences in `sed`-style replacements for transformed tab stops. Given the following example snippet body…\r\n\r\n```\r\n[$1] becomes [${1/(.*)/${1:/upcase}/}]\r\n```\r\n\r\n…invoking the snippet and typing `Lorem ipsum dolor` will produce:\r\n\r\n```\r\n[Lorem ipsum dolor] becomes [LOREM IPSUM DOLOR]\r\n```\r\n\r\n\r\n#### Variable caveats\r\n\r\n* `WORKSPACE_NAME`, `WORKSPACE_FOLDER`, and `RELATIVE_PATH` all rely on the presence of a root project folder, but a Pulsar project can technically have multiple root folders. While this is rare, it is handled by `snippets` as follows: whichever project path is an ancestor of the currently active file is treated as the project root — or the first one found if multiple roots are ancestors.\r\n* `WORKSPACE_NAME` in VSCode refers to “the name of the opened workspace or folder.” In the former case, this appears to mean bundled projects with a `.code-workspace` file extension — which have no Pulsar equivalent. Instead, `WORKSPACE_NAME` will always refer to the last path component of your project’s root directory as defined above.\r\n\r\n#### Variables that are not yet supported\r\n\r\nOf the variables supported by VSCode, Pulsar does not yet support:\r\n\r\n* `UUID` (Will automatically be supported when Pulsar uses a version of Electron that has native `crypto.randomUUID`.)\r\n\r\n## Multi-line Snippet Body\r\n\r\nYou can also use multi-line syntax using `\"\"\"` for larger templates:\r\n\r\n```coffee\r\n'.source.js':\r\n  'if, else if, else':\r\n    'prefix': 'ieie'\r\n    'body': \"\"\"\r\n      if (${1:true}) {\r\n        $2\r\n      } else if (${3:false}) {\r\n        $4\r\n      } else {\r\n        $5\r\n      }\r\n    \"\"\"\r\n```\r\n\r\n## Escaping Characters\r\n\r\nIncluding a literal closing brace inside the text provided by a snippet's tab stop will close that tab stop early. To prevent that, escape the brace with two backslashes, like so:\r\n\r\n```coffee\r\n'.source.js':\r\n  'function':\r\n    'prefix': 'funct'\r\n    'body': \"\"\"\r\n      ${1:function () {\r\n        statements;\r\n      \\\\}\r\n      this line is also included in the snippet tab;\r\n      }\r\n      \"\"\"\r\n```\r\n\r\nLikewise, if your snippet includes literal references to `$` or `{`, you may have to escape those with two backslashes as well, depending on the context.\r\n\r\n## Multiple snippets for the same scope\r\n\r\nSnippets for the same scope must be placed within the same key. See [this section of the Pulsar Flight Manual](https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#configuring-with-cson) for more information.\r\n\r\n\r\n[lsp]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#variables\r\n[vscode]: https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables\r\n",
+    "metadata": {
+      "name": "snippets",
+      "version": "1.8.0",
+      "main": "./lib/snippets",
+      "description": "Expand snippets matching the current prefix with `tab`.",
+      "repository": "https://github.com/pulsar-edit/pulsar",
+      "license": "MIT",
+      "engines": {
+        "atom": "*"
+      },
+      "dependencies": {
+        "async": "~0.2.6",
+        "atom-select-list": "^0.7.0",
+        "pegjs": "^0.10.0",
+        "scoped-property-store": "^0.17.0",
+        "season": "^6.0.2",
+        "temp": "~0.8.0",
+        "underscore-plus": "^1.0.0"
+      },
+      "providedServices": {
+        "snippets": {
+          "description": "Snippets are text shortcuts that can be expanded to their definition.",
+          "versions": {
+            "0.1.0": "provideSnippets"
+          }
+        }
+      },
+      "devDependencies": {
+        "eslint": "^8.35.0"
       }
     }
   },
@@ -2869,7 +3068,7 @@
     }
   },
   "symbol-provider-tree-sitter": {
-    "readme": "# symbol-provider-tree-sitter package\r\n\r\nProvides symbols to `symbols-view` via Tree-sitter queries.\r\n\r\nTree-sitter grammars [with tags queries](https://tree-sitter.github.io/tree-sitter/code-navigation-systems) can very easily give us a list of all the symbols in a file without the drawbacks of a `ctags`-based approach. For instance, they operate on the contents of the buffer, not the contents of the file on disk, so they work just fine in brand-new files and in files that have been modified since the last save.\r\n\r\nThis provider does not currently support project-wide symbol search, but possibly could do so in the future.\r\n\r\n## Tags queries\r\n\r\nThis provider expects for a grammar to have specified a tags query in its grammar definition file. All the built-in Tree-sitter grammars will have such a file. If you’re using a third-party Tree-sitter grammar that hasn’t defined one, file an issue on Pulsar and we’ll see what we can do.\r\n\r\nIf you’re writing your own grammar, or contributing a `tags.scm` to a grammar without one, keep reading.\r\n\r\n### Query syntax\r\n\r\nThe query syntax starts as a subset of what is described [on this page](https://tree-sitter.github.io/tree-sitter/code-navigation-systems). Here’s what this package can understand:\r\n\r\n* A query that consists of a `@definition.THING` capture with a `@name` capture inside will properly be understood as a symbol with a tag corresponding to `THING` and a name corresponding to the `@name` capture’s text.\r\n* A query that consists of a `@reference.THING` capture with a `@name` capture inside will be ignored by default. If the proper setting is enabled, each of these references will become a symbol with a tag corresponding to `THING` and a name corresponding to the `@name` capture’s text.\r\n* All other `@name` captures that are not within either a `@definition` or a `@reference` will be considered as a symbol in isolation. (These symbols can still specify a tag via a `#set!` predicate.)\r\n\r\nTo match the current behavior of the `symbols-view` package, you can usually take a `queries/tags.scm` file from a Tree-sitter repository — many parsers define them — and paste it straight into your grammar’s `tags.scm` file.\r\n\r\n#### Advanced features\r\n\r\nThe text of the captured node is what will be displayed as the symbol’s name, but a few predicates are available to alter that field and others. Symbol predicates use `#set!` and the `symbol` namespace.\r\n\r\n##### Node position descriptors\r\n\r\nSeveral predicates take a **node position descriptor** as an argument. It’s a string that resembles an object lookup chain in JavaScript:\r\n\r\n```scm\r\n(#set! symbol.prependTextForNode parent.parent.firstNamedChild)\r\n```\r\n\r\nStarting at the captured node, it describes a path to take within the tree in order to get to another meaningful node.\r\n\r\nIn all these examples, if the descriptor is invalid and does not return a node, the predicate will be ignored.\r\n\r\n##### Changing the symbol’s name\r\n\r\nThere are several ways to add text to the beginning or end of the symbol’s name:\r\n\r\n###### symbol.prepend\r\n\r\n```scm\r\n(class_declaration\r\n  name: (identifier) @name\r\n  (#set! symbol.prepend \"Class: \"))\r\n```\r\n\r\nThe `symbol.prepend` predicate adds a constant string to the beginning of a symbol name. For a class `Foo` in JavaScript, this predicate would result in a symbol called `Class: Foo`.\r\n\r\n###### symbol.append\r\n\r\n```scm\r\n(class_declaration\r\n  name: (identifier) @name\r\n  (#set! symbol.append \" (class)\"))\r\n```\r\n\r\nThe `symbol.append` predicate adds a constant string to the end of a symbol name. For a class `Foo`, this predicate would result in a symbol called `Foo (class)`.\r\n\r\n\r\n###### symbol.strip\r\n\r\n```scm\r\n(class_declaration\r\n  name: (identifier) @name\r\n  (#set! symbol.strip \"^\\\\s+|\\\\s+$\"))\r\n```\r\n\r\nThe `symbol.strip` predicate will replace everything matched by the regular expression with an empty string. The pattern given is compiled into a JavaScript `RegExp` with an implied `g` (global) flag.\r\n\r\nIn this example, _if_ the `identifier` node included whitespace on either side of the symbol, the symbol’s name would be stripped of that whitespace before being shown in the UI.\r\n\r\n###### symbol.prependTextForNode\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.prependTextForNode \"parent.parent.previousNamedSibling\")\r\n  (#set! symbol.joiner \"#\")\r\n))\r\n```\r\n\r\nThe `symbol.prependTextForNode` predicate will look up the text of the node referred to by the provided _node position descriptor_, then prepend that text to the symbol name. If `symbol.joiner` is provided, it will be inserted in between the two.\r\n\r\nIn this example, a `bar` method on a class named `Foo` would have a symbol name of `Foo#bar`.\r\n\r\n###### symbol.prependSymbolForNode\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.prependSymbolForNode \"parent.parent.previousNamedSibling\")\r\n  (#set! symbol.joiner \"#\")\r\n))\r\n```\r\n\r\nThe `symbol.prependSymbolForNode` predicate will look up the symbol name of the node referred to by the provided _node position descriptor_, then prepend that name to the symbol name. If `symbol.joiner` is provided, it will be inserted in between the two.\r\n\r\nUnlike `symbol.prependTextForNode`, the node referred to with the descriptor must have its own symbol name, and it must have been processed already — that is, it must be a symbol whose name was determined earlier than that of the current node.\r\n\r\nThis allows us to incorporate any transformations that were applied to the other node’s symbol name. We can use this to build “recursive” symbol names — for instance, JSON keys whose symbols consist of their entire key path from the root.\r\n\r\n##### Adding the `context` field\r\n\r\nThe `context` field of a symbol is a short piece of text meant to give context. For instance, a symbol that represents a class method could have a `context` field that contains the name of the owning class. The `context` field is not filtered on.\r\n\r\n###### symbol.contextNode\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.contextNode \"parent.parent.previousNamedSibling\")\r\n))\r\n```\r\n\r\nThe `symbol.contextNode` predicate will set the value of a symbol’s `context` property to the text of a node based on the provided _node position descriptor_.\r\n\r\n###### symbol.context\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.context \"class\")\r\n))\r\n```\r\n\r\nThe `symbol.context` predicate will set the value of a symbol’s `context` property to a fixed string.\r\n\r\nThe point of `context` is to provide information to help you tell symbols apart, so you probably don’t want to set it to a fixed value. But this predicate is available just in case.\r\n\r\n##### Adding a tag\r\n\r\nThe `tag` field is a string (ideally a short string) that indicates a symbol’s kind or type. A `tag` for a class method’s symbol might say `method`, whereas the symbol for the class itself might have a `tag` of `class`. These tags will be indicated in the UI with a badge or an icon.\r\n\r\nThe preferred method of adding a tag is to leverage the `@definition.` captures that are typically present in a tags file. For instance, in this excerpt from the JavaScript grammar’s `tags.scm` file…\r\n\r\n```scm\r\n(assignment_expression\r\n  left: [\r\n    (identifier) @name\r\n    (member_expression\r\n      property: (property_identifier) @name)\r\n  ]\r\n  right: [(arrow_function) (function)]\r\n) @definition.function\r\n```\r\n\r\n…the resulting symbol will infer a `tag` value of `function`.\r\n\r\nIn cases where this is impractical, you can provide the tag explicitly with a predicate.\r\n\r\n###### symbol.icon\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.icon \"package\")\r\n))\r\n```\r\n\r\nThe icon to be shown alongside the symbol in a list. Will only be shown if the user has enabled the “Show Icons in Symbols View” option in the `symbols-view` settings. You can see the full list of available icons by invoking the **Styleguide: Show** command and browsing the “Icons” section. The value can include the preceding `icon-` or can omit it; e.g., `icon-package` and `package` are both valid values.\r\n\r\nIf this value is omitted, this provider will still attempt to match certain common tag values to icons. If `tag` is not present on the symbol, or is an uncommon value, there will be a blank space instead of an icon.\r\n\r\n###### symbol.tag\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.tag \"class\")\r\n))\r\n```\r\n\r\nThe `symbol.tag` predicate will set the value of a symbol’s `tag` property to a fixed string.\r\n\r\nThe `tag` property is used to supply a word that represents the symbol in some way. For conventional symbols, this will often be something like `class` or `function`.\r\n",
+    "readme": "# symbol-provider-tree-sitter package\r\n\r\nProvides symbols to `symbols-view` via Tree-sitter queries.\r\n\r\nTree-sitter grammars [with tags queries](https://tree-sitter.github.io/tree-sitter/code-navigation-systems) can very easily give us a list of all the symbols in a file without the drawbacks of a `ctags`-based approach. For instance, they operate on the contents of the buffer, not the contents of the file on disk, so they work just fine in brand-new files and in files that have been modified since the last save.\r\n\r\nThis provider does not currently support project-wide symbol search, but possibly could do so in the future.\r\n\r\n## Tags queries\r\n\r\nThis provider expects for a grammar to have specified a tags query in its grammar definition file. All the built-in Tree-sitter grammars will have such a file. If you’re using a third-party Tree-sitter grammar that hasn’t defined one, file an issue on Pulsar and we’ll see what we can do.\r\n\r\nIf you’re writing your own grammar, or contributing a `tags.scm` to a grammar without one, keep reading.\r\n\r\n### Query syntax\r\n\r\nThe query syntax starts as a subset of what is described [on this page](https://tree-sitter.github.io/tree-sitter/code-navigation-systems). Here’s what this package can understand:\r\n\r\n* A query that consists of a `@definition.THING` capture with a `@name` capture inside will properly be understood as a symbol with a tag corresponding to `THING` and a name corresponding to the `@name` capture’s text.\r\n* A query that consists of a `@reference.THING` capture with a `@name` capture inside will be ignored by default. If the proper setting is enabled, each of these references will become a symbol with a tag corresponding to `THING` and a name corresponding to the `@name` capture’s text.\r\n* All other `@name` captures that are not within either a `@definition` or a `@reference` will be considered as a symbol in isolation. (These symbols can still specify a tag via a `#set!` predicate.)\r\n\r\nTo match the current behavior of the `symbols-view` package, you can usually take a `queries/tags.scm` file from a Tree-sitter repository — many parsers define them — and paste it straight into your grammar’s `tags.scm` file.\r\n\r\n#### Advanced features\r\n\r\nThe text of the captured node is what will be displayed as the symbol’s name, but a few predicates are available to alter that field and others. Symbol predicates use `#set!` and the `symbol` namespace.\r\n\r\n##### Node position descriptors\r\n\r\nSeveral predicates take a **node position descriptor** as an argument. It’s a string that resembles an object lookup chain in JavaScript:\r\n\r\n```scm\r\n(#set! symbol.prependTextForNode parent.parent.firstNamedChild)\r\n```\r\n\r\nStarting at the captured node, it describes a path to take within the tree in order to get to another meaningful node.\r\n\r\nIn all these examples, if the descriptor is invalid and does not return a node, the predicate will be ignored.\r\n\r\n##### Changing the symbol’s name\r\n\r\nThere are several ways to add text to the beginning or end of the symbol’s name:\r\n\r\n###### symbol.prepend\r\n\r\n```scm\r\n(class_declaration\r\n  name: (identifier) @name\r\n  (#set! symbol.prepend \"Class: \"))\r\n```\r\n\r\nThe `symbol.prepend` predicate adds a constant string to the beginning of a symbol name. For a class `Foo` in JavaScript, this predicate would result in a symbol called `Class: Foo`.\r\n\r\n###### symbol.append\r\n\r\n```scm\r\n(class_declaration\r\n  name: (identifier) @name\r\n  (#set! symbol.append \" (class)\"))\r\n```\r\n\r\nThe `symbol.append` predicate adds a constant string to the end of a symbol name. For a class `Foo`, this predicate would result in a symbol called `Foo (class)`.\r\n\r\n\r\n###### symbol.strip\r\n\r\n```scm\r\n(class_declaration\r\n  name: (identifier) @name\r\n  (#set! symbol.strip \"^\\\\s+|\\\\s+$\"))\r\n```\r\n\r\nThe `symbol.strip` predicate will replace everything matched by the regular expression with an empty string. The pattern given is compiled into a JavaScript `RegExp` with an implied `g` (global) flag.\r\n\r\nIn this example, _if_ the `identifier` node included whitespace on either side of the symbol, the symbol’s name would be stripped of that whitespace before being shown in the UI.\r\n\r\n###### symbol.prependTextForNode\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.prependTextForNode \"parent.parent.previousNamedSibling\")\r\n  (#set! symbol.joiner \"#\")\r\n))\r\n```\r\n\r\nThe `symbol.prependTextForNode` predicate will look up the text of the node referred to by the provided _node position descriptor_, then prepend that text to the symbol name. If `symbol.joiner` is provided, it will be inserted in between the two.\r\n\r\nIn this example, a `bar` method on a class named `Foo` would have a symbol name of `Foo#bar`.\r\n\r\n###### symbol.prependSymbolForNode\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.prependSymbolForNode \"parent.parent.previousNamedSibling\")\r\n  (#set! symbol.joiner \"#\")\r\n))\r\n```\r\n\r\nThe `symbol.prependSymbolForNode` predicate will look up the symbol name of the node referred to by the provided _node position descriptor_, then prepend that name to the symbol name. If `symbol.joiner` is provided, it will be inserted in between the two.\r\n\r\nUnlike `symbol.prependTextForNode`, the node referred to with the descriptor must have its own symbol name, and it must have been processed already — that is, it must be a symbol whose name was determined earlier than that of the current node.\r\n\r\nThis allows us to incorporate any transformations that were applied to the other node’s symbol name. We can use this to build “recursive” symbol names — for instance, JSON keys whose symbols consist of their entire key path from the root.\r\n\r\n##### Adding the `context` field\r\n\r\nThe `context` field of a symbol is a short piece of text meant to give context. For instance, a symbol that represents a class method could have a `context` field that contains the name of the class it belongs to. The `context` field is not filtered on.\r\n\r\n###### symbol.contextNode\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.contextNode \"parent.parent.previousNamedSibling\")\r\n))\r\n```\r\n\r\nThe `symbol.contextNode` predicate will set the value of a symbol’s `context` property to the text of a node based on the provided _node position descriptor_.\r\n\r\n###### symbol.context\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.context \"class\")\r\n))\r\n```\r\n\r\nThe `symbol.context` predicate will set the value of a symbol’s `context` property to a fixed string.\r\n\r\nThe point of `context` is to provide information to help you tell symbols apart, so you probably don’t want to set it to a fixed value. But this predicate is available just in case.\r\n\r\n##### Adding a tag\r\n\r\nThe `tag` field is a string that indicates a symbol’s kind or type. It should be a single word wherever possible. A `tag` for a class method’s symbol would typically be `method`, whereas the symbol for the class itself would typically have a `tag` of `class`. These tags will be indicated in the UI with a badge, an icon, or both.\r\n\r\nIf you’re not sure what to call something, consult [this list from the Language Server Protocol spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolKind). But some symbols may not fit any of those, so ultimately it’s up to the author. (For example, headings in Markdown files are assigned a kind of `heading`.)\r\n\r\nFor consistency, tags should be all lowercase. The interface will apply its own casing effect through CSS (`text-transform: capitalize` by default, but customizable in UI themes).\r\n\r\nThe preferred method of adding a tag is to leverage the `@definition.` captures that are typically present in a tags file. For instance, in this excerpt from the JavaScript grammar’s `tags.scm` file…\r\n\r\n```scm\r\n(assignment_expression\r\n  left: [\r\n    (identifier) @name\r\n    (member_expression\r\n      property: (property_identifier) @name)\r\n  ]\r\n  right: [(arrow_function) (function)]\r\n) @definition.function\r\n```\r\n\r\n…the resulting symbol will infer a `tag` value of `function`.\r\n\r\nIn cases where this is impractical, you can provide the tag explicitly with a predicate.\r\n\r\nNearly all the tags on [the aforementioned list](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolKind) will also apply an appropriate `icon` to their symbol when assigned. If you choose a tag name not on that list, or want to override the default, you can use the `symbol.icon` predicate described below.\r\n\r\n###### symbol.tag\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.tag \"class\")\r\n))\r\n```\r\n\r\nThe `symbol.tag` predicate will set the value of a symbol’s `tag` property to a fixed string.\r\n\r\nThe `tag` property is used to supply a word that represents the symbol in some way. For conventional symbols, this will often be something like `class` or `function`.\r\n\r\nThis provider will attempt to match certain common tag values to icons. This can be overridden by specifying an explicit `symbol.icon` value.\r\n\r\n###### symbol.icon\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.icon \"package\")\r\n))\r\n```\r\n\r\nThe icon to be shown alongside the symbol in a list. Will only be shown if the user has enabled the “Show Icons in Symbols View” option in the `symbols-view` settings. You can see the full list of available icons by invoking the **Styleguide: Show** command and browsing the “Icons” section. The value can include the preceding `icon-` or can omit it; e.g., `icon-package` and `package` are both valid values.\r\n\r\nIf this value is omitted, this provider will still attempt to match certain common tag values to icons. If `tag` is not present on the symbol, or is an uncommon value, there will be a blank space instead of an icon.\r\n",
     "metadata": {
       "name": "symbol-provider-tree-sitter",
       "main": "./lib/main",
@@ -2920,39 +3119,52 @@
         "quickJumpToFileSymbol": {
           "default": true,
           "type": "boolean",
+          "order": 1,
           "description": "Automatically visit selected file-symbols as you navigate the symbols list."
-        },
-        "showProviderNamesInSymbolsView": {
-          "default": false,
-          "type": "boolean",
-          "description": "When enabled, the name of the provider will be shown alongside each result."
         },
         "showIconsInSymbolsView": {
           "default": true,
           "type": "boolean",
+          "order": 2,
           "description": "When enabled, an icon will be shown alongside a symbol if the symbol provider specifies one."
+        },
+        "useBadgeColors": {
+          "default": false,
+          "type": "boolean",
+          "order": 3,
+          "description": "Whether to use an assortment of colors for symbol badges. If enabled, each badge will be one of sixteen colors based on its text. Badge colors are generated automatically as hue variants of your theme’s ordinary badge color."
+        },
+        "prefillSelectedText": {
+          "default": true,
+          "type": "boolean",
+          "order": 4,
+          "description": "When enabled, any text you may have selected in the active editor will be used as the search query in the symbols list."
+        },
+        "showProviderNamesInSymbolsView": {
+          "default": false,
+          "type": "boolean",
+          "order": 5,
+          "description": "When enabled, the name of the provider will be shown alongside each result."
         },
         "preferCertainProviders": {
           "default": [],
           "type": "array",
+          "order": 6,
           "items": {
             "type": "string"
           },
           "description": "A comma-separated list of preferred providers. Used to help break ties when more than one provider can contribute symbols. Anything on this list will be preferred over anything not on this list, and earlier items will be preferred over later items. (A provider can be identified by its official name or its package name; run the **Symbols View: Show Active Providers** command to see both values.)"
         },
-        "useBadgeColors": {
-          "default": false,
-          "type": "boolean",
-          "description": "Whether to use an assortment of colors for symbol badges. If enabled, each badge will be one of sixteen colors based on its text. Badge colors are generated automatically as hue variants of your theme’s ordinary badge color."
-        },
         "providerTimeout": {
           "default": 2000,
           "type": "number",
+          "order": 7,
           "description": "How long providers have to respond to symbol requests before this package gives up and shows the list. If a certain provider is particularly slow, you may have to increase this value. (Does not apply to project-wide symbol search **if** the list is already visible.)"
         },
         "enableDebugLogging": {
           "default": false,
           "type": "boolean",
+          "order": 10,
           "description": "Whether to log certain diagnostic information to the console. (For example: which provider is chosen for a given task.)"
         }
       },
@@ -3025,8 +3237,15 @@
           "description": "Show the tab bar even when only one tab is open."
         },
         "tabScrolling": {
-          "type": ["boolean", "string"],
-          "enum": [true, false, "platform"],
+          "type": [
+            "boolean",
+            "string"
+          ],
+          "enum": [
+            true,
+            false,
+            "platform"
+          ],
           "default": "platform",
           "description": "Jump to next or previous tab by scrolling on the tab bar."
         },
@@ -3186,7 +3405,9 @@
         "atom": ">0.39.0"
       },
       "activationCommands": {
-        "atom-workspace": ["update-package-dependencies:update"]
+        "atom-workspace": [
+          "update-package-dependencies:update"
+        ]
       },
       "consumedServices": {
         "status-bar": {
@@ -3355,46 +3576,12 @@
       }
     }
   },
-  "snippets": {
-    "readme": "# Snippets package\r\n\r\nExpand snippets matching the current prefix with <kbd>tab</kbd> in Pulsar.\r\n\r\nTo add your own snippets, select the _Pulsar > Snippets..._ menu option if you're using macOS, or the _File > Snippets..._ menu option if you're using Windows, or the _Edit > Snippets..._ menu option if you are using Linux.\r\n\r\n## Snippet Format\r\n\r\nSnippets files are stored in a package's `snippets/` folder and also loaded from `~/.pulsar/snippets.cson`. They can be either `.json` or `.cson` file types.\r\n\r\n```coffee\r\n'.source.js':\r\n  'console.log':\r\n    'prefix': 'log'\r\n    'command': 'insert-console-log'\r\n    'body': 'console.log(${1:\"crash\"});$2'\r\n```\r\n\r\nThe outermost keys are the selectors where these snippets should be active, prefixed with a period (`.`) (details below).\r\n\r\nThe next level of keys are the snippet names. Because this is object notation, each snippet must have a different name.\r\n\r\nUnder each snippet name is a `body` to insert when the snippet is triggered.\r\n\r\n`$` followed by a number are the tabs stops which can be cycled between by pressing <kbd>Tab</kbd> once a snippet has been triggered.\r\n\r\nThe above example adds a `console.log` snippet to JavaScript files that would expand to:\r\n\r\n```js\r\nconsole.log(\"crash\");\r\n```\r\n\r\nThe string `\"crash\"` would be initially selected and pressing tab again would place the cursor after the `;`\r\n\r\nA snippet specifies how it can be triggered. Thus it must provide **at least one** of the following keys:\r\n\r\n### The ‘prefix’ key\r\n\r\nIf a `prefix` is defined, it specifies a string that can trigger the snippet. In the above example, typing `log` (as its own word) and then pressing <kbd>Tab</kbd> would replace `log` with the string `console.log(\"crash\")` as described above.\r\n\r\nPrefix completions can be suggested if partially typed thanks to the `autocomplete-snippets` package.\r\n\r\n### The ‘command’ key\r\n\r\nIf a `command` is defined, it specifies a command name that can trigger the snippet. That command can be invoked from the command palette or mapped to a keyboard shortcut via your `keymap.cson`.\r\n\r\nIf a package called `some-package` had defined that snippet, it would be available in the keymap as `some-package:insert-console-log`, or in the command palette as **Some Package: Insert Console Log**.\r\n\r\nIf you defined the `console.log` snippet described above in your own `snippets.cson`, it could be referenced in a keymap file as `snippets:insert-console-log`, or in the command palette as **Snippets: Insert Console Log**.\r\n\r\nInvoking the command would insert the snippet at the cursor, replacing any text that may be selected.\r\n\r\nSnippet command names must be unique. They can’t conflict with each other, nor can they conflict with any other commands that have been defined. If there is such a conflict, you’ll see an error notification describing the problem.\r\n\r\n### Optional parameters\r\n\r\nThese parameters are meant to provide extra information about your snippet to [autocomplete-plus](https://github.com/atom/autocomplete-plus/wiki/Provider-API).\r\n\r\n* `leftLabel` will add text to the left part of the autocomplete results box.\r\n* `leftLabelHTML` will overwrite what's in `leftLabel` and allow you to use a bit of CSS such as `color`.\r\n* `rightLabelHTML`. By default, in the right part of the results box you will see the name of the snippet. When using `rightLabelHTML` the name of the snippet will no longer be displayed, and you will be able to use a bit of CSS.\r\n* `description` will add text to a description box under the autocomplete results list.\r\n* `descriptionMoreURL` URL to the documentation of the snippet.\r\n\r\n![autocomplete-description](http://i.imgur.com/cvI2lOq.png)\r\n\r\nExample:\r\n```coffee\r\n'.source.js':\r\n  'console.log':\r\n    'prefix': 'log'\r\n    'body': 'console.log(${1:\"crash\"});$2'\r\n    'description': 'Output data to the console'\r\n    'rightLabelHTML': '<span style=\"color:#ff0\">JS</span>'\r\n```\r\n\r\n### Determining the correct scope for a snippet\r\n\r\nThe outmost key of a snippet is the “scope” that you want the descendent snippets to be available in. The key should be prefixed with a period (`text.html.basic` → `.text.html.basic`). You can find out the correct scope by opening the Settings (<kbd>cmd-,</kbd> on macOS) and selecting the corresponding *Language [xxx]* package. For example, here’s the settings page for `language-html`:\r\n\r\n![Screenshot of Language Html settings](https://cloud.githubusercontent.com/assets/1038121/5137632/126beb66-70f2-11e4-839b-bc7e84103f67.png)\r\n\r\nIf it's difficult to determine the package handling the file type in question (for example, for `.md`-documents), you can use another approach:\r\n\r\n1. Put your cursor in a file in which you want the snippet to be available.\r\n2. Open the [Command Palette](https://github.com/pulsar-edit/command-palette)\r\n(<kbd>cmd-shift-p</kbd> or <kbd>ctrl-shift-p</kbd>).\r\n3. Run the `Editor: Log Cursor Scope` command.\r\n\r\nThis will trigger a notification which will contain a list of scopes. The first scope that's listed is the scope for that language. Here are some examples: `source.coffee`, `text.plain`, `text.html.basic`.\r\n\r\n## Snippet syntax\r\n\r\nThis package supports a subset of the features of TextMate snippets, [documented here](http://manual.macromates.com/en/snippets), as well as most features described in the [LSP specification][lsp] and [supported by VSCode][vscode].\r\n\r\nThe following features from TextMate snippets are not yet supported:\r\n\r\n* Interpolated shell code can’t reliably be supported cross-platform, and is probably a bad idea anyway. No other editors that support snippets have adopted this feature, and Pulsar won’t either.\r\n\r\nThe following features from VSCode snippets are not yet supported:\r\n\r\n* “Choice” syntax like `${1|one,two,three|}` requires that the autocomplete engine pop up a menu to offer the user a choice between the available placeholder options. This may be supported in the future, but right now Pulsar effectively converts this to `${1:one}`, treating the first choice as a conventional placeholder.\r\n\r\n### Variables\r\n\r\nPulsar snippets support all of the variables mentioned in the [LSP specification][lsp], plus many of the variables [supported by VSCode][vscode].\r\n\r\nVariables can be referenced with `$`, either without braces (`$CLIPBOARD`) or with braces (`${CLIPBOARD}`). Variables can also have fallback values (`${CLIPBOARD:http://example.com}`), simple flag-based transformations (`${CLIPBOARD:/upcase}`), or `sed`-style transformations `${CLIPBOARD/ /_/g}`.\r\n\r\nOne of the most useful is `TM_SELECTED_TEXT`, which represents whatever text was selected when the snippet was invoked. (Naturally, this can only happen when a snippet is invoked via command or key shortcut, rather than by typing in a <kbd>Tab</kbd> trigger.)\r\n\r\nOthers that can be useful:\r\n\r\n* `TM_FILENAME`: The name of the current file (`foo.rb`).\r\n* `TM_FILENAME_BASE`: The name of the current file, but without its extension (`foo`).\r\n* `TM_FILEPATH`: The entire path on disk to the current file.\r\n* `TM_CURRENT_LINE`: The entire current line that the cursor is sitting on.\r\n* `TM_CURRENT_WORD`: The entire word that the cursor is within or adjacent to, as interpreted by `cursor.getCurrentWordBufferRange`.\r\n* `CLIPBOARD`: The current contents of the clipboard.\r\n* `CURRENT_YEAR`, `CURRENT_MONTH`, et cetera: referneces to the current date and time in various formats.\r\n\r\nAny variable that has no value — for instance, `TM_FILENAME` on an untitled document — will resolve to an empty string.\r\n\r\n#### Variable transformation flags\r\n\r\nPulsar supports the three flags defined in the [LSP snippets specification][lsp] and two other flags that are [implemented in VSCode][vscode]:\r\n\r\n* `/upcase` (`foo` → `FOO`)\r\n* `/downcase` (`BAR` → `bar`)\r\n* `/capitalize` (`lorem ipsum dolor` → `Lorem ipsum dolor`)\r\n* `/camelcase` (`foo bar` → `fooBar`, `lorem-ipsum.dolor` → `loremIpsumDolor`)\r\n* `/pascalcase` (`foo bar` → `FooBar`, `lorem-ipsum.dolor` → `LoremIpsumDolor`)\r\n\r\n#### Variable caveats\r\n\r\n* `WORKSPACE_NAME`, `WORKSPACE_FOLDER`, and `RELATIVE_PATH` all rely on the presence of a root project folder, but a Pulsar project can technically have multiple root folders. While this is rare, it is handled by `snippets` as follows: whichever project path is an ancestor of the currently active file is treated as the project root — or the first one found if multiple roots are ancestors.\r\n* `WORKSPACE_NAME` in VSCode refers to “the name of the opened workspace or folder.” In the former case, this appears to mean bundled projects with a `.code-workspace` file extension — which have no Pulsar equivalent. Instead, `WORKSPACE_NAME` will always refer to the last path component of your project’s root directory as defined above.\r\n\r\n#### Variables that are not yet supported\r\n\r\nOf the variables supported by VSCode, Pulsar does not yet support:\r\n\r\n* `UUID`\r\n* `BLOCK_COMMENT_START`\r\n* `BLOCK_COMMENT_END`\r\n* `LINE_COMMENT`\r\n\r\n## Multi-line Snippet Body\r\n\r\nYou can also use multi-line syntax using `\"\"\"` for larger templates:\r\n\r\n```coffee\r\n'.source.js':\r\n  'if, else if, else':\r\n    'prefix': 'ieie'\r\n    'body': \"\"\"\r\n      if (${1:true}) {\r\n        $2\r\n      } else if (${3:false}) {\r\n        $4\r\n      } else {\r\n        $5\r\n      }\r\n    \"\"\"\r\n```\r\n\r\n## Escaping Characters\r\n\r\nIncluding a literal closing brace inside the text provided by a snippet's tab stop will close that tab stop early. To prevent that, escape the brace with two backslashes, like so:\r\n\r\n```coffee\r\n'.source.js':\r\n  'function':\r\n    'prefix': 'funct'\r\n    'body': \"\"\"\r\n      ${1:function () {\r\n        statements;\r\n      \\\\}\r\n      this line is also included in the snippet tab;\r\n      }\r\n      \"\"\"\r\n```\r\n\r\nLikewise, if your snippet includes literal references to `$` or `{`, you may have to escape those with two backslashes as well, depending on the context.\r\n\r\n## Multiple snippets for the same scope\r\n\r\nSnippets for the same scope must be placed within the same key. See [this section of the Pulsar Flight Manual](https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#configuring-with-cson) for more information.\r\n\r\n\r\n[lsp]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#variables\r\n[vscode]: https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables\r\n",
-    "metadata": {
-      "name": "snippets",
-      "version": "1.7.0",
-      "main": "./lib/snippets",
-      "description": "Expand snippets matching the current prefix with `tab`.",
-      "repository": "https://github.com/pulsar-edit/snippets",
-      "license": "MIT",
-      "engines": {
-        "atom": "*"
-      },
-      "dependencies": {
-        "async": "~0.2.6",
-        "atom-select-list": "^0.7.0",
-        "pegjs": "^0.10.0",
-        "scoped-property-store": "^0.17.0",
-        "season": "^6.0.2",
-        "temp": "~0.8.0",
-        "underscore-plus": "^1.0.0"
-      },
-      "providedServices": {
-        "snippets": {
-          "description": "Snippets are text shortcuts that can be expanded to their definition.",
-          "versions": {
-            "0.1.0": "provideSnippets"
-          }
-        }
-      },
-      "devDependencies": {
-        "eslint": "^8.35.0"
-      }
-    }
-  },
   "github": {
     "readme": "# Pulsar GitHub Package\r\n\r\nThe Pulsar GitHub package provides Git and GitHub integration for Pulsar.\r\n\r\n<img width=\"880\" alt=\"GitHub for Pulsar\" src=\"https://user-images.githubusercontent.com/378023/49062969-2e717a00-f259-11e8-8207-2ecbc6981cd6.png\">\r\n\r\n<img width=\"880\" alt=\"git-integration\" src=\"https://user-images.githubusercontent.com/378023/49062970-2f0a1080-f259-11e8-91e9-9402ec76cd66.png\">\r\n\r\n<img width=\"880\" alt=\"pull request view\" src=\"https://user-images.githubusercontent.com/6842965/55753896-7aa7a480-5a19-11e9-8540-a932a746fc29.png\">\r\n\r\n<img width=\"880\" alt=\"in-editor pull request comments\" src=\"https://user-images.githubusercontent.com/6842965/55753909-81ceb280-5a19-11e9-9762-2716b5e0f09f.png\">\r\n\r\n## Installation\r\n\r\nThis package is bundled with Pulsar starting in version 1.18, and does not need to be installed separately.\r\n\r\n## License\r\n\r\nThe MIT license grant is not for GitHub's trademarks, which include the logo designs. GitHub reserves all trademark and copyright rights in and to all GitHub trademarks.\r\n\r\nGitHub® and its stylized versions and the Invertocat mark are GitHub's Trademarks or registered Trademarks. When using GitHub's logos, be sure to follow the GitHub [logo guidelines](https://github.com/logos).\r\n",
     "metadata": {
       "name": "github",
       "main": "./lib/index",
-      "version": "0.36.19",
+      "version": "0.36.20",
       "description": "GitHub integration",
       "repository": "https://github.com/pulsar-edit/github",
       "license": "MIT",
@@ -3446,7 +3633,7 @@
         "classnames": "2.2.6",
         "compare-sets": "1.0.1",
         "dompurify": "2.0.17",
-        "dugite": "2.1.0",
+        "dugite": "2.5.2",
         "event-kit": "2.5.3",
         "fs-extra": "4.0.3",
         "graphql": "14.5.8",
@@ -3468,7 +3655,7 @@
         "underscore-plus": "1.7.0",
         "what-the-diff": "0.6.0",
         "what-the-status": "1.0.3",
-        "whats-my-line": "https://github.com/pulsar-edit/whats-my-line/archive/348e8d10d9b9a1fd717cd4cc1263297844732768.tar.gz",
+        "whats-my-line": "https://github.com/pulsar-edit/whats-my-line/archive/4029ca9567a0bf0f12843890461fb13e758cfcbf.tar.gz",
         "yubikiri": "2.0.0"
       },
       "devDependencies": {
@@ -3523,7 +3710,11 @@
         "viewChangesForCurrentFileDiffPaneSplitDirection": {
           "type": "string",
           "default": "none",
-          "enum": ["none", "right", "down"],
+          "enum": [
+            "none",
+            "right",
+            "down"
+          ],
           "title": "Direction to open diff pane",
           "description": "Direction to split the active pane when showing diff associated with open file. If 'none', the results will be shown in the active pane."
         },
@@ -3539,7 +3730,9 @@
         },
         "performanceMask": {
           "type": "array",
-          "default": [".*"],
+          "default": [
+            ".*"
+          ],
           "items": {
             "type": "string"
           },
@@ -3593,7 +3786,10 @@
         "remoteFetchProtocol": {
           "type": "string",
           "default": "https",
-          "enum": ["https", "ssh"],
+          "enum": [
+            "https",
+            "ssh"
+          ],
           "description": "Transport protocol to prefer when creating a new git remote"
         }
       },
@@ -3609,7 +3805,10 @@
         "ReviewsStub": "createReviewsStub"
       },
       "greenkeeper": {
-        "ignore": ["electron-link", "electron-mksnapshot"]
+        "ignore": [
+          "electron-link",
+          "electron-mksnapshot"
+        ]
       }
     }
   }


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [ ] Have you ran tests against this code?
* [X] This PR contains zero code changes.

### Description of the Change

Now that the `snippets` package has been [bundled](https://github.com/pulsar-edit/pulsar/pull/993) into the core repository of Pulsar this PR updates the information about the package to match these new details.

Additionally, this has picked up any of the other changes made in any of the built-in packages since the last time this was ran, which seems to be from a few versions ago.