### PR TITLE
Package Rename bug fix

### DIFF
--- a/src/controllers/postPackagesPackageNameVersions.js
+++ b/src/controllers/postPackagesPackageNameVersions.js
@@ -248,7 +248,7 @@ module.exports = {
 
       callStack.addCall("db.packageNameAvailability", isAvailable);
 
-      if (isAvailable.ok) {
+      if (!isAvailable.ok) {
         const sso = new context.sso();
 
         return sso


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

As helpfully discovered by @savetheclocktower we currently, mistakenly check for the truthy return of `db.packageNameAvailability` to fail on a package rename, when we need to check it's falsey return. 