### PR TITLE
Keyword Search Support

### DIFF
--- a/src/controllers/getPackages.js
+++ b/src/controllers/getPackages.js
@@ -49,6 +49,9 @@ module.exports = {
     owner: (context, req) => {
       return context.query.owner(req);
     },
+    tags: (context, req) => {
+      return context.query.tags(req);
+    },
   },
 
   /**

--- a/src/controllers/getPackagesSearch.js
+++ b/src/controllers/getPackagesSearch.js
@@ -55,6 +55,9 @@ module.exports = {
     owner: (context, req) => {
       return context.query.owner(req);
     },
+    tags: (context, req) => {
+      return context.query.tags(req);
+    },
   },
 
   /**

--- a/src/database/_clause.js
+++ b/src/database/_clause.js
@@ -78,6 +78,12 @@ function keywordsClause(sql, opts) {
     return getEmptyClause(sql);
   }
 
+  // TODO: This only supports exact matches. If we want partial matching support
+  // we obviously need to use the 'LIKE' operator. But due to right hand sided
+  // arguments I can't find how to make this work. With the below being the closest
+  // I've come:
+  // AND jsonb_typeof(v.meta -> 'keywords') = 'array' AND '"es6"' LIKE ANY (
+  // ARRAY(SELECT * FROM jsonb_array_elements(v.meta -> 'keywords'))::text[])
   return sql`AND (v.meta -> 'keywords')::jsonb ? ${opts.tags}`;
 }
 

--- a/src/database/_clause.js
+++ b/src/database/_clause.js
@@ -73,6 +73,14 @@ function fileExtensionClause(sql, opts) {
   return sql`AND ${opts.fileExtension}=ANY(v.supported_languages)`;
 }
 
+function keywordsClause(sql, opts) {
+  if (typeof opts.tags !== "string") {
+    return getEmptyClause(sql);
+  }
+
+  return sql`AND (v.meta -> 'keywords')::jsonb ? ${opts.tags}`;
+}
+
 module.exports = {
   getEmptyClause,
   queryClause,
@@ -80,4 +88,5 @@ module.exports = {
   ownerClause,
   serviceClause,
   fileExtensionClause,
+  keywordsClause,
 };

--- a/src/database/getSortedPackages.js
+++ b/src/database/getSortedPackages.js
@@ -59,6 +59,7 @@ module.exports = {
         ${clause.serviceClause(sql, opts)}
         ${clause.fileExtensionClause(sql, opts)}
         ${clause.ownerClause(sql, opts)}
+        ${clause.keywordsClause(sql, opts)}
 
         ORDER BY p.name, v.semver_v1 DESC, v.semver_v2 DESC, v.semver_v3 DESC, v.created DESC
       )

--- a/src/query_parameters/tags.js
+++ b/src/query_parameters/tags.js
@@ -1,0 +1,24 @@
+/**
+ * @function tags
+ * @desc Returns the tags being requested.
+ * @param {object} req - The `Request` object inherited from the Express endpoint.
+ * @returns {string|boolean} Returns false if the provided value is invalid or
+ * nonexistent. Returns the 'tags' string otherwise.
+ */
+const utils = require("./utils.js");
+
+module.exports = {
+  schema: {
+    name: "tags",
+    in: "query",
+    schema: {
+      type: "string"
+    },
+    example: "tree-sitter",
+    allowEmptyValue: true,
+    description: "The 'tags' available via the 'keywords' entry of a package's 'package.json'.",
+  },
+  logic: (req) => {
+    return utils.stringValidation(req.query.tags);
+  },
+};

--- a/tests/unit/query.test.js
+++ b/tests/unit/query.test.js
@@ -194,3 +194,16 @@ describe("Verify owner Returns", () => {
     expect(query.owner(arg)).toBe(result);
   });
 });
+
+const tagsCases = [
+  [{ query: { tags: "es6" } }, "es6"],
+  [{ query: { tags: "" } }, false],
+  [{ query: { tags: 1 } }, false],
+  [{ query: {} }, false],
+];
+
+describe("Verify tags Returns", () => {
+  test.each(tagsCases)("Given %o Returns %p", (arg, result) => {
+    expect(query.tags(arg)).toBe(result);
+  });
+});


### PR DESCRIPTION
Exposed via the `tags` query parameter

### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

As referenced in #206 we discussed how to allow users to search tags of packages, including tags that exist only on this platform.

In my reply there I detail several steps that would be needed to begin to support this kind functionality.

With the first step possible being one that enables the generic searching of details within the `package.json`s `keywords` array at all. Which is exactly what this PR does.

Although unfortunately this PR doesn't support searching this field just yet, it will match with any exact matches just fine.

This new functionality is exposed via the query parameter `tags` on the following endpoints:

* GET `/api/packages/search`
* GET `/api/packages`

This will allow exact matches to be found for any existing packages data in the `keywords` array from the `package.json`. An example request would look like:

* [`https://web.pulsar-edit.dev/packages?tags=es6`](https://web.pulsar-edit.dev/packages?tags=es6)
* [`https://web.pulsar-edit.dev/packages?tags=es6&q=language`](https://web.pulsar-edit.dev/packages?tags=es6&q=language)
