### PR TITLE
Migrate to packages subdomain

### DIFF
--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,9 +1,15 @@
 dispatch:
   # The Package Browser Service handles all `web` subdomain root requests
+  - url: "packages.pulsar-edit.dev/"
+    service: package-browser
+
   - url: "web.pulsar-edit.dev/"
     service: package-browser
 
   # Package Browser Service handles root `web` subdomain requests with paths
+  - url: "packages.pulsar-edit.dev/*"
+    service: package-browser
+    
   - url: "web.pulsar-edit.dev/*"
     service: package-browser
 


### PR DESCRIPTION
This PR adds new subdomain mappings for a migration from `web.pulsar-edit.dev` to `packages.pulsar-edit.dev`.

I'm leaving in both mappings for the time being to reduce the possibility of any loss of service. Although once these changes are in I'll work on cloudflare to ensure redirects can occur to the right subdomain, and once we are confident of that behavior then we can remove these old mappings.

Closes #99 