### PR TITLE
Change `database.test.js` to better test package renaming

### DIFF
--- a/tests/database/fixtures/lifetime/package-a.js
+++ b/tests/database/fixtures/lifetime/package-a.js
@@ -25,6 +25,39 @@ const createPack = {
   },
 };
 
+const createPackRenamed = {
+  name: "package-a-lifetime-renamed",
+  repository: {
+    type: "git",
+    url: "https://github.com/pulsar-edit/package-a-lifetime",
+  },
+  owner: "pulsar-edit",
+  creation_method: "Test Package",
+  readme: "This is a readme!",
+  metadata: {
+    name: "package-a-lifetime-renamed",
+    license: "MIT",
+    version: "1.0.1",
+  },
+  releases: {
+    latest: "1.0.1",
+  },
+  versions: {
+    "1.0.1": {
+      name: "package-a-lifetime-renamed",
+      version: "1.0.0",
+      tarball_url: "https://nowhere.com",
+      sha: "12345",
+    },
+    "1.0.0": {
+      name: "package-a-lifetime",
+      version: "1.0.0",
+      tarball_url: "https://nowhere.com",
+      sha: "12345",
+    },
+  },
+};
+
 const addVersion = (v) => {
   return {
     name: "package-a-lifetime",
@@ -49,6 +82,7 @@ const packageDataForVersion = (v) => {
 
 module.exports = {
   createPack,
+  createPackRenamed,
   addVersion,
   packageDataForVersion,
 };


### PR DESCRIPTION
Tests for package renaming scenarios.

The main difference is that these use `insertNewPackageVersion` instead of `insertNewPackageName`. The latter is no longer really used; `insertNewPackageVersion` also better captures the fact that a renamed package necessarily has at least two versions.

I'd changed `getPackageByName.js` locally in such a way as to make these tests pass, but my approach locally won't actually work; the database migration proposed by @confused-Techie is wiser. My way of figuring out a package's canonical name was to find out what the name was on the most recently published version of the package, but that approach won't work if a package is renamed and then the version associated with the renaming is deleted. In that scenario, we need a way of figuring out that the newer package name is still canonical even though there aren't any (non-deleted) package versions under that name.