### PR TITLE
Bump NodeJS to v22, as 18 is no longer supported on App Engine

### DIFF
--- a/.github/workflows/ci-standards.yml
+++ b/.github/workflows/ci-standards.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [22.x]
 
     steps:
     - name: Checkout the latest code

--- a/.github/workflows/ci-tests-pull.yml
+++ b/.github/workflows/ci-tests-pull.yml
@@ -44,7 +44,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [17.x, 18.x, 19.x]
+        node-version: [19.x, 22.x]
 
     steps:
     - name: Checkout the latest code

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -47,7 +47,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [17.x, 18.x, 19.x]
+        node-version: [19.x, 22.x]
 
     steps:
       - name: Checkout the latest code

--- a/app.example.yaml
+++ b/app.example.yaml
@@ -2,7 +2,7 @@
 # Name this file app.yaml, and it will be picked up by the server.
 # app.yaml is in the git ignore to prevent any secrets from leaking.
 
-runtime: nodejs18
+runtime: nodejs22
 service: default
 
 env_variables:


### PR DESCRIPTION
Like the title says, after #281 I attempted to deploy to GCP, to figure out that NodeJS v18 is no longer supported and I can't deploy that version. So bumping the version in our tests here to ensure we can actually run everything without issue there, if the tests pass I'll merge this without review so we can get to deploying our changes.