### PR TITLE
Fix package version updates not appearing on Discord notifications

### DIFF
--- a/src/controllers/postPackagesPackageNameVersions.js
+++ b/src/controllers/postPackagesPackageNameVersions.js
@@ -40,14 +40,12 @@ module.exports = {
     },
   },
   async postReturnHTTP(req, res, context, obj) {
-    console.log("START: Noisy postPackagesPackageNameVersions.postReturnHTTP Logging");
     // We use postReturnHTTP to ensure the user doesn't wait on these other actions
 
     // Lets bail early in case these values don't exist.
     // Such as the original request failing
     if (!obj.webhook || !obj.featureDetection) {
       // This data isn't defined, and we cannot work with it
-      console.log("Webhook/Feature Detection data isn't properly defined!");
       return;
     }
 
@@ -59,8 +57,6 @@ module.exports = {
     if (!webhookSend.ok) {
       context.logger.generic(3, webhookSend);
     }
-
-    console.log(`Webhook sent: ${JSON.stringify(webhookRet)}`);
 
     // Now to call for feature detection
     let features = await context.vcs.featureDetection(

--- a/src/controllers/postPackagesPackageNameVersions.js
+++ b/src/controllers/postPackagesPackageNameVersions.js
@@ -45,26 +45,20 @@ module.exports = {
 
     // Lets bail early in case these values don't exist.
     // Such as the original request failing
-    if (!obj.webhook) {
+    if (!obj.webhook || !obj.featureDetection) {
       // This data isn't defined, and we cannot work with it
-      console.log("Webhook data isn't properly defined!");
+      console.log("Webhook/Feature Detection data isn't properly defined!");
       return;
     }
 
-    if (
-      typeof obj?.featureDetection?.user !== "string" ||
-      typeof obj?.featureDetection?.ownerRepo !== "string" ||
-      typeof obj?.featureDetection?.service !== "string"
-    ) {
-      // This data isn't defined, and we cannot work with it
-      console.log("feature detection data isn't properly defined!");
-      return;
-    }
-
-    const webhookRet = await context.webhook.alertPublishVersion(
+    let webhookSend = await context.webhook.alertPublishVersion(
       obj.webhook.pack,
       obj.webhook.user
     );
+
+    if (!webhookSend.ok) {
+      context.logger.generic(3, webhookSend);
+    }
 
     console.log(`Webhook sent: ${JSON.stringify(webhookRet)}`);
 

--- a/src/controllers/postPackagesPackageNameVersions.js
+++ b/src/controllers/postPackagesPackageNameVersions.js
@@ -40,6 +40,7 @@ module.exports = {
     },
   },
   async postReturnHTTP(req, res, context, obj) {
+    console.log("START: Noisy postPackagesPackageNameVersions.postReturnHTTP Logging");
     // We use postReturnHTTP to ensure the user doesn't wait on these other actions
 
     // Lets bail early in case these values don't exist.
@@ -50,6 +51,7 @@ module.exports = {
       typeof obj?.webhook?.user !== "string"
     ) {
       // This data isn't defined, and we cannot work with it
+      console.log("Webhook data isn't properly defined!");
       return;
     }
 
@@ -59,14 +61,17 @@ module.exports = {
       typeof obj?.featureDetection?.service !== "string"
     ) {
       // This data isn't defined, and we cannot work with it
+      console.log("feature detection data isn't properly defined!");
       return;
     }
 
-    await context.webhook.alertPublishVersion(
+    const webhookRet = await context.webhook.alertPublishVersion(
       obj.webhook.pack,
       obj.webhook.user
     );
 
+    console.log(`Webhook sent: ${JSON.stringify(webhookRet)}`);
+    
     // Now to call for feature detection
     let features = await context.vcs.featureDetection(
       obj.featureDetection.user,

--- a/src/controllers/postPackagesPackageNameVersions.js
+++ b/src/controllers/postPackagesPackageNameVersions.js
@@ -45,11 +45,7 @@ module.exports = {
 
     // Lets bail early in case these values don't exist.
     // Such as the original request failing
-
-    if (
-      typeof obj?.webhook?.pack !== "string" ||
-      typeof obj?.webhook?.user !== "string"
-    ) {
+    if (!obj.webhook) {
       // This data isn't defined, and we cannot work with it
       console.log("Webhook data isn't properly defined!");
       return;
@@ -71,7 +67,7 @@ module.exports = {
     );
 
     console.log(`Webhook sent: ${JSON.stringify(webhookRet)}`);
-    
+
     // Now to call for feature detection
     let features = await context.vcs.featureDetection(
       obj.featureDetection.user,


### PR DESCRIPTION
This PR fixes the package version publications not appearing on Discord.
Seems the issue stems from overly restrictive validity checks before the webhook ever even ran.

Which also has the unfortunate side effect of feature detection not updating on a per version basis like we would expect.

But this PR loosens those checks opting to instead check the same exact way we do on package publication, and letting the individual functions we call deal with the specific validity.

Having already tested this in production we can now be confident this PR fixes the issue. And like I've mentioned these changes are already in production, this PR serves more as an post-approval, just to ensure there's some transparency about what I've changed.