### PR TITLE
Update list of bundled packages

### DIFF
--- a/scripts/tools/update-bundled.js
+++ b/scripts/tools/update-bundled.js
@@ -20,6 +20,11 @@ const REPOS = [
     url: "https://github.com/pulsar-edit/github",
     isPulsar: false,
   },
+  {
+    name: "terminal",
+    url: "https://github.com/pulsar-edit/terminal",
+    isPulsar: false,
+  }
 ];
 
 (async () => {

--- a/src/bundled_packages/bundled.json
+++ b/src/bundled_packages/bundled.json
@@ -1,6 +1,6 @@
 {
   "about": {
-    "readme": "# About package\r\n\r\nView useful information about your Pulsar installation.\r\n\r\n![About Pulsar](https://cloud.githubusercontent.com/assets/16760489/19395499/69bbb780-922d-11e6-9779-2b8327027ea5.png)\r\n\r\nThis is a package for [Pulsar](https://pulsar-edit.dev), a community-led hyper-hackable text editor\r\n\r\n## Usage\r\n\r\nThis package provides a cross-platform \"About Pulsar\" view that displays information about your Pulsar installation, which currently includes the current version, the license, and the Terms of Use.\r\n\r\n## Contributing\r\nAlways feel free to help out!  Whether it's filing bugs and feature requests\r\nor working on some of the open issues, Pulsar's [contributing guide](https://github.com/pulsar-edit/.github/blob/main/CONTRIBUTING.md)\r\nwill help get you started while the [guide for contributing to packages](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#contributing-to-packages)\r\nhas some extra information.\r\n",
+    "readme": "# About package\n\nView useful information about your Pulsar installation.\n\n![About Pulsar](https://cloud.githubusercontent.com/assets/16760489/19395499/69bbb780-922d-11e6-9779-2b8327027ea5.png)\n\nThis is a package for [Pulsar](https://pulsar-edit.dev), a community-led hyper-hackable text editor\n\n## Usage\n\nThis package provides a cross-platform \"About Pulsar\" view that displays information about your Pulsar installation, which currently includes the current version, the license, and the Terms of Use.\n\n## Contributing\nAlways feel free to help out!  Whether it's filing bugs and feature requests\nor working on some of the open issues, Pulsar's [contributing guide](https://github.com/pulsar-edit/.github/blob/main/CONTRIBUTING.md)\nwill help get you started while the [guide for contributing to packages](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#contributing-to-packages)\nhas some extra information.\n",
     "metadata": {
       "name": "about",
       "author": "Machisté N. Quintana <mnquintana@users.noreply.github.com>",
@@ -21,16 +21,16 @@
     }
   },
   "archive-view": {
-    "readme": "# Archive view package\r\n\r\nAdds support for browsing archive files in Pulsar with the following extensions:\r\n\r\n* `.egg`\r\n* `.epub`\r\n* `.jar`\r\n* `.love`\r\n* `.nupkg`\r\n* `.tar`\r\n* `.tar.gz`\r\n* `.tgz`\r\n* `.war`\r\n* `.whl`\r\n* `.xpi`\r\n* `.zip`\r\n\r\nSelect a file to extract it to a temp file and open it in a new editor.\r\n\r\n![](./resources/preview.png)\r\n",
+    "readme": "# Archive view package\n\nAdds support for browsing archive files in Pulsar with the following extensions:\n\n* `.egg`\n* `.epub`\n* `.jar`\n* `.love`\n* `.nupkg`\n* `.tar`\n* `.tar.gz`\n* `.tgz`\n* `.war`\n* `.whl`\n* `.xpi`\n* `.zip`\n\nSelect a file to extract it to a temp file and open it in a new editor.\n\n![](./resources/preview.png)\n",
     "metadata": {
       "name": "archive-view",
       "version": "0.66.0",
       "description": "View the files and folders inside archive files",
       "main": "./lib/archive-editor",
       "dependencies": {
+        "@pulsar-edit/ls-archive": "^2.0.0",
         "etch": "^0.14.1",
         "humanize-plus": "~1.8.2",
-        "ls-archive": "1.3.4",
         "temp": "^0.9.4"
       },
       "repository": "https://github.com/pulsar-edit/pulsar",
@@ -38,6 +38,7 @@
       "engines": {
         "atom": "*"
       },
+      "atomTestRunner": "runners/jasmine2-test-runner",
       "deserializers": {
         "ArchiveEditor": "deserialize",
         "ArchiveEditorView": "deserialize"
@@ -57,7 +58,7 @@
     }
   },
   "atom-dark-syntax": {
-    "readme": "# Pulsar Dark Syntax theme\r\n\r\nA dark syntax theme for Pulsar.\r\n\r\nThis theme is installed by default with Pulsar and can be activated by going to\r\nthe _Themes_ section in the Settings view (`cmd-,`) and selecting it from the\r\n_Syntax Themes_ dropdown menu.\r\n\r\n![](https://f.cloud.github.com/assets/671378/2264549/f49e9bf2-9e73-11e3-9329-e2d59dd1b119.png)\r\n",
+    "readme": "# Pulsar Dark Syntax theme\n\nA dark syntax theme for Pulsar.\n\nThis theme is installed by default with Pulsar and can be activated by going to\nthe _Themes_ section in the Settings view (`cmd-,`) and selecting it from the\n_Syntax Themes_ dropdown menu.\n\n![](https://f.cloud.github.com/assets/671378/2264549/f49e9bf2-9e73-11e3-9329-e2d59dd1b119.png)\n",
     "metadata": {
       "name": "atom-dark-syntax",
       "theme": "syntax",
@@ -71,7 +72,7 @@
     }
   },
   "atom-dark-ui": {
-    "readme": "# Pulsar Dark UI theme\r\n\r\nA dark UI theme for Pulsar.\r\n\r\nThis theme is installed by default with Pulsar and can be activated by going to\r\nthe _Themes_ section in the Settings view (`cmd-,`) and selecting it from the\r\n_UI Themes_ drop-down menu.\r\n\r\n![](https://f.cloud.github.com/assets/671378/2265086/c6897dba-9e7b-11e3-945d-551cac610717.png)\r\n",
+    "readme": "# Pulsar Dark UI theme\n\nA dark UI theme for Pulsar.\n\nThis theme is installed by default with Pulsar and can be activated by going to\nthe _Themes_ section in the Settings view (`cmd-,`) and selecting it from the\n_UI Themes_ drop-down menu.\n\n![](https://f.cloud.github.com/assets/671378/2265086/c6897dba-9e7b-11e3-945d-551cac610717.png)\n",
     "metadata": {
       "name": "atom-dark-ui",
       "theme": "ui",
@@ -85,7 +86,7 @@
     }
   },
   "atom-light-syntax": {
-    "readme": "# Pulsar Light Syntax theme\r\n\r\nA light syntax theme for Pulsar.\r\n\r\nThis theme is installed by default with Pulsar and can be activated by going to\r\nthe _Themes_ section in the Settings view (`cmd-,`) and selecting it from the\r\n_Syntax Themes_ dropdown menu.\r\n\r\n![](https://f.cloud.github.com/assets/671378/2264690/886ce496-9e75-11e3-971a-9a24f359c481.png)\r\n",
+    "readme": "# Pulsar Light Syntax theme\n\nA light syntax theme for Pulsar.\n\nThis theme is installed by default with Pulsar and can be activated by going to\nthe _Themes_ section in the Settings view (`cmd-,`) and selecting it from the\n_Syntax Themes_ dropdown menu.\n\n![](https://f.cloud.github.com/assets/671378/2264690/886ce496-9e75-11e3-971a-9a24f359c481.png)\n",
     "metadata": {
       "name": "atom-light-syntax",
       "theme": "syntax",
@@ -99,7 +100,7 @@
     }
   },
   "atom-light-ui": {
-    "readme": "# Pulsar Light UI theme\r\n\r\nA light UI theme for Pulsar.\r\n\r\nThis theme is installed by default with Pulsar and can be activated by going to\r\nthe _Themes_ section in the Settings view (`cmd-,`) and selecting it from the\r\n_UI Themes_ drop-down menu.\r\n\r\n![](https://f.cloud.github.com/assets/671378/2265022/bb148a20-9e7a-11e3-81c8-bf5965d48183.png)\r\n",
+    "readme": "# Pulsar Light UI theme\n\nA light UI theme for Pulsar.\n\nThis theme is installed by default with Pulsar and can be activated by going to\nthe _Themes_ section in the Settings view (`cmd-,`) and selecting it from the\n_UI Themes_ drop-down menu.\n\n![](https://f.cloud.github.com/assets/671378/2265022/bb148a20-9e7a-11e3-81c8-bf5965d48183.png)\n",
     "metadata": {
       "name": "atom-light-ui",
       "theme": "ui",
@@ -113,7 +114,7 @@
     }
   },
   "autocomplete-atom-api": {
-    "readme": "# Atom API Autocomplete package\r\n\r\nProvides autocompletions for properties and methods available from the `atom.` global.\r\n\r\n![autocomplete-atom-api](https://cloud.githubusercontent.com/assets/69169/7211322/9c402ea2-e50e-11e4-9d74-56ab91aa101d.gif)\r\n",
+    "readme": "# Atom API Autocomplete package\n\nProvides autocompletions for properties and methods available from the `atom.` global.\n\n![autocomplete-atom-api](https://cloud.githubusercontent.com/assets/69169/7211322/9c402ea2-e50e-11e4-9d74-56ab91aa101d.gif)\n",
     "metadata": {
       "name": "autocomplete-atom-api",
       "version": "0.10.7",
@@ -133,12 +134,12 @@
       },
       "devDependencies": {
         "request": "^2.53.0",
-        "temp": "^0.8.1"
+        "temp": "^0.9.0"
       }
     }
   },
   "autocomplete-css": {
-    "readme": "# CSS Autocomplete package\r\n\r\nCSS property name and value autocompletions in Pulsar. Uses the\r\n[autocomplete-plus](https://github.com/pulsar-edit/autocomplete-plus) package.\r\n\r\nThis is powered by the list of CSS property and values [here](https://github.com/adobe/brackets/blob/master/src/extensions/default/CSSCodeHints/CSSProperties.json).\r\n\r\n![css-completions](https://cloud.githubusercontent.com/assets/671378/6357910/b9ecbe7c-bc1c-11e4-89b1-033e626c891f.gif)\r\n\r\nYou can update the prebuilt list of completions by running `node update.js` at the root of this package and checking for changes within `completions.json`. This does rely on having dev dependencies installed, so ensure you install all dependencies before doing so.\r\n",
+    "readme": "# CSS Autocomplete package\n\nCSS property name and value autocompletions in Pulsar. Uses the\n[autocomplete-plus](https://github.com/pulsar-edit/autocomplete-plus) package.\n\nThis is powered by the list of CSS property and values [here](https://github.com/adobe/brackets/blob/master/src/extensions/default/CSSCodeHints/CSSProperties.json).\n\n![css-completions](https://cloud.githubusercontent.com/assets/671378/6357910/b9ecbe7c-bc1c-11e4-89b1-033e626c891f.gif)\n\nYou can update the prebuilt list of completions by running `node ./update/update.js` at the root of this package and checking for changes within `completions.json`. This does rely on having dev dependencies installed, so ensure you install all dependencies before doing so.\n",
     "metadata": {
       "name": "autocomplete-css",
       "version": "0.17.5",
@@ -157,14 +158,15 @@
         }
       },
       "devDependencies": {
-        "@webref/css": "^6.3.4",
-        "content": "github:mdn/content",
-        "superagent": "^8.0.9"
+        "@webref/css": "^6.18.1",
+        "@webref/elements": "^2.4.0",
+        "download-git-repo": "^3.0.2",
+        "superagent": "^10.1.1"
       }
     }
   },
   "autocomplete-html": {
-    "readme": "# HTML Autocomplete package\r\n\r\nHTML tag and attribute autocompletions in Pulsar.\r\n\r\nTag and attribute autocompletions are powered by the list of HTML tags [here](https://github.com/adobe/brackets/blob/master/src/extensions/default/HTMLCodeHints/HtmlTags.json) and HTML attributes [here](https://github.com/adobe/brackets/blob/master/src/extensions/default/HTMLCodeHints/HtmlAttributes.json).\r\nDescriptions are powered by [MDN](https://developer.mozilla.org).\r\n\r\n![html-completions](https://cloud.githubusercontent.com/assets/2766036/25668197/ffd24928-2ff3-11e7-85fc-b327ac2287e6.gif)\r\n\r\nYou can update the prebuilt list of tags and attributes names and values by running `npm run update` at the root of the package and then checking-in the changed `completions.json` file.\r\n",
+    "readme": "# HTML Autocomplete package\n\nHTML tag and attribute autocompletions in Pulsar.\n\nTag and attribute autocompletions are powered by the list of HTML tags [here](https://github.com/adobe/brackets/blob/master/src/extensions/default/HTMLCodeHints/HtmlTags.json) and HTML attributes [here](https://github.com/adobe/brackets/blob/master/src/extensions/default/HTMLCodeHints/HtmlAttributes.json).\nDescriptions are powered by [MDN](https://developer.mozilla.org).\n\n![html-completions](https://cloud.githubusercontent.com/assets/2766036/25668197/ffd24928-2ff3-11e7-85fc-b327ac2287e6.gif)\n\nYou can update the prebuilt list of tags and attributes names and values by running `npm run update` at the root of the package and then checking-in the changed `completions.json` file.\n",
     "metadata": {
       "name": "autocomplete-html",
       "version": "0.8.9",
@@ -198,7 +200,7 @@
     }
   },
   "autocomplete-plus": {
-    "readme": "# Autocomplete+ package\r\n\r\nDisplays possible autocomplete suggestions on keystroke (or manually by typing `ctrl-space`) and inserts a suggestion in the editor if confirmed.\r\n\r\n![autocomplete+](https://cloud.githubusercontent.com/assets/744740/7656861/9fb8bcc4-faea-11e4-9814-9dca218ded93.png)\r\n\r\n[Changelog](https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md)\r\n\r\n## Installation\r\n\r\n`autocomplete+` is bundled with Pulsar. You don't have to do anything to install it.\r\n\r\n## Providers\r\n\r\n`autocomplete+` has a powerful autocomplete provider API, allowing provider authors to add language-specific behavior to this package.\r\n\r\nYou should *definitely* install additional providers (the default provider bundled with this package is somewhat crude): https://github.com/atom/autocomplete-plus/wiki/Autocomplete-Providers\r\n\r\n## Usage\r\n\r\nJust type some stuff, and autocomplete+ will automatically show you some suggestions.\r\nPress `UP` and `DOWN` to select another suggestion, press `TAB` or `ENTER` to confirm your selection. You can change the default keymap in `Preferences`:\r\n\r\n* Keymap For Confirming A Suggestion\r\n\r\nAdditionally, the confirm keymap can be customized in your keymap.cson:\r\n\r\n```coffeescript\r\n'atom-text-editor.autocomplete-active':\r\n  'tab': 'unset!'\r\n  'ctrl-shift-a': 'autocomplete-plus:confirm'\r\n```\r\n\r\nIf setting custom keybindings, use the `none` setting for the confirmation keymap. All this option does is not set any other keybindings. This allows the `TAB` and `ENTER` keys to be used like normal, without side effects.\r\n\r\n### Remapping Movement Commands\r\n\r\nBy default, autocomplete-plus commandeers the editor's core movement commands when the suggestion list is open. You may want to change these movement commands to use your own keybindings.\r\n\r\nFirst you need to set the `autocomplete-plus.useCoreMovementCommands` setting to `false`, which you can do from the `autocomplete-plus` settings in the settings view.\r\n\r\n![core-movement](https://cloud.githubusercontent.com/assets/69169/8839134/72a9c7e6-3087-11e5-9d1f-8d3d15961327.jpg)\r\n\r\nOr by adding this to your config file:\r\n\r\n```coffee\r\n\"*\":\r\n  \"autocomplete-plus\":\r\n    \"useCoreMovementCommands\": false\r\n```\r\n\r\nThen add these to your keymap file:\r\n\r\n```coffeescript\r\n'body atom-text-editor.autocomplete-active':\r\n  'ctrl-p': 'autocomplete-plus:move-up'\r\n  'ctrl-n': 'autocomplete-plus:move-down'\r\n  'pageup': 'autocomplete-plus:page-up'\r\n  'pagedown': 'autocomplete-plus:page-down'\r\n  'home': 'autocomplete-plus:move-to-top'\r\n  'end': 'autocomplete-plus:move-to-bottom'\r\n```\r\n\r\n## Features\r\n\r\n* Shows suggestions while typing\r\n* Includes a default provider (`SymbolProvider`):\r\n  * Wordlist generation happens when you open a file, while editing the file, and on save\r\n  * Suggestions are calculated using `fuzzaldrin`\r\n* Exposes a provider API which can be used to extend the functionality of the package and provide targeted / contextually correct suggestions\r\n* Disable autocomplete for file(s) via blacklisting, e.g. `*.md` to blacklist Markdown files\r\n* Disable autocomplete for editor scope(s) via blacklisting\r\n* Expands a snippet if an autocomplete+ provider includes one in a suggestion\r\n* Allows external editors to register for autocompletions\r\n\r\n## Provider API\r\n\r\nGreat autocomplete depends on having great autocomplete providers. If there is not already a great provider for the language / grammar that you are working in, please consider creating a provider.\r\n\r\n[Read the `Provider API` documentation](https://github.com/atom/autocomplete-plus/wiki/Provider-API) to learn how to create a new autocomplete provider.\r\n\r\n## `SymbolProvider` Configuration\r\n\r\nIf the default `SymbolProvider` is missing useful information for the language / grammar you're working with, please take a look at the [`SymbolProvider` Config API](https://github.com/atom/autocomplete-plus/wiki/SymbolProvider-Config-API).\r\n\r\n## The `watchEditor` API\r\n\r\nThe `watchEditor` method on the `AutocompleteManager` object is exposed as a [provided service](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar/#interacting-with-other-packages-via-services), named `autocomplete.watchEditor`. The method allows external editors to register for autocompletions from providers with a given set of labels. Disposing the returned object will undo this request. External packages can access this service with the following code.\r\n\r\nIn `package.json`:\r\n```\r\n{\r\n  \"consumedServices\": {\r\n    \"autocomplete.watchEditor\": {\r\n      \"versions\": {\r\n        \"1.0.0\": \"consumeAutocompleteWatchEditor\"\r\n      }\r\n    }\r\n  }\r\n}\r\n```\r\nIn the main module file:\r\n```\r\nconsumeAutocompleteWatchEditor(watchEditor) {\r\n  this.autocompleteDisposable = watchEditor(\r\n    this.editor, ['symbol-provider']\r\n  )\r\n}\r\n```\r\n",
+    "readme": "# Autocomplete+ package\n\nDisplays possible autocomplete suggestions on keystroke (or manually by typing `ctrl-space`) and inserts a suggestion in the editor if confirmed.\n\n![autocomplete+](https://cloud.githubusercontent.com/assets/744740/7656861/9fb8bcc4-faea-11e4-9814-9dca218ded93.png)\n\n[Changelog](https://github.com/pulsar-edit/pulsar/blob/master/CHANGELOG.md)\n\n## Installation\n\n`autocomplete+` is bundled with Pulsar. You don't have to do anything to install it.\n\n## Providers\n\n`autocomplete+` has a powerful autocomplete provider API, allowing provider authors to add language-specific behavior to this package.\n\nYou should *definitely* install additional providers (the default provider bundled with this package is somewhat crude): here’s [a list of all Pulsar packages (built-in or community) that provide `autocomplete.provider`](https://web.pulsar-edit.dev/packages?serviceType=provided&service=autocomplete.provider).\n\n## Usage\n\nJust type some stuff, and autocomplete+ will automatically show you some suggestions.\nPress `UP` and `DOWN` to select another suggestion, press `TAB` or `ENTER` to confirm your selection. You can change the default keymap in `Preferences`:\n\n* Keymap For Confirming A Suggestion\n\nAdditionally, the confirm keymap can be customized in your keymap.cson:\n\n```coffeescript\n'atom-text-editor.autocomplete-active':\n  'tab': 'unset!'\n  'ctrl-shift-a': 'autocomplete-plus:confirm'\n```\n\nIf setting custom keybindings, use the `none` setting for the confirmation keymap. All this option does is not set any other keybindings. This allows the `TAB` and `ENTER` keys to be used like normal, without side effects.\n\n### Remapping Movement Commands\n\nBy default, autocomplete-plus commandeers the editor's core movement commands when the suggestion list is open. You may want to change these movement commands to use your own keybindings.\n\nFirst you need to set the `autocomplete-plus.useCoreMovementCommands` setting to `false`, which you can do from the `autocomplete-plus` settings in the settings view.\n\n![core-movement](https://cloud.githubusercontent.com/assets/69169/8839134/72a9c7e6-3087-11e5-9d1f-8d3d15961327.jpg)\n\nOr by adding this to your config file:\n\n```coffee\n\"*\":\n  \"autocomplete-plus\":\n    \"useCoreMovementCommands\": false\n```\n\nThen add these to your keymap file:\n\n```coffeescript\n'body atom-text-editor.autocomplete-active':\n  'ctrl-p': 'autocomplete-plus:move-up'\n  'ctrl-n': 'autocomplete-plus:move-down'\n  'pageup': 'autocomplete-plus:page-up'\n  'pagedown': 'autocomplete-plus:page-down'\n  'home': 'autocomplete-plus:move-to-top'\n  'end': 'autocomplete-plus:move-to-bottom'\n```\n\n## Features\n\n* Shows suggestions while typing\n* Includes a default provider (`SymbolProvider`):\n  * Wordlist generation happens when you open a file, while editing the file, and on save\n  * Suggestions are calculated using `fuzzaldrin`\n* Exposes a provider API which can be used to extend the functionality of the package and provide targeted / contextually correct suggestions\n* Disable autocomplete for file(s) via blacklisting, e.g. `*.md` to blacklist Markdown files\n* Disable autocomplete for editor scope(s) via blacklisting\n* Expands a snippet if an autocomplete+ provider includes one in a suggestion\n* Allows external editors to register for autocompletions\n\n## Provider API\n\nGreat autocomplete depends on having great autocomplete providers. If there is not already a great provider for the language / grammar that you are working in, please consider creating a provider.\n\n[Read the `Provider API` documentation](./docs/provider-api.md) to learn how to create a new autocomplete provider.\n\n## `SymbolProvider` Configuration\n\nIf the default `SymbolProvider` is missing useful information for the language / grammar you're working with, please take a look at the [`SymbolProvider` Config API](https://github.com/atom/autocomplete-plus/wiki/SymbolProvider-Config-API).\n\n## The `watchEditor` API\n\nThe `watchEditor` method on the `AutocompleteManager` object is exposed as a [provided service](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar/#interacting-with-other-packages-via-services), named `autocomplete.watchEditor`. The method allows external editors to register for autocompletions from providers with a given set of labels. Disposing the returned object will undo this request. External packages can access this service with the following code.\n\nIn `package.json`:\n```\n{\n  \"consumedServices\": {\n    \"autocomplete.watchEditor\": {\n      \"versions\": {\n        \"1.0.0\": \"consumeAutocompleteWatchEditor\"\n      }\n    }\n  }\n}\n```\nIn the main module file:\n```\nconsumeAutocompleteWatchEditor(watchEditor) {\n  this.autocompleteDisposable = watchEditor(\n    this.editor, ['symbol-provider']\n  )\n}\n```\n",
     "metadata": {
       "name": "autocomplete-plus",
       "version": "2.42.6",
@@ -236,7 +238,8 @@
             "2.0.0": "consumeProvider_2",
             "3.0.0": "consumeProvider_3",
             "4.0.0": "consumeProvider_4",
-            "5.0.0": "consumeProvider_5"
+            "5.0.0": "consumeProvider_5",
+            "5.1.0": "consumeProvider_5_1"
           }
         },
         "snippets": {
@@ -293,7 +296,9 @@
           "title": "File Blacklist",
           "description": "Suggestions will not be provided for files matching this list, e.g. `*.md` for Markdown files. To blacklist more than one file extension, use comma as a separator, e.g. `*.md, *.txt` (both Markdown and text files).",
           "type": "array",
-          "default": [".*"],
+          "default": [
+            ".*"
+          ],
           "items": {
             "type": "string"
           },
@@ -322,6 +327,13 @@
           "type": "boolean",
           "default": false,
           "order": 9
+        },
+        "firstCharacterMustMatch": {
+          "title": "Enforce First-Character Match",
+          "description": "When this is enabled, the first character of the suggestion option must match the first character the user types, even when using fuzzy searching.",
+          "type": "boolean",
+          "default": false,
+          "order": 9.5
         },
         "minimumWordLength": {
           "description": "Only autocomplete when you've typed at least this many characters. Note: May not affect external providers.",
@@ -368,7 +380,10 @@
           "description": "With 'Cursor' the suggestion list appears at the cursor's position. With 'Word' it appears at the beginning of the word that's being completed.",
           "type": "string",
           "default": "Word",
-          "enum": ["Word", "Cursor"],
+          "enum": [
+            "Word",
+            "Cursor"
+          ],
           "order": 15
         },
         "suppressActivationForEditorClasses": {
@@ -430,7 +445,7 @@
     }
   },
   "autocomplete-snippets": {
-    "readme": "# autocomplete+ snippet suggestions package\r\n\r\nAdds snippets to autocomplete+ suggestions\r\n\r\n## Features\r\n\r\n* Adds user snippets and language snippets to the autocomplete+ suggestions list\r\n",
+    "readme": "# autocomplete+ snippet suggestions package\n\nAdds snippets to autocomplete+ suggestions\n\n## Features\n\n* Adds user snippets and language snippets to the autocomplete+ suggestions list\n",
     "metadata": {
       "name": "autocomplete-snippets",
       "main": "./lib/autocomplete-snippets",
@@ -458,14 +473,16 @@
     }
   },
   "autoflow": {
-    "readme": "# Autoflow package\r\n\r\nFormat the current selection to have lines no longer than 80 characters using `cmd-alt-q` on macOS and `ctrl-shift-q` on Windows and Linux. If nothing is selected, the current paragraph will be reflowed.\r\n\r\nThis package uses the config value of `editor.preferredLineLength` when set to determine desired line length.\r\n",
+    "readme": "# Autoflow package\n\nFormat the current selection to have lines no longer than 80 characters using `cmd-alt-q` on macOS and `ctrl-shift-q` on Windows and Linux. If nothing is selected, the current paragraph will be reflowed.\n\nThis package uses the config value of `editor.preferredLineLength` when set to determine desired line length.\n",
     "metadata": {
       "name": "autoflow",
       "version": "0.29.4",
       "main": "./lib/autoflow",
       "description": "Format the current selection to have lines no longer than 80 characters.\n\nThis packages uses the config value of `editor.preferredLineLength` when set.",
       "activationCommands": {
-        "atom-text-editor": ["autoflow:reflow-selection"]
+        "atom-text-editor": [
+          "autoflow:reflow-selection"
+        ]
       },
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
@@ -478,7 +495,7 @@
     }
   },
   "autosave": {
-    "readme": "# Autosave package\r\n\r\nAutosaves editor when they lose focus, are destroyed, or when the window is closed.\r\n\r\nThis package is disabled by default and can be enabled via the `autosave.enabled` config\r\nsetting or by checking *Enabled* in the settings for the *autosave* package in the\r\nSettings view.\r\n\r\n## Service API\r\nThe service exposes an object with a function `dontSaveIf`, which accepts a callback.\r\nCallbacks will be invoked with each pane item eligible for an autosave and if the callback\r\nreturns true, the item will be skipped.\r\n\r\n### Usage\r\n\r\n#### package.json\r\n``` json\r\n\"consumedServices\": {\r\n  \"autosave\": {\r\n    \"versions\": {\r\n      \"1.0.0\": \"consumeAutosave\"\r\n    }\r\n  }\r\n}\r\n```\r\n\r\n#### package initialize\r\n``` javascript\r\nconsumeAutosave({dontSaveIf}) {\r\n  dontSaveIf(paneItem -> paneItem.getPath() === '/dont/autosave/me.coffee')\r\n}\r\n```\r\n",
+    "readme": "# Autosave package\n\nAutosaves editor when they lose focus, are destroyed, or when the window is closed.\n\nThis package is disabled by default and can be enabled via the `autosave.enabled` config\nsetting or by checking *Enabled* in the settings for the *autosave* package in the\nSettings view.\n\n## Service API\nThe service exposes an object with a function `dontSaveIf`, which accepts a callback.\nCallbacks will be invoked with each pane item eligible for an autosave and if the callback\nreturns true, the item will be skipped.\n\n### Usage\n\n#### package.json\n``` json\n\"consumedServices\": {\n  \"autosave\": {\n    \"versions\": {\n      \"1.0.0\": \"consumeAutosave\"\n    }\n  }\n}\n```\n\n#### package initialize\n``` javascript\nconsumeAutosave({dontSaveIf}) {\n  dontSaveIf(paneItem -> paneItem.getPath() === '/dont/autosave/me.coffee')\n}\n```\n",
     "metadata": {
       "name": "autosave",
       "main": "./lib/autosave",
@@ -506,7 +523,7 @@
     }
   },
   "background-tips": {
-    "readme": "## Background Tips package\r\n\r\nDisplays tips about Pulsar in the background when there are no open editors.\r\n\r\n![Screen shot](https://f.cloud.github.com/assets/69169/1796267/c3de038c-6a60-11e3-8bf8-36f45684902c.png)\r\n",
+    "readme": "## Background Tips package\n\nDisplays tips about Pulsar in the background when there are no open editors.\n\n![Screen shot](https://f.cloud.github.com/assets/69169/1796267/c3de038c-6a60-11e3-8bf8-36f45684902c.png)\n",
     "metadata": {
       "name": "background-tips",
       "main": "./lib/background-tips",
@@ -524,13 +541,17 @@
     }
   },
   "base16-tomorrow-dark-theme": {
-    "readme": "# Base16 Tomorrow Dark Syntax theme\r\n\r\nPulsar theme using the ever popular [Base16 Tomorrow](https://web.archive.org/web/20220806075017/https://chriskempson.com/projects/base16/) dark colors.\r\n\r\n![Base16 Tomorrow light](https://cloud.githubusercontent.com/assets/378023/10118589/f108a568-64b6-11e5-8438-eb34dc9b40a1.png)\r\n\r\n\r\n## Install\r\n\r\nThis theme is installed by default with Pulsar and can be activated by going to the _Themes_ section in the Settings view (`cmd-,`) and selecting it from the _Syntax Themes_ drop-down menu.\r\n\r\nA\r\n[light version](../base16-tomorrow-light-theme) of this theme is also available.\r\n",
+    "readme": "# Base16 Tomorrow Dark Syntax theme\n\nPulsar theme using the ever popular [Base16 Tomorrow](https://web.archive.org/web/20220806075017/https://chriskempson.com/projects/base16/) dark colors.\n\n![Base16 Tomorrow light](https://cloud.githubusercontent.com/assets/378023/10118589/f108a568-64b6-11e5-8438-eb34dc9b40a1.png)\n\n\n## Install\n\nThis theme is installed by default with Pulsar and can be activated by going to the _Themes_ section in the Settings view (`cmd-,`) and selecting it from the _Syntax Themes_ drop-down menu.\n\nA\n[light version](../base16-tomorrow-light-theme) of this theme is also available.\n",
     "metadata": {
       "name": "base16-tomorrow-dark-theme",
       "theme": "syntax",
       "version": "1.6.0",
       "description": "Base16 dark theme developed for Atom, repurposed for Pulsar",
-      "keywords": ["base16", "dark", "syntax"],
+      "keywords": [
+        "base16",
+        "dark",
+        "syntax"
+      ],
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
       "engines": {
@@ -539,13 +560,17 @@
     }
   },
   "base16-tomorrow-light-theme": {
-    "readme": "# Base16 Tomorrow Light Syntax theme\r\n\r\nPulsar theme using the ever popular [Base16 Tomorrow](https://web.archive.org/web/20220806075017/https://chriskempson.com/projects/base16/) light colors.\r\n\r\n![Base16 Tomorrow light](https://cloud.githubusercontent.com/assets/378023/10118588/f1002474-64b6-11e5-9107-b6bedee9777a.png)\r\n\r\n\r\n## Install\r\n\r\nThis theme is installed by default with Pulsar and can be activated by going to the _Themes_ section in the Settings view (`cmd-,`) and selecting it from the _Syntax Themes_ drop-down menu.\r\n\r\nA\r\n[dark version](../base16-tomorrow-dark-theme) of this theme is also available.\r\n",
+    "readme": "# Base16 Tomorrow Light Syntax theme\n\nPulsar theme using the ever popular [Base16 Tomorrow](https://web.archive.org/web/20220806075017/https://chriskempson.com/projects/base16/) light colors.\n\n![Base16 Tomorrow light](https://cloud.githubusercontent.com/assets/378023/10118588/f1002474-64b6-11e5-9107-b6bedee9777a.png)\n\n\n## Install\n\nThis theme is installed by default with Pulsar and can be activated by going to the _Themes_ section in the Settings view (`cmd-,`) and selecting it from the _Syntax Themes_ drop-down menu.\n\nA\n[dark version](../base16-tomorrow-dark-theme) of this theme is also available.\n",
     "metadata": {
       "name": "base16-tomorrow-light-theme",
       "theme": "syntax",
       "version": "1.6.0",
       "description": "Base16 light theme developed for Atom, repurposed for Pulsar",
-      "keywords": ["base16", "light", "syntax"],
+      "keywords": [
+        "base16",
+        "light",
+        "syntax"
+      ],
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
       "engines": {
@@ -554,7 +579,7 @@
     }
   },
   "bookmarks": {
-    "readme": "# Bookmarks package\r\n\r\nBookmark lines in the editor.\r\n\r\n### Commands and Keybindings\r\n\r\n|Command|Description|Keybinding (Linux)|Keybinding (macOS)|Keybinding (Windows)|\r\n|-------|-----------|------------------|------------------|--------------------|\r\n|`bookmarks:toggle-bookmark`|Add/remove a bookmark on the current line|<kbd>ctrl-shift-f2</kbd>|<kbd>cmd-f2</kbd>|<kbd>alt-ctrl-f2</kbd>|\r\n|`bookmarks:clear-bookmarks`|Remove all bookmarks in the current editor|<kbd>alt-shift-f2</kbd>|<kbd>cmd-shift-f2</kbd>|<kbd>ctrl-shift-f2</kbd>|\r\n|`bookmarks:view-all`|View all the bookmarks|<kbd>ctrl-f2</kbd>|<kbd>ctrl-f2</kbd>|<kbd>ctrl-f2</kbd>|\r\n|`bookmarks:jump-to-next-bookmark`|Move the cursor to the next bookmark|<kbd>f2</kbd>|<kbd>f2</kbd>|<kbd>f2</kbd>|\r\n|`bookmarks:jump-to-previous-bookmark`|Move the cursor to the previous bookmark|<kbd>shift-f2</kbd>|<kbd>shift-f2</kbd>|<kbd>shift-f2</kbd>|\r\n|`bookmarks:select-to-next-bookmark`|Select the text to the next bookmark| | | |\r\n|`bookmarks:select-to-previous-bookmark`|Select the text to the previous bookmark| | | |\r\n\r\n![](https://cloud.githubusercontent.com/assets/1545996/10419203/97d75e32-7035-11e5-818f-5b34d60865c1.png)\r\n",
+    "readme": "# Bookmarks package\n\nBookmark lines in the editor.\n\n### Commands and Keybindings\n\n|Command|Description|Keybinding (Linux)|Keybinding (macOS)|Keybinding (Windows)|\n|-------|-----------|------------------|------------------|--------------------|\n|`bookmarks:toggle-bookmark`|Add/remove a bookmark on the current line|<kbd>ctrl-shift-f2</kbd>|<kbd>cmd-f2</kbd>|<kbd>alt-ctrl-f2</kbd>|\n|`bookmarks:clear-bookmarks`|Remove all bookmarks in the current editor|<kbd>alt-shift-f2</kbd>|<kbd>cmd-shift-f2</kbd>|<kbd>ctrl-shift-f2</kbd>|\n|`bookmarks:view-all`|View all the bookmarks|<kbd>ctrl-f2</kbd>|<kbd>ctrl-f2</kbd>|<kbd>ctrl-f2</kbd>|\n|`bookmarks:jump-to-next-bookmark`|Move the cursor to the next bookmark|<kbd>f2</kbd>|<kbd>f2</kbd>|<kbd>f2</kbd>|\n|`bookmarks:jump-to-previous-bookmark`|Move the cursor to the previous bookmark|<kbd>shift-f2</kbd>|<kbd>shift-f2</kbd>|<kbd>shift-f2</kbd>|\n|`bookmarks:select-to-next-bookmark`|Select the text to the next bookmark| | | |\n|`bookmarks:select-to-previous-bookmark`|Select the text to the previous bookmark| | | |\n\n![](https://cloud.githubusercontent.com/assets/1545996/10419203/97d75e32-7035-11e5-818f-5b34d60865c1.png)\n",
     "metadata": {
       "name": "bookmarks",
       "version": "0.46.0",
@@ -579,7 +604,7 @@
     }
   },
   "bracket-matcher": {
-    "readme": "# Bracket Matcher package\r\n\r\nHighlights and jumps between `[]`, `()`, and `{}`. Also highlights matching XML\r\nand HTML tags.\r\n\r\nAutocompletes `[]`, `()`, `{}`, `\"\"`, `''`, `“”`, `‘’`, `«»`, `‹›`, and\r\nbackticks by default.\r\n\r\nUse <kbd>ctrl-m</kbd> to jump to the bracket matching the one adjacent to the cursor.\r\nIt jumps to the nearest enclosing bracket when there's no adjacent bracket,\r\n\r\nUse <kbd>ctrl-cmd-m</kbd> to select all the text inside the current brackets.\r\n\r\nUse <kbd>alt-cmd-.</kbd> to close the current XML/HTML tag.\r\n\r\n---\r\n### Configuration\r\n\r\nMatching brackets and quotes are sensibly inserted for you. If you dislike this\r\nfunctionality, you can disable it from the Bracket Matcher section of the\r\nSettings View.\r\n\r\n#### Custom Pairs\r\n\r\nYou can customize matching pairs in Bracket Matcher at any time. You can do so either globally via the Settings View or at the scope level via your `config.cson`. Changes take effect immediately.\r\n\r\n* **Autocomplete Characters** - Comma-separated pairs that the editor will treat as brackets / quotes. Entries in this field override the package defaults.\r\n  * For example: `<>, (), []`\r\n\r\n* **Pairs With Extra Newline** - Comma-separated pairs that enhance the editor's auto indent feature. When used, a newline is automatically added between the pair when enter is pressed between them. Note: This feature is meant to be used in combination with brackets defined for indentation by the active language package (`increaseIndentPattern` / `decreaseIndentPattern`).\r\nExample:\r\n```\r\nfn main() {\r\n    | <---- Cursor positioned at one indent level higher\r\n}\r\n```\r\n\r\n#### Scoped settings\r\nIn addition to the global settings, you are also able to add scope-specific modifications to Pulsar in your `config.cson`. This is especially useful for editor rule changes specific to each language. Scope-specific settings override package defaults _and_ global settings.\r\nExample:\r\n```cson\r\n\".rust.source\":\r\n  \"bracket-matcher\":\r\n    autocompleteCharacters: [\r\n      \"()\"\r\n      \"[]\"\r\n      \"{}\"\r\n      \"<>\"\r\n      \"\\\"\\\"\"\r\n      \"``\"\r\n    ]\r\n```\r\n",
+    "readme": "# Bracket Matcher package\n\nHighlights and jumps between `[]`, `()`, and `{}`. Also highlights matching XML\nand HTML tags.\n\nAutocompletes `[]`, `()`, `{}`, `\"\"`, `''`, `“”`, `‘’`, `«»`, `‹›`, and\nbackticks by default.\n\nUse <kbd>ctrl-m</kbd> to jump to the bracket matching the one adjacent to the cursor.\nIt jumps to the nearest enclosing bracket when there's no adjacent bracket,\n\nUse <kbd>ctrl-cmd-m</kbd> to select all the text inside the current brackets.\n\nUse <kbd>alt-cmd-.</kbd> to close the current XML/HTML tag.\n\n---\n### Configuration\n\nMatching brackets and quotes are sensibly inserted for you. If you dislike this\nfunctionality, you can disable it from the Bracket Matcher section of the\nSettings View.\n\n#### Custom Pairs\n\nYou can customize matching pairs in Bracket Matcher at any time. You can do so either globally via the Settings View or at the scope level via your `config.cson`. Changes take effect immediately.\n\n* **Autocomplete Characters** - Comma-separated pairs that the editor will treat as brackets / quotes. Entries in this field override the package defaults.\n  * For example: `<>, (), []`\n\n* **Pairs With Extra Newline** - Comma-separated pairs that enhance the editor's auto indent feature. When used, a newline is automatically added between the pair when enter is pressed between them. Note: This feature is meant to be used in combination with brackets defined for indentation by the active language package (`increaseIndentPattern` / `decreaseIndentPattern`).\nExample:\n```\nfn main() {\n    | <---- Cursor positioned at one indent level higher\n}\n```\n\n#### Scoped settings\nIn addition to the global settings, you are also able to add scope-specific modifications to Pulsar in your `config.cson`. This is especially useful for editor rule changes specific to each language. Scope-specific settings override package defaults _and_ global settings.\nExample:\n```cson\n\".rust.source\":\n  \"bracket-matcher\":\n    autocompleteCharacters: [\n      \"()\"\n      \"[]\"\n      \"{}\"\n      \"<>\"\n      \"\\\"\\\"\"\n      \"``\"\n    ]\n```\n",
     "metadata": {
       "name": "bracket-matcher",
       "version": "0.92.0",
@@ -616,7 +641,11 @@
         "pairsWithExtraNewline": {
           "description": "Automatically add a newline between the pair when enter is pressed.",
           "type": "array",
-          "default": ["()", "[]", "{}"],
+          "default": [
+            "()",
+            "[]",
+            "{}"
+          ],
           "items": {
             "type": "string"
           }
@@ -645,14 +674,16 @@
     }
   },
   "command-palette": {
-    "readme": "# Command Palette package\r\n\r\nFind and run available commands using <kbd>cmd-shift-p</kbd> (macOS) or <kbd>ctrl-shift-p</kbd> (Linux/Windows) in Pulsar.\r\n\r\n![](https://f.cloud.github.com/assets/671378/2241354/2908b768-9ccd-11e3-9da1-a11753c0495d.png)\r\n",
+    "readme": "# Command Palette package\n\nFind and run available commands using <kbd>cmd-shift-p</kbd> (macOS) or <kbd>ctrl-shift-p</kbd> (Linux/Windows) in Pulsar.\n\n![](https://f.cloud.github.com/assets/671378/2241354/2908b768-9ccd-11e3-9da1-a11753c0495d.png)\n",
     "metadata": {
       "name": "command-palette",
       "version": "0.43.5",
       "main": "./lib/command-palette-package",
       "description": "Find and run available commands using `cmd-shift-p` (macOS) or `ctrl-shift-p` (Linux/Windows).",
       "activationCommands": {
-        "atom-workspace": ["command-palette:toggle"]
+        "atom-workspace": [
+          "command-palette:toggle"
+        ]
       },
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
@@ -680,7 +711,7 @@
     }
   },
   "dalek": {
-    "readme": "# dalek\r\n\r\n**EXTERMINATEs** core packages installed in `~/.pulsar/packages`.\r\n\r\n## Why worry?\r\n\r\nWhen people install core Pulsar packages as if they are community packages, it can cause many problems that are very hard to diagnose. This package is intended to notify people when they are in this precarious position so they can take corrective action.\r\n\r\n## I got a warning, what do I do?\r\n\r\n1. Note down the packages named in the notification\r\n2. Exit Pulsar\r\n3. Open a command prompt\r\n4. For each package named in the notification, execute `pulsar -p uninstall [package-name]`\r\n5. Start Pulsar again normally to verify that the warning notification no longer appears\r\n\r\n## I have more questions. Where can I ask them?\r\n\r\nPlease feel free to ask in any of our [Community Areas](https://pulsar-edit.dev/community.html).\r\n",
+    "readme": "# dalek\n\n**EXTERMINATEs** core packages installed in `~/.pulsar/packages`.\n\n## Why worry?\n\nWhen people install core Pulsar packages as if they are community packages, it can cause many problems that are very hard to diagnose. This package is intended to notify people when they are in this precarious position so they can take corrective action.\n\n## I got a warning, what do I do?\n\n1. Note down the packages named in the notification\n2. Exit Pulsar\n3. Open a command prompt\n4. For each package named in the notification, execute `pulsar -p uninstall [package-name]`\n5. Start Pulsar again normally to verify that the warning notification no longer appears\n\n## I have more questions. Where can I ask them?\n\nPlease feel free to ask in any of our [Community Areas](https://pulsar-edit.dev/community.html).\n",
     "metadata": {
       "name": "dalek",
       "main": "./lib/main",
@@ -702,7 +733,7 @@
     }
   },
   "deprecation-cop": {
-    "readme": "# Deprecation Cop package\r\n\r\nShows a list of deprecated methods calls. Ideally it should show nothing!\r\n\r\n![https://github-images.s3.amazonaws.com/skitch/Deprecation_Cop_-__Users_corey_github_deprecation-cop-20140414-144618.jpg](https://github-images.s3.amazonaws.com/skitch/Deprecation_Cop_-__Users_corey_github_deprecation-cop-20140414-144618.jpg)\r\n",
+    "readme": "# Deprecation Cop package\n\nShows a list of deprecated methods calls. Ideally it should show nothing!\n\n![https://github-images.s3.amazonaws.com/skitch/Deprecation_Cop_-__Users_corey_github_deprecation-cop-20140414-144618.jpg](https://github-images.s3.amazonaws.com/skitch/Deprecation_Cop_-__Users_corey_github_deprecation-cop-20140414-144618.jpg)\n",
     "metadata": {
       "name": "deprecation-cop",
       "main": "./lib/main",
@@ -732,7 +763,7 @@
     }
   },
   "dev-live-reload": {
-    "readme": "# Dev Live Reload package\r\n\r\nThis live reloads the Pulsar `.less` files. You edit styles and they are magically reflected in any running Pulsar windows. Magic! :tophat: :sparkles: :rabbit2:\r\n\r\nInstalled by default on Pulsar windows running in dev mode. Use the \"Application: Open Dev\" command to open a new dev mode window.\r\n\r\nUse <kbd>meta-shift-ctrl-r</kbd> to reload all core and package stylesheets.\r\n\r\nThis package is __experimental__, it does not handle the following:\r\n\r\n* File additions to a theme. New files will not be watched.\r\n\r\n![gif](https://f.cloud.github.com/assets/69169/1387004/d2dc45f2-3b84-11e3-877e-cac8c51e9702.gif)\r\n",
+    "readme": "# Dev Live Reload package\n\nThis live reloads the Pulsar `.less` files. You edit styles and they are magically reflected in any running Pulsar windows. Magic! :tophat: :sparkles: :rabbit2:\n\nInstalled by default on Pulsar windows running in dev mode. Use the \"Application: Open Dev\" command to open a new dev mode window.\n\nUse <kbd>meta-shift-ctrl-r</kbd> to reload all core and package stylesheets.\n\nThis package is __experimental__, it does not handle the following:\n\n* File additions to a theme. New files will not be watched.\n\n![gif](https://f.cloud.github.com/assets/69169/1387004/d2dc45f2-3b84-11e3-877e-cac8c51e9702.gif)\n",
     "metadata": {
       "name": "dev-live-reload",
       "main": "./lib/main",
@@ -749,7 +780,7 @@
     }
   },
   "encoding-selector": {
-    "readme": "# Encoding Selector package\r\n\r\nPick the encoding in the editor using <kbd>ctrl-shift-U</kbd> or by clicking the current encoding name in the status bar.\r\n\r\n![screenshot](https://cloud.githubusercontent.com/assets/671378/4815579/1334d066-5ed8-11e4-8cce-a1734be09c8a.png)\r\n",
+    "readme": "# Encoding Selector package\n\nPick the encoding in the editor using <kbd>ctrl-shift-U</kbd> or by clicking the current encoding name in the status bar.\n\n![screenshot](https://cloud.githubusercontent.com/assets/671378/4815579/1334d066-5ed8-11e4-8cce-a1734be09c8a.png)\n",
     "metadata": {
       "name": "encoding-selector",
       "version": "0.23.9",
@@ -774,30 +805,8 @@
       }
     }
   },
-  "exception-reporting": {
-    "readme": "## Exception Reporting package\r\n\r\nReports uncaught exceptions in Pulsar to [bugsnag](https://bugsnag.com).\r\n",
-    "metadata": {
-      "name": "exception-reporting",
-      "main": "./lib/main",
-      "version": "0.43.1",
-      "description": "Reports uncaught Pulsar exceptions to the Pulsar team via bugsnag.com",
-      "repository": "https://github.com/pulsar-edit/pulsar",
-      "license": "MIT",
-      "engines": {
-        "atom": ">0.48.0"
-      },
-      "dependencies": {
-        "node-uuid": "~1.4.7",
-        "stack-trace": "0.0.9",
-        "underscore-plus": "^1.7.0"
-      },
-      "devDependencies": {
-        "semver": "^5.3.0"
-      }
-    }
-  },
   "find-and-replace": {
-    "readme": "# Find and Replace package\r\n\r\nFind and replace in the current buffer or across the entire project.\r\n\r\n## Find in buffer\r\n\r\nUsing the shortcut <kbd>cmd-f</kbd> (Mac) or <kbd>ctrl-f</kbd> (Windows and Linux).\r\n![screen shot 2013-11-26 at 12 25 22 pm](https://f.cloud.github.com/assets/69169/1625938/a859fa70-56d9-11e3-8b2a-ac37c5033159.png)\r\n\r\n## Find in project\r\n\r\nUsing the shortcut <kbd>cmd-shift-f</kbd> (Mac) or <kbd>ctrl-shift-f</kbd> (Windows and Linux).\r\n![screen shot 2013-11-26 at 12 26 02 pm](https://f.cloud.github.com/assets/69169/1625945/b216d7b8-56d9-11e3-8b14-6afc33467be9.png)\r\n\r\n## Provided Service\r\n\r\nIf you need access the marker layer containing result markers for a given editor, use the `find-and-replace@0.0.1` service. The service exposes one method, `resultsMarkerLayerForTextEditor`, which takes a `TextEditor` and returns a `TextEditorMarkerLayer` that you can interact with. Keep in mind that any work you do in synchronous event handlers on this layer will impact the performance of find and replace.\r\n",
+    "readme": "# Find and Replace package\n\nFind and replace in the current buffer or across the entire project.\n\n## Find in buffer\n\nUsing the shortcut <kbd>cmd-f</kbd> (Mac) or <kbd>ctrl-f</kbd> (Windows and Linux).\n![screen shot 2013-11-26 at 12 25 22 pm](https://f.cloud.github.com/assets/69169/1625938/a859fa70-56d9-11e3-8b2a-ac37c5033159.png)\n\n## Find in project\n\nUsing the shortcut <kbd>cmd-shift-f</kbd> (Mac) or <kbd>ctrl-shift-f</kbd> (Windows and Linux).\n![screen shot 2013-11-26 at 12 26 02 pm](https://f.cloud.github.com/assets/69169/1625945/b216d7b8-56d9-11e3-8b14-6afc33467be9.png)\n\n## Provided Service\n\nIf you need access the marker layer containing result markers for a given editor, use the `find-and-replace@0.0.1` service. The service exposes one method, `resultsMarkerLayerForTextEditor`, which takes a `TextEditor` and returns a `TextEditorMarkerLayer` that you can interact with. Keep in mind that any work you do in synchronous event handlers on this layer will impact the performance of find and replace.\n",
     "metadata": {
       "name": "find-and-replace",
       "main": "./lib/find",
@@ -874,7 +883,11 @@
         "projectSearchResultsPaneSplitDirection": {
           "type": "string",
           "default": "none",
-          "enum": ["none", "right", "down"],
+          "enum": [
+            "none",
+            "right",
+            "down"
+          ],
           "title": "Direction to open results pane",
           "description": "Direction to split the active pane when showing project search results. If 'none', the results will be shown in the active pane."
         },
@@ -942,7 +955,7 @@
     }
   },
   "fuzzy-finder": {
-    "readme": "# Fuzzy Finder package\r\n\r\nQuickly find and open files using <kbd>cmd/ctrl-t</kbd>.\r\n\r\n  * <kbd>cmd-t</kbd>/<kbd>cmd-p</kbd> *(macOS)* or <kbd>ctrl-t</kbd>/<kbd>ctrl-p</kbd> *(Linux/Windows)* to open the file finder\r\n  * <kbd>cmd-b</kbd> *(macOS)* or <kbd>ctrl-b</kbd> *(Linux/Windows)* to open the list of open buffers\r\n  * <kbd>cmd-shift-b</kbd> *(macOS)* or <kbd>ctrl-shift-b</kbd> *(Linux/Windows)* to open the list of Git modified and untracked files\r\n\r\nWhen opening a file, you can control the behavior.\r\n\r\n  * <kbd>enter</kbd> defaults to opening the selected file without leaving the current pane\r\n  * <kbd>shift-enter</kbd> defaults to switching to another pane if the file is already open there\r\n  * <kbd>cmd-k</kbd> <kbd>right</kbd> *(macOS)* or <kbd>ctrl-k</kbd> <kbd>right</kbd> *(Linux/Windows)* (or any other directional arrow) will open the highlighted file in a new pane on the side indicated by the arrow\r\n  * Adding `:<line number>` to the end of your search will go directly to the line number you specify, or the last line if the number is larger\r\n\r\nTurning on the \"Search All Panes\" setting reverses the behavior of <kbd>enter</kbd> and <kbd>shift-enter</kbd> so <kbd>enter</kbd> opens the file in any pane and <kbd>shift-enter</kbd> creates a new tab in the current pane.\r\n\r\nThis package uses both the `core.ignoredNames` and `fuzzy-finder.ignoredNames` config settings to filter out files and folders that will not be shown. Both of those config settings are interpreted as arrays of [minimatch](https://github.com/isaacs/minimatch) glob patterns.\r\n\r\nThis package also will also not show Git ignored files when the `core.excludeVcsIgnoredPaths` is enabled.\r\n\r\n![](https://f.cloud.github.com/assets/671378/2241456/100db6b8-9cd3-11e3-9b3a-569c6b50cc60.png)\r\n",
+    "readme": "# Fuzzy Finder package\n\nQuickly find and open files using <kbd>cmd/ctrl-t</kbd>.\n\n  * <kbd>cmd-t</kbd>/<kbd>cmd-p</kbd> *(macOS)* or <kbd>ctrl-t</kbd>/<kbd>ctrl-p</kbd> *(Linux/Windows)* to open the file finder\n  * <kbd>cmd-b</kbd> *(macOS)* or <kbd>ctrl-b</kbd> *(Linux/Windows)* to open the list of open buffers\n  * <kbd>cmd-shift-b</kbd> *(macOS)* or <kbd>ctrl-shift-b</kbd> *(Linux/Windows)* to open the list of Git modified and untracked files\n\nWhen opening a file, you can control the behavior.\n\n  * <kbd>enter</kbd> defaults to opening the selected file without leaving the current pane\n  * <kbd>shift-enter</kbd> defaults to switching to another pane if the file is already open there\n  * <kbd>cmd-k</kbd> <kbd>right</kbd> *(macOS)* or <kbd>ctrl-k</kbd> <kbd>right</kbd> *(Linux/Windows)* (or any other directional arrow) will open the highlighted file in a new pane on the side indicated by the arrow\n  * Adding `:<line number>` to the end of your search will go directly to the line number you specify, or the last line if the number is larger\n\nTurning on the \"Search All Panes\" setting reverses the behavior of <kbd>enter</kbd> and <kbd>shift-enter</kbd> so <kbd>enter</kbd> opens the file in any pane and <kbd>shift-enter</kbd> creates a new tab in the current pane.\n\nThis package uses both the `core.ignoredNames` and `fuzzy-finder.ignoredNames` config settings to filter out files and folders that will not be shown. Both of those config settings are interpreted as arrays of [minimatch](https://github.com/isaacs/minimatch) glob patterns.\n\nThis package also will also not show Git ignored files when the `core.excludeVcsIgnoredPaths` is enabled.\n\n![](https://f.cloud.github.com/assets/671378/2241456/100db6b8-9cd3-11e3-9b3a-569c6b50cc60.png)\n",
     "metadata": {
       "name": "fuzzy-finder",
       "version": "1.14.3",
@@ -953,7 +966,7 @@
       "dependencies": {
         "atom-select-list": "^0.7.0",
         "fs-plus": "^3.0.0",
-        "minimatch": "~3.0.3",
+        "minimatch": "~3.1.0",
         "underscore-plus": "^1.7.0",
         "vscode-ripgrep": "^1.2.5",
         "wrench": "^1.5"
@@ -1018,7 +1031,7 @@
     }
   },
   "git-diff": {
-    "readme": "# Git Diff package\r\n\r\nMarks lines in the editor gutter that have been added, edited, or deleted since the last commit.\r\n\r\n  * <kbd>alt-g up</kbd> to move the cursor to the previous diff in the editor\r\n  * <kbd>alt-g down</kbd> to move the cursor to the next diff in the editor\r\n\r\n![](https://f.cloud.github.com/assets/671378/2241519/04791a24-9cd6-11e3-9a12-164cabe81d58.png)\r\n",
+    "readme": "# Git Diff package\n\nMarks lines in the editor gutter that have been added, edited, or deleted since the last commit.\n\n  * <kbd>alt-g up</kbd> to move the cursor to the previous diff in the editor\n  * <kbd>alt-g down</kbd> to move the cursor to the next diff in the editor\n\n![](https://f.cloud.github.com/assets/671378/2241519/04791a24-9cd6-11e3-9a12-164cabe81d58.png)\n",
     "metadata": {
       "name": "git-diff",
       "version": "1.3.9",
@@ -1051,7 +1064,7 @@
     }
   },
   "go-to-line": {
-    "readme": "# Go To Line package\r\n\r\nMove the cursor to a specific line in the editor using <kbd>ctrl-g</kbd>.\r\n\r\n![](https://f.cloud.github.com/assets/671378/2241602/fdd88c4c-9cd8-11e3-9d14-74844ec7da01.png)\r\n",
+    "readme": "# Go To Line package\n\nMove the cursor to a specific line in the editor using <kbd>ctrl-g</kbd>.\n\n![](https://f.cloud.github.com/assets/671378/2241602/fdd88c4c-9cd8-11e3-9d14-74844ec7da01.png)\n",
     "metadata": {
       "name": "go-to-line",
       "version": "0.33.0",
@@ -1059,7 +1072,9 @@
       "description": "Jump to a specific editor line number with `ctrl-g`.",
       "license": "MIT",
       "activationCommands": {
-        "atom-text-editor": ["go-to-line:toggle"]
+        "atom-text-editor": [
+          "go-to-line:toggle"
+        ]
       },
       "repository": "https://github.com/pulsar-edit/pulsar",
       "engines": {
@@ -1068,7 +1083,7 @@
     }
   },
   "grammar-selector": {
-    "readme": "# Grammar Selector package\r\n\r\nPick the grammar used for syntax highlighting using <kbd>ctrl-shift-L</kbd> or by clicking the current grammar name in the status bar.\r\n\r\n![](https://f.cloud.github.com/assets/671378/2241618/b7661f08-9cd9-11e3-8276-fe1c02955901.png)\r\n",
+    "readme": "# Grammar Selector package\n\nPick the grammar used for syntax highlighting using <kbd>ctrl-shift-L</kbd> or by clicking the current grammar name in the status bar.\n\n![](https://f.cloud.github.com/assets/671378/2241618/b7661f08-9cd9-11e3-8276-fe1c02955901.png)\n",
     "metadata": {
       "name": "grammar-selector",
       "version": "0.50.1",
@@ -1105,7 +1120,7 @@
     }
   },
   "image-view": {
-    "readme": "# Image View package\r\n\r\nOpen images in an editor in Pulsar. Support zooming via <kbd>cmd-+</kbd>, <kbd>cmd--</kbd>, and <kbd>cmd-0</kbd>.\r\n\r\n\r\nCurrently supports the following file extensions:\r\n\r\n  * `.bmp`\r\n  * `.gif`\r\n  * `.ico`\r\n  * `.jpeg`\r\n  * `.jpg`\r\n  * `.png`\r\n  * `.webp`\r\n\r\n![](https://f.cloud.github.com/assets/671378/2241669/7df82fec-9cdc-11e3-992d-f19a7235ebda.png)\r\n",
+    "readme": "# Image View package\n\nOpen images in an editor in Pulsar. Support zooming via <kbd>cmd-+</kbd>, <kbd>cmd--</kbd>, and <kbd>cmd-0</kbd>.\n\n\nCurrently supports the following file extensions:\n\n  * `.bmp`\n  * `.gif`\n  * `.ico`\n  * `.jpeg`\n  * `.jpg`\n  * `.png`\n  * `.webp`\n\n![](https://f.cloud.github.com/assets/671378/2241669/7df82fec-9cdc-11e3-992d-f19a7235ebda.png)\n",
     "metadata": {
       "name": "image-view",
       "version": "0.64.0",
@@ -1133,7 +1148,7 @@
     }
   },
   "incompatible-packages": {
-    "readme": "# Incompatible Packages package\r\n\r\nDisplays a list of installed Pulsar packages that have native module\r\ndependencies that are not compatible with the current version of Pulsar.\r\n\r\n![](https://cloud.githubusercontent.com/assets/671378/3767534/3f099820-18ce-11e4-9fa0-feef7947aab2.png)\r\n",
+    "readme": "# Incompatible Packages package\n\nDisplays a list of installed Pulsar packages that have native module\ndependencies that are not compatible with the current version of Pulsar.\n\n![](https://cloud.githubusercontent.com/assets/671378/3767534/3f099820-18ce-11e4-9fa0-feef7947aab2.png)\n",
     "metadata": {
       "name": "incompatible-packages",
       "main": "./lib/main",
@@ -1160,7 +1175,7 @@
     }
   },
   "keybinding-resolver": {
-    "readme": "# Keybinding Resolver package\r\n\r\nShows what commands a keybinding resolves to.\r\n\r\nYou can open and close the resolver using <kbd>Cmd+.</kbd> (macOS) or <kbd>Ctrl+.</kbd> (Linux and Windows).\r\n\r\nPlease note the clipboard icon which can be selected to copy the given keybinding\r\ndirective so that you can easily paste it into your keymap files.\r\n\r\n![](https://user-images.githubusercontent.com/4137660/44482876-8de73a80-a617-11e8-8bd5-24023c96b39e.png)\r\n",
+    "readme": "# Keybinding Resolver package\n\nShows what commands a keybinding resolves to.\n\nYou can open and close the resolver using <kbd>Cmd+.</kbd> (macOS) or <kbd>Ctrl+.</kbd> (Linux and Windows).\n\nPlease note the clipboard icon which can be selected to copy the given keybinding\ndirective so that you can easily paste it into your keymap files.\n\n![](https://user-images.githubusercontent.com/4137660/44482876-8de73a80-a617-11e8-8bd5-24023c96b39e.png)\n",
     "metadata": {
       "name": "keybinding-resolver",
       "main": "./lib/main",
@@ -1182,22 +1197,20 @@
     }
   },
   "language-c": {
-    "readme": "# C/C++ language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to C/C++ files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\r\nfrom the [C TextMate bundle](https://github.com/textmate/c.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a\r\npull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# C/C++ language support in Pulsar\n\nAdds syntax highlighting and snippets to C/C++ files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\nfrom the [C TextMate bundle](https://github.com/textmate/c.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a\npull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "version": "0.60.20",
       "name": "language-c",
       "description": "Atom language support for C/C++",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "main": "lib/main",
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
       "engines": {
         "atom": "*",
         "node": ">=12"
-      },
-      "dependencies": {
-        "tree-sitter-c": "0.20.2",
-        "tree-sitter-cpp": "0.20.0"
       },
       "consumedServices": {
         "hyperlink.injection": {
@@ -1214,7 +1227,7 @@
     }
   },
   "language-clojure": {
-    "readme": "# Clojure language support in Pulsar\r\n\r\nAdds syntax highlighting to Clojure files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\r\nfrom the [Clojure TextMate bundle](https://github.com/mmcgrana/textmate-clojure).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Clojure language support in Pulsar\n\nAdds syntax highlighting to Clojure files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\nfrom the [Clojure TextMate bundle](https://github.com/mmcgrana/textmate-clojure).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-clojure",
       "version": "0.22.8",
@@ -1246,7 +1259,7 @@
     }
   },
   "language-coffee-script": {
-    "readme": "# CoffeeScript language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to CoffeeScript files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [CoffeeScript TextMate bundle](https://github.com/jashkenas/coffee-script-tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# CoffeeScript language support in Pulsar\n\nAdds syntax highlighting and snippets to CoffeeScript files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [CoffeeScript TextMate bundle](https://github.com/jashkenas/coffee-script-tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "version": "0.50.0",
       "name": "language-coffee-script",
@@ -1260,14 +1273,18 @@
     }
   },
   "language-csharp": {
-    "readme": "# C# language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to C# files in Pulsar.\r\n\r\nThe C# grammar comes from the [.NET Foundation's C# grammar](https://github.com/dotnet/csharp-tmLanguage)\r\n\r\nContributions and issues with the the grammar should be raised upstream.\r\n",
+    "readme": "# C# language support in Pulsar\n\nAdds syntax highlighting and snippets to C# files in Pulsar.\n\nThe C# grammar comes from the [.NET Foundation's C# grammar](https://github.com/dotnet/csharp-tmLanguage)\n\nContributions and issues with the the grammar should be raised upstream.\n",
     "metadata": {
       "name": "language-csharp",
       "version": "1.1.0",
       "private": true,
       "description": "C# language support for Atom",
       "repository": "https://github.com/pulsar-edit/pulsar",
-      "keywords": ["C#", "csharp", ".Net"],
+      "keywords": [
+        "C#",
+        "csharp",
+        ".Net"
+      ],
       "license": "MIT",
       "engines": {
         "atom": ">0.50.0"
@@ -1275,11 +1292,13 @@
     }
   },
   "language-css": {
-    "readme": "# CSS language support in Pulsar\r\n\r\nAdds syntax highlighting, completions, and snippets to CSS files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\r\nfrom the [CSS TextMate bundle](https://github.com/textmate/css.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a\r\npull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# CSS language support in Pulsar\n\nAdds syntax highlighting, completions, and snippets to CSS files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\nfrom the [CSS TextMate bundle](https://github.com/textmate/css.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a\npull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-css",
       "description": "CSS support in Atom",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "version": "0.45.4",
       "engines": {
         "atom": "*",
@@ -1288,9 +1307,6 @@
       "main": "lib/main",
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
-      "dependencies": {
-        "tree-sitter-css": "^0.19.0"
-      },
       "consumedServices": {
         "hyperlink.injection": {
           "versions": {
@@ -1306,7 +1322,7 @@
     }
   },
   "language-gfm": {
-    "readme": "# GitHub flavored Markdown package\r\n\r\nAdds syntax highlighting and snippets to [GitHub flavored Markdown](https://help.github.com/articles/github-flavored-markdown) files in Pulsar.\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# GitHub flavored Markdown package\n\nAdds syntax highlighting and snippets to [GitHub flavored Markdown](https://help.github.com/articles/github-flavored-markdown) files in Pulsar.\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-gfm",
       "version": "0.90.8",
@@ -1330,7 +1346,7 @@
     }
   },
   "language-git": {
-    "readme": "# Git editing support in Pulsar\r\n\r\nAdds syntax highlighting to Git commit, merge, and rebase messages edited in Pulsar.\r\n\r\nYou can configure Pulsar to be your Git editor with the following command:\r\n\r\n```sh\r\ngit config --global core.editor \"pulsar --wait\"\r\n```\r\n\r\n## Commit message highlighting\r\n\r\nThis package uses warning and error highlighting to help bring attention to some violations of [standard conventions around commit message best practices](http://chris.beams.io/posts/git-commit/#seven-rules):\r\n\r\n1. If the subject line goes beyond 50 characters and again if it goes beyond 72 characters\r\n1. If the subject line begins with a lower-case letter (emoji at the beginning of the subject line won't be highlighted)\r\n1. If the subject line ends with a period\r\n1. If any non-comment body line goes beyond 72 characters\r\n\r\n## Diff highlighting\r\n\r\nIf [language-diff](https://web.pulsar-edit.dev/packages/language-diff) is installed, the\r\ndiff part of `git commit --verbose` messages is highlighted as well.\r\n\r\n## Background\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Git TextMate bundle](https://github.com/textmate/git.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Git editing support in Pulsar\n\nAdds syntax highlighting to Git commit, merge, and rebase messages edited in Pulsar.\n\nYou can configure Pulsar to be your Git editor with the following command:\n\n```sh\ngit config --global core.editor \"pulsar --wait\"\n```\n\n## Commit message highlighting\n\nThis package uses warning and error highlighting to help bring attention to some violations of [standard conventions around commit message best practices](http://chris.beams.io/posts/git-commit/#seven-rules):\n\n1. If the subject line goes beyond 50 characters and again if it goes beyond 72 characters\n1. If the subject line begins with a lower-case letter (emoji at the beginning of the subject line won't be highlighted)\n1. If the subject line ends with a period\n1. If any non-comment body line goes beyond 72 characters\n\n## Diff highlighting\n\nIf [language-diff](https://web.pulsar-edit.dev/packages/language-diff) is installed, the\ndiff part of `git commit --verbose` messages is highlighted as well.\n\n## Background\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Git TextMate bundle](https://github.com/textmate/git.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-git",
       "version": "0.19.1",
@@ -1344,12 +1360,14 @@
     }
   },
   "language-go": {
-    "readme": "# Go language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to Go files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Go TextMate bundle](https://github.com/rsms/Go.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Go language support in Pulsar\n\nAdds syntax highlighting and snippets to Go files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Go TextMate bundle](https://github.com/rsms/Go.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-go",
       "description": "Go language support in Atom",
       "main": "lib/main",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "version": "0.47.3",
       "license": "MIT",
       "engines": {
@@ -1357,9 +1375,6 @@
         "node": ">=14"
       },
       "repository": "https://github.com/pulsar-edit/pulsar",
-      "dependencies": {
-        "tree-sitter-go": "0.19.1"
-      },
       "consumedServices": {
         "hyperlink.injection": {
           "versions": {
@@ -1375,13 +1390,15 @@
     }
   },
   "language-html": {
-    "readme": "# HTML language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to HTML files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\r\nfrom the [HTML TextMate bundle](https://github.com/textmate/html.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a\r\npull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# HTML language support in Pulsar\n\nAdds syntax highlighting and snippets to HTML files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\nfrom the [HTML TextMate bundle](https://github.com/textmate/html.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a\npull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-html",
       "main": "lib/main",
       "version": "0.53.1",
       "description": "HTML language support in Atom",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "engines": {
         "atom": "*",
         "node": ">=14"
@@ -1389,9 +1406,7 @@
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
       "dependencies": {
-        "atom-grammar-test": "^0.6.3",
-        "tree-sitter-embedded-template": "0.19.0",
-        "tree-sitter-html": "0.19.0"
+        "atom-grammar-test": "^0.6.3"
       },
       "devDependencies": {
         "dedent": "^0.7.0"
@@ -1411,7 +1426,7 @@
     }
   },
   "language-hyperlink": {
-    "readme": "# Hyperlink colorization in Pulsar\r\n\r\nAdds syntax highlighting to hyperlinks embedded in strings, comments, and plain\r\ntext in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\r\nfrom the [Hyperlink Helper TextMate bundle](https://github.com/textmate/hyperlink-helper.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a\r\npull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Hyperlink colorization in Pulsar\n\nAdds syntax highlighting to hyperlinks embedded in strings, comments, and plain\ntext in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\nfrom the [Hyperlink Helper TextMate bundle](https://github.com/textmate/hyperlink-helper.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a\npull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-hyperlink",
       "version": "0.17.1",
@@ -1433,7 +1448,7 @@
     }
   },
   "language-java": {
-    "readme": "# Java language support in Pulsar\r\n\r\nAdd syntax highlighting and snippets to Java/JSP files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Java TextMate bundle](https://github.com/textmate/java.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Java language support in Pulsar\n\nAdd syntax highlighting and snippets to Java/JSP files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Java TextMate bundle](https://github.com/textmate/java.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-java",
       "main": "lib/main",
@@ -1445,9 +1460,6 @@
       },
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
-      "dependencies": {
-        "tree-sitter-java": "0.19.1"
-      },
       "consumedServices": {
         "hyperlink.injection": {
           "versions": {
@@ -1463,7 +1475,7 @@
     }
   },
   "language-javascript": {
-    "readme": "# JavaScript language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets for JavaScript in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\r\nfrom the [JavaScript TextMate bundle](https://github.com/textmate/javascript.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a\r\npull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# JavaScript language support in Pulsar\n\nAdds syntax highlighting and snippets for JavaScript in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\nfrom the [JavaScript TextMate bundle](https://github.com/textmate/javascript.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a\npull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-javascript",
       "version": "0.134.2",
@@ -1475,12 +1487,9 @@
       "main": "lib/main",
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
-      "keywords": ["tree-sitter"],
-      "dependencies": {
-        "tree-sitter-javascript": "0.19.0",
-        "tree-sitter-jsdoc": "0.19.0",
-        "tree-sitter-regex": "0.19.0"
-      },
+      "keywords": [
+        "tree-sitter"
+      ],
       "configSchema": {
         "indentation": {
           "title": "Indentation",
@@ -1553,7 +1562,7 @@
     }
   },
   "language-json": {
-    "readme": "# JSON language support in Pulsar\r\n\r\nAdds syntax highlighting of JSON files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [JSON TextMate bundle](https://github.com/textmate/json.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# JSON language support in Pulsar\n\nAdds syntax highlighting of JSON files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [JSON TextMate bundle](https://github.com/textmate/json.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n\n## Comments in JSON\n\nComments are disallowed in the JSON specification, but many libraries for parsing JSON tolerate their presence.\n\nThis package contains two grammars: **JSON** and **JSON with Comments**. The **JSON with Comments** grammar is used by default with `.jsonc` files (the JSON-with-comments file extension popularized by Visual Studio Code) and supports comments. A user can also switch to this grammar manually via the grammar selector.\n\nBy default, the **JSON** grammar marks comments as illegal. But you can opt into tolerance of comments in `.json` files by enabling the **Allow Comments in .json files** option.\n",
     "metadata": {
       "name": "language-json",
       "main": "lib/main",
@@ -1565,13 +1574,30 @@
       },
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
-      "dependencies": {
-        "tree-sitter-json": "0.20.0"
+      "configSchema": {
+        "allowCommentsInJsonFiles": {
+          "type": "boolean",
+          "title": "Allow Comments in .json files",
+          "description": "When checked, will allow comments in `.json` files even though they’re not valid according to the official JSON specification. When unchecked, comments in `.json` files will be marked as invalid, and only files with the `.jsonc` extension will mark comments as valid and allowed. (It’s recommended to reload your window or restart Pulsar after changing this setting.)",
+          "default": false
+        }
+      },
+      "consumedServices": {
+        "hyperlink.injection": {
+          "versions": {
+            "0.1.0": "consumeHyperlinkInjection"
+          }
+        },
+        "todo.injection": {
+          "versions": {
+            "0.1.0": "consumeTodoInjection"
+          }
+        }
       }
     }
   },
   "language-less": {
-    "readme": "# Less language support in Pulsar\r\n\r\nAdds syntax highlighting to [Less](http://lesscss.org) files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Less TextMate bundle](https://github.com/textmate/less.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Less language support in Pulsar\n\nAdds syntax highlighting to [Less](http://lesscss.org) files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Less TextMate bundle](https://github.com/textmate/less.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-less",
       "version": "0.34.3",
@@ -1590,7 +1616,7 @@
     }
   },
   "language-make": {
-    "readme": "# Make language support in Pulsar\r\n\r\nAdds syntax highlighting to [Makefiles](https://www.gnu.org/software/make/manual/make.html) in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Make TextMate bundle](https://github.com/textmate/make.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Make language support in Pulsar\n\nAdds syntax highlighting to [Makefiles](https://www.gnu.org/software/make/manual/make.html) in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Make TextMate bundle](https://github.com/textmate/make.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-make",
       "version": "0.23.0",
@@ -1604,7 +1630,7 @@
     }
   },
   "language-mustache": {
-    "readme": "# Mustache/Handlebars support in Pulsar\r\n\r\nAdds syntax highlighting to [Mustache](http://mustache.github.io) and [Handlebars](http://handlebarsjs.com) files in Pulsar.\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Mustache/Handlebars support in Pulsar\n\nAdds syntax highlighting to [Mustache](http://mustache.github.io) and [Handlebars](http://handlebarsjs.com) files in Pulsar.\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-mustache",
       "version": "0.14.5",
@@ -1618,7 +1644,7 @@
     }
   },
   "language-objective-c": {
-    "readme": "# Objective-C language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to Objective-C files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Objective-C TextMate bundle](https://github.com/textmate/objective-c.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Objective-C language support in Pulsar\n\nAdds syntax highlighting and snippets to Objective-C files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Objective-C TextMate bundle](https://github.com/textmate/objective-c.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-objective-c",
       "version": "0.16.0",
@@ -1632,7 +1658,7 @@
     }
   },
   "language-perl": {
-    "readme": "# Perl language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to Perl files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Perl TextMate bundle](https://github.com/textmate/perl.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Perl language support in Pulsar\n\nAdds syntax highlighting and snippets to Perl files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Perl TextMate bundle](https://github.com/textmate/perl.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-perl",
       "version": "0.38.1",
@@ -1646,7 +1672,7 @@
     }
   },
   "language-php": {
-    "readme": "# PHP language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to PHP files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [PHP TextMate bundle](https://github.com/textmate/php.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# PHP language support in Pulsar\n\nAdds syntax highlighting and snippets to PHP files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [PHP TextMate bundle](https://github.com/textmate/php.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-php",
       "version": "0.48.1",
@@ -1673,7 +1699,7 @@
     }
   },
   "language-property-list": {
-    "readme": "# Property list support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to [plist](https://en.wikipedia.org/wiki/Property_list)\r\nfiles in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\r\nfrom the [Property List TextMate bundle](https://github.com/textmate/property-list.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a\r\npull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Property list support in Pulsar\n\nAdds syntax highlighting and snippets to [plist](https://en.wikipedia.org/wiki/Property_list)\nfiles in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\nfrom the [Property List TextMate bundle](https://github.com/textmate/property-list.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a\npull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-property-list",
       "version": "0.9.1",
@@ -1687,7 +1713,7 @@
     }
   },
   "language-python": {
-    "readme": "# Python language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to Python files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Python TextMate bundle](https://github.com/textmate/python.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Python language support in Pulsar\n\nAdds syntax highlighting and snippets to Python files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Python TextMate bundle](https://github.com/textmate/python.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-python",
       "main": "lib/main",
@@ -1697,13 +1723,13 @@
         "node": ">=12"
       },
       "description": "Python language support in Atom",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
-      "dependencies": {
-        "atom-grammar-test": "^0.6.4",
-        "tree-sitter-python": "0.19.0"
-      },
+      "atomTestRunner": "runners/jasmine2-test-runner",
+      "dependencies": {},
       "consumedServices": {
         "hyperlink.injection": {
           "versions": {
@@ -1719,12 +1745,14 @@
     }
   },
   "language-ruby": {
-    "readme": "# Ruby language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to Ruby files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Ruby TextMate bundle](https://github.com/textmate/ruby.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Ruby language support in Pulsar\n\nAdds syntax highlighting and snippets to Ruby files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Ruby TextMate bundle](https://github.com/textmate/ruby.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-ruby",
       "version": "0.73.0",
       "description": "Ruby language support in Atom",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "engines": {
         "atom": "*",
         "node": ">=12"
@@ -1732,10 +1760,6 @@
       "main": "lib/main",
       "license": "MIT",
       "repository": "https://github.com/pulsar-edit/pulsar",
-      "dependencies": {
-        "tree-sitter-regex": "^0.19.0",
-        "tree-sitter-ruby": "^0.19.0"
-      },
       "devDependencies": {
         "dedent": "^0.7.0"
       },
@@ -1754,7 +1778,7 @@
     }
   },
   "language-ruby-on-rails": {
-    "readme": "# Ruby on Rails language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to Rails files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Ruby on Rails TextMate bundle](https://github.com/drnic/ruby-on-rails-tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Ruby on Rails language support in Pulsar\n\nAdds syntax highlighting and snippets to Rails files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Ruby on Rails TextMate bundle](https://github.com/drnic/ruby-on-rails-tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-ruby-on-rails",
       "version": "0.25.3",
@@ -1768,18 +1792,19 @@
     }
   },
   "language-rust-bundled": {
-    "readme": "# language-rust-bundled\r\n\r\nThis package provides Rust syntax highlighting in Atom based on syntax trees provided by [tree-sitter-rust](https://github.com/tree-sitter/tree-sitter-rust).\r\n",
+    "readme": "# language-rust-bundled\n\nThis package provides Rust syntax highlighting in Atom based on syntax trees provided by [tree-sitter-rust](https://github.com/tree-sitter/tree-sitter-rust).\n",
     "metadata": {
       "name": "language-rust-bundled",
       "version": "0.1.1",
       "description": "Rust support for Pulsar",
-      "keywords": ["language", "grammar", "rust"],
+      "keywords": [
+        "language",
+        "grammar",
+        "rust"
+      ],
       "main": "lib/main.js",
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
-      "dependencies": {
-        "tree-sitter-rust": "0.20.1"
-      },
       "engines": {
         "atom": ">=1.0.0 <2.0.0",
         "node": ">=12"
@@ -1799,7 +1824,7 @@
     }
   },
   "language-sass": {
-    "readme": "# Sass/SCSS language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to Sass/SCSS files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Sass TextMate bundle](https://github.com/alexsancho/SASS.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Sass/SCSS language support in Pulsar\n\nAdds syntax highlighting and snippets to Sass/SCSS files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [Sass TextMate bundle](https://github.com/alexsancho/SASS.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-sass",
       "version": "0.62.2",
@@ -1829,22 +1854,21 @@
     }
   },
   "language-shellscript": {
-    "readme": "# ShellScript language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to shell scripts in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [ShellScript TextMate bundle](https://github.com/textmate/shellscript.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# ShellScript language support in Pulsar\n\nAdds syntax highlighting and snippets to shell scripts in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [ShellScript TextMate bundle](https://github.com/textmate/shellscript.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-shellscript",
       "version": "0.28.2",
       "main": "lib/main",
       "description": "ShellScript language support in Atom",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "engines": {
         "atom": "*",
         "node": ">=12"
       },
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
-      "dependencies": {
-        "tree-sitter-bash": "0.19.0"
-      },
       "consumedServices": {
         "hyperlink.injection": {
           "versions": {
@@ -1860,7 +1884,7 @@
     }
   },
   "language-source": {
-    "readme": "# Source code support in Pulsar\r\n\r\nAdds basic comment, indent, and outdent patterns used as a fallback by all\r\nsource files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\r\nfrom the [Source TextMate bundle](https://github.com/textmate/source.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a\r\npull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Source code support in Pulsar\n\nAdds basic comment, indent, and outdent patterns used as a fallback by all\nsource files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\nfrom the [Source TextMate bundle](https://github.com/textmate/source.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a\npull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-source",
       "version": "0.9.0",
@@ -1874,7 +1898,7 @@
     }
   },
   "language-sql": {
-    "readme": "# SQL language support in Pulsar\r\n\r\nAdds syntax highlighting to SQL files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [SQL TextMate bundle](https://github.com/textmate/sql.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# SQL language support in Pulsar\n\nAdds syntax highlighting to SQL files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [SQL TextMate bundle](https://github.com/textmate/sql.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-sql",
       "version": "0.25.10",
@@ -1888,7 +1912,7 @@
     }
   },
   "language-text": {
-    "readme": "# Plain text support in Pulsar\r\n\r\nGrammar and snippets for plain text files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\r\nfrom the [Text TextMate bundle](https://github.com/textmate/text.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a\r\npull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# Plain text support in Pulsar\n\nGrammar and snippets for plain text files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate)\nfrom the [Text TextMate bundle](https://github.com/textmate/text.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a\npull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-text",
       "version": "0.7.4",
@@ -1902,7 +1926,7 @@
     }
   },
   "language-todo": {
-    "readme": "# TODO support in Pulsar\r\n\r\nAdds syntax highlighting to `TODO`, `FIXME`, `CHANGED`, `XXX`, `IDEA`, `HACK`, `NOTE`, `REVIEW`, `NB`, `BUG`, `QUESTION`, `COMBAK`, `TEMP`, `DEBUG`, `OPTIMIZE`, and `WARNING` in comments\r\nand text in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [TODO TextMate bundle](https://github.com/textmate/todo.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# TODO support in Pulsar\n\nAdds syntax highlighting to `TODO`, `FIXME`, `CHANGED`, `XXX`, `IDEA`, `HACK`, `NOTE`, `REVIEW`, `NB`, `BUG`, `QUESTION`, `COMBAK`, `TEMP`, `DEBUG`, `OPTIMIZE`, and `WARNING` in comments\nand text in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [TODO TextMate bundle](https://github.com/textmate/todo.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-todo",
       "version": "0.29.4",
@@ -1924,7 +1948,7 @@
     }
   },
   "language-toml": {
-    "readme": "# TOML language support in Pulsar\r\n\r\nAdds syntax highlighting for [TOML](https://github.com/toml-lang/toml) in Pulsar.\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# TOML language support in Pulsar\n\nAdds syntax highlighting for [TOML](https://github.com/toml-lang/toml) in Pulsar.\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-toml",
       "version": "0.20.0",
@@ -1935,9 +1959,6 @@
       "engines": {
         "atom": "*",
         "node": ">=14"
-      },
-      "devDependencies": {
-        "tree-sitter-toml": "^0.5.1"
       },
       "consumedServices": {
         "hyperlink.injection": {
@@ -1954,12 +1975,14 @@
     }
   },
   "language-typescript": {
-    "readme": "# TypeScript language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets for TypeScript in Pulsar.\r\n\r\nThe grammar is the [Microsoft TypeScript TextMate grammar](https://github.com/Microsoft/TypeScript-TmLanguage) and copied here on a semi-regular basis.  Any issues relating to syntax highlighting are likely to be there.\r\n",
+    "readme": "# TypeScript language support in Pulsar\n\nAdds syntax highlighting and snippets for TypeScript in Pulsar.\n\nThe grammar is the [Microsoft TypeScript TextMate grammar](https://github.com/Microsoft/TypeScript-TmLanguage) and copied here on a semi-regular basis.  Any issues relating to syntax highlighting are likely to be there.\n",
     "metadata": {
       "name": "language-typescript",
       "version": "0.6.4",
       "description": "TypeScript language support in Atom",
-      "keywords": ["tree-sitter"],
+      "keywords": [
+        "tree-sitter"
+      ],
       "engines": {
         "atom": ">=1.19.1",
         "node": ">=12"
@@ -1967,9 +1990,6 @@
       "main": "lib/main",
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
-      "dependencies": {
-        "tree-sitter-typescript": "0.20.1"
-      },
       "configSchema": {
         "indentation": {
           "title": "Indentation",
@@ -2042,7 +2062,7 @@
     }
   },
   "language-xml": {
-    "readme": "# XML language support in Pulsar\r\n\r\nAdds syntax highlighting and snippets to XML files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [XML TextMate bundle](https://github.com/textmate/xml.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# XML language support in Pulsar\n\nAdds syntax highlighting and snippets to XML files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [XML TextMate bundle](https://github.com/textmate/xml.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-xml",
       "version": "0.35.3",
@@ -2056,7 +2076,7 @@
     }
   },
   "language-yaml": {
-    "readme": "# YAML language support in Pulsar\r\n\r\nAdds syntax highlighting to YAML files in Pulsar.\r\n\r\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [YAML TextMate bundle](https://github.com/textmate/yaml.tmbundle).\r\n\r\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\r\n",
+    "readme": "# YAML language support in Pulsar\n\nAdds syntax highlighting to YAML files in Pulsar.\n\nOriginally [converted](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#converting-from-textmate) from the [YAML TextMate bundle](https://github.com/textmate/yaml.tmbundle).\n\nContributions are greatly appreciated. Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.\n",
     "metadata": {
       "name": "language-yaml",
       "version": "0.32.0",
@@ -2083,7 +2103,7 @@
     }
   },
   "line-ending-selector": {
-    "readme": "# Line Ending Selector package\r\n\r\n![status bar tile](https://cloud.githubusercontent.com/assets/1305617/9274149/6b317568-4293-11e5-83ba-614a6c0d9890.png)\r\n\r\nThis is an [Pulsar](https://pulsar-edit.dev) package that displays the current line ending type of a file: `CRLF` (Windows), `LF` (Unix), or `Mixed` (both). It also lets you change the line ending of a file.\r\n\r\n## To Use\r\n\r\nWhen the package is activated it will show the current line ending of the file in the right side of the status-bar. If a new file is created the line ending will start with the system default: `CRLF` for Windows, `LF` for Mac and Linux, and `CR` for old-style Mac files. If a file contains multiple line-ending types it will display `Mixed`.\r\n\r\n### Changing a File's Line Ending\r\n\r\nYou can click the line ending in the status-bar to open a modal with the line ending options. Selecting a different line ending will change each line of the file in the active editor.\r\n\r\n![modal](https://cloud.githubusercontent.com/assets/1305617/9273907/2be5c136-4291-11e5-94af-65ece408eb12.png)\r\n\r\n**Line Endings**\r\n\r\n- `LF` is \"\\n\"\r\n- `CRLF` is \"\\r\\n\"\r\n\r\n**Note:** Because the `CR` line ending style is not used in any modern operating system, this package only supports converting *from* `CR` line endings not to it.\r\n\r\n### Pulsar Commands\r\n\r\nYou can also change a file's line endings by using or <kbd>cmd-shift-P</kbd> searching for these commands:\r\n\r\n```text\r\nline-ending-selector:convert-to-LF\r\nline-ending-selector:convert-to-CRLF\r\n```\r\n",
+    "readme": "# Line Ending Selector package\n\n![status bar tile](https://cloud.githubusercontent.com/assets/1305617/9274149/6b317568-4293-11e5-83ba-614a6c0d9890.png)\n\nThis is an [Pulsar](https://pulsar-edit.dev) package that displays the current line ending type of a file: `CRLF` (Windows), `LF` (Unix), or `Mixed` (both). It also lets you change the line ending of a file.\n\n## To Use\n\nWhen the package is activated it will show the current line ending of the file in the right side of the status-bar. If a new file is created the line ending will start with the system default: `CRLF` for Windows, `LF` for Mac and Linux, and `CR` for old-style Mac files. If a file contains multiple line-ending types it will display `Mixed`.\n\n### Changing a File's Line Ending\n\nYou can click the line ending in the status-bar to open a modal with the line ending options. Selecting a different line ending will change each line of the file in the active editor.\n\n![modal](https://cloud.githubusercontent.com/assets/1305617/9273907/2be5c136-4291-11e5-94af-65ece408eb12.png)\n\n**Line Endings**\n\n- `LF` is \"\\n\"\n- `CRLF` is \"\\r\\n\"\n\n**Note:** Because the `CR` line ending style is not used in any modern operating system, this package only supports converting *from* `CR` line endings not to it.\n\n### Pulsar Commands\n\nYou can also change a file's line endings by using or <kbd>cmd-shift-P</kbd> searching for these commands:\n\n```text\nline-ending-selector:convert-to-LF\nline-ending-selector:convert-to-CRLF\n```\n",
     "metadata": {
       "name": "line-ending-selector",
       "version": "0.7.7",
@@ -2111,13 +2131,17 @@
           "description": "Line ending to use for new files",
           "type": "string",
           "default": "OS Default",
-          "enum": ["OS Default", "LF", "CRLF"]
+          "enum": [
+            "OS Default",
+            "LF",
+            "CRLF"
+          ]
         }
       }
     }
   },
   "link": {
-    "readme": "# Link package\r\n\r\nOpens http(s) links under the cursor.\r\n\r\n### Commands and Keybindings\r\n\r\n|Command|Selector|Description|Keybinding (Linux)|Keybinding (macOS)|Keybinding (Windows)|\r\n|-------|--------|-----------|------------------|------------------|--------------------|\r\n|`link:open`|`atom-text-editor`|Opens the http(s) link under the cursor||<kbd>ctrl-shift-o</kbd>||\r\n\r\nCustom keybindings can be added by referencing the above commands.  To learn more, visit the [Using Pulsar: Basic Customization](https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#basic-customization) or [Behind Pulsar: Keymaps In-Depth](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar#keymaps-in-depth) sections of the Pulsar documentation.\r\n",
+    "readme": "# Link package\n\nOpens http(s) links under the cursor.\n\n### Commands and Keybindings\n\n|Command|Selector|Description|Keybinding (Linux)|Keybinding (macOS)|Keybinding (Windows)|\n|-------|--------|-----------|------------------|------------------|--------------------|\n|`link:open`|`atom-text-editor`|Opens the http(s) link under the cursor||<kbd>ctrl-shift-o</kbd>||\n\nCustom keybindings can be added by referencing the above commands.  To learn more, visit the [Using Pulsar: Basic Customization](https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#basic-customization) or [Behind Pulsar: Keymaps In-Depth](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar#keymaps-in-depth) sections of the Pulsar documentation.\n",
     "metadata": {
       "name": "link",
       "version": "0.31.6",
@@ -2129,7 +2153,9 @@
         "atom": "*"
       },
       "activationCommands": {
-        "atom-workspace": ["link:open"]
+        "atom-workspace": [
+          "link:open"
+        ]
       },
       "dependencies": {
         "underscore-plus": "^1.7.0"
@@ -2137,7 +2163,7 @@
     }
   },
   "markdown-preview": {
-    "readme": "# Markdown Preview package\r\n\r\nShow the rendered HTML markdown to the right of the current editor using <kbd>ctrl-shift-m</kbd>.\r\n\r\nIt is currently enabled for `.markdown`, `.md`, `.mdown`, `.mkd`, `.mkdown`, `.ron`, and `.txt` files.\r\n\r\n![markdown-preview](https://cloud.githubusercontent.com/assets/378023/10013086/24cad23e-6149-11e5-90e6-663009210218.png)\r\n\r\n## Customize\r\n\r\nBy default Markdown Preview uses the colors of the active syntax theme. Enable **Use GitHub.com Style** in the __package settings__ to make it look closer to how markdown files get rendered on github.com.\r\n\r\n![markdown-preview GitHub style](https://cloud.githubusercontent.com/assets/378023/10013087/24ccc7ec-6149-11e5-97ea-53a842a715ea.png)\r\n\r\nWhen **Use GitHub.com Style** is selected, you can further customize the theme of the Markdown preview with the **GitHub.com Style Mode** setting. Since the GitHub website has a light theme and a dark theme, `markdown-preview` allows you to choose which theme to use when previewing your files. By default, it will use whatever mode is preferred by your system, but you can opt into “Light” or “Dark” to force it to use a particular theme.\r\n\r\nNo matter which theme you use, you can apply further customizations in your `styles.less` file. For example:\r\n\r\n```css\r\n.markdown-preview pre {\r\n  background-color: #444;\r\n}\r\n```\r\n\r\n## Language identifiers in fenced code blocks\r\n\r\nA detailed Markdown specification helps to ensure that Markdown is displayed consistently across multiple parsers. Sadly, the same isn’t true of code block language identifiers — the strings you use to tell the renderer what sort of code is inside a code block.\r\n\r\nThe CommonMark specification [explicitly avoids standardizing these identifiers](https://spec.commonmark.org/0.31.2/#info-string):\r\n\r\n> The first word of the info string is typically used to specify the language of the code sample, and rendered in the class attribute of the code tag. However, this spec does not mandate any particular treatment of the info string.\r\n\r\nThere are several valid ways to infer specific languages from language identifiers such as `js`, `less`, `coffee`,  and `c`. This package supports the following systems, configured via the **Syntax Highlighting Language Identifiers** setting:\r\n\r\n  * [Linguist](https://github.com/github-linguist/linguist): Used by GitHub (previously the default and only language identification system).\r\n  * [Chroma](https://github.com/alecthomas/chroma): Used by CodeBerg/Gitea/Hugo/Goldmark.\r\n  * [Rouge](https://github.com/rouge-ruby/rouge): Used by GitLab/Jekyll.\r\n  * [HighlightJS](https://highlightjs.org/): Used in a number of places, but most relevantly on the [Pulsar Package Registry](https://web.pulsar-edit.dev/) website.\r\n\r\nIf none of these systems meets your needs, you may specify custom language identifiers. This may not be as portable as the systems described above, but it will at least produce the desired outcome on your own system.\r\n\r\nThe setting **Custom Syntax Highlighting Language Identifiers** lets you define a list of custom language identifiers that match up to languages available within your Pulsar installation.\r\n\r\nFor example, if you wanted to map `j` to JavaScript and `p` to Python, you’d add the following text to the **Custom Syntax Highlighting Language Identifiers** field:\r\n\r\n```\r\nj: source.js, p: source.python\r\n```\r\n\r\nNow `markdown-preview` will understand what to do with fenced code blocks that begin with <code>\\`\\`\\`j</code> or <code>\\`\\`\\`p</code>. These custom identifiers will work alongside whatever system you’ve chosen with **Syntax Highlighting Language Identifiers**, but will supersede that system in the event of conflict.\r\n",
+    "readme": "# Markdown Preview package\n\nShow the rendered HTML markdown to the right of the current editor using <kbd>ctrl-shift-m</kbd>.\n\nIt is currently enabled for `.markdown`, `.md`, `.mdown`, `.mkd`, `.mkdown`, `.ron`, and `.txt` files.\n\n![markdown-preview](https://cloud.githubusercontent.com/assets/378023/10013086/24cad23e-6149-11e5-90e6-663009210218.png)\n\n## Customize\n\nBy default Markdown Preview uses the colors of the active syntax theme. Enable **Use GitHub.com Style** in the __package settings__ to make it look closer to how markdown files get rendered on github.com.\n\n![markdown-preview GitHub style](https://cloud.githubusercontent.com/assets/378023/10013087/24ccc7ec-6149-11e5-97ea-53a842a715ea.png)\n\nWhen **Use GitHub.com Style** is selected, you can further customize the theme of the Markdown preview with the **GitHub.com Style Mode** setting. Since the GitHub website has a light theme and a dark theme, `markdown-preview` allows you to choose which theme to use when previewing your files. By default, it will use whatever mode is preferred by your system, but you can opt into “Light” or “Dark” to force it to use a particular theme.\n\nNo matter which theme you use, you can apply further customizations in your `styles.less` file. For example:\n\n```css\n.markdown-preview pre {\n  background-color: #444;\n}\n```\n\n## Language identifiers in fenced code blocks\n\nA detailed Markdown specification helps to ensure that Markdown is displayed consistently across multiple parsers. Sadly, the same isn’t true of code block language identifiers — the strings you use to tell the renderer what sort of code is inside a code block.\n\nThe CommonMark specification [explicitly avoids standardizing these identifiers](https://spec.commonmark.org/0.31.2/#info-string):\n\n> The first word of the info string is typically used to specify the language of the code sample, and rendered in the class attribute of the code tag. However, this spec does not mandate any particular treatment of the info string.\n\nThere are several valid ways to infer specific languages from language identifiers such as `js`, `less`, `coffee`,  and `c`. This package supports the following systems, configured via the **Syntax Highlighting Language Identifiers** setting:\n\n  * [Linguist](https://github.com/github-linguist/linguist): Used by GitHub (previously the default and only language identification system).\n  * [Chroma](https://github.com/alecthomas/chroma): Used by CodeBerg/Gitea/Hugo/Goldmark.\n  * [Rouge](https://github.com/rouge-ruby/rouge): Used by GitLab/Jekyll.\n  * [HighlightJS](https://highlightjs.org/): Used in a number of places, but most relevantly on the [Pulsar Package Registry](https://web.pulsar-edit.dev/) website.\n\nIf none of these systems meets your needs, you may specify custom language identifiers. This may not be as portable as the systems described above, but it will at least produce the desired outcome on your own system.\n\nThe setting **Custom Syntax Highlighting Language Identifiers** lets you define a list of custom language identifiers that match up to languages available within your Pulsar installation.\n\nFor example, if you wanted to map `j` to JavaScript and `p` to Python, you’d add the following text to the **Custom Syntax Highlighting Language Identifiers** field:\n\n```\nj: source.js, p: source.python\n```\n\nNow `markdown-preview` will understand what to do with fenced code blocks that begin with <code>\\`\\`\\`j</code> or <code>\\`\\`\\`p</code>. These custom identifiers will work alongside whatever system you’ve chosen with **Syntax Highlighting Language Identifiers**, but will supersede that system in the event of conflict.\n",
     "metadata": {
       "name": "markdown-preview",
       "version": "0.160.2",
@@ -2155,7 +2181,7 @@
       "dependencies": {
         "cheerio": "^1.0.0-rc.3",
         "dedent": "^1.5.3",
-        "dompurify": "^2.0.17",
+        "dompurify": "^3.2.6",
         "emoji-images": "^0.1.1",
         "fs-plus": "^3.0.0",
         "github-markdown-css": "^5.5.1",
@@ -2275,7 +2301,7 @@
     }
   },
   "notifications": {
-    "readme": " # Notifications package\r\n\r\n![notifications](https://cloud.githubusercontent.com/assets/69169/5176406/350d0e80-73fd-11e4-8101-1776b9d6d8bf.gif)\r\n\r\n### Docs\r\n\r\nNotifications are available for use in your Pulsar packages via the `atom.notifications` `NotificationManager` object. See\r\nhttps://atom.io/docs/api/latest/NotificationManager and https://atom.io/docs/api/latest/Notification for documentation.\r\n",
+    "readme": " # Notifications package\n\n![notifications](https://cloud.githubusercontent.com/assets/69169/5176406/350d0e80-73fd-11e4-8101-1776b9d6d8bf.gif)\n\n### Docs\n\nNotifications are available for use in your Pulsar packages via the `atom.notifications` `NotificationManager` object. See\nhttps://atom.io/docs/api/latest/NotificationManager and https://atom.io/docs/api/latest/Notification for documentation.\n",
     "metadata": {
       "name": "notifications",
       "main": "./lib/main",
@@ -2315,13 +2341,17 @@
     }
   },
   "one-dark-syntax": {
-    "readme": "## One Dark Syntax theme\r\n\r\n![one-dark-syntax](https://user-images.githubusercontent.com/238929/40553597-5f741518-6000-11e8-9068-70dfc5008b54.png)\r\n\r\n> The font used in the screenshot is [Fira Mono](https://github.com/mozilla/Fira).\r\n\r\nThere is also a matching [UI theme](https://atom.io/themes/one-dark-ui).\r\n\r\n### Install\r\n\r\nThis theme is installed by default with Pulsar and can be activated by going to the __Settings > Themes__ section and selecting it from the __Syntax Themes__ drop-down menu.\r\n",
+    "readme": "## One Dark Syntax theme\n\n![one-dark-syntax](https://user-images.githubusercontent.com/238929/40553597-5f741518-6000-11e8-9068-70dfc5008b54.png)\n\n> The font used in the screenshot is [Fira Mono](https://github.com/mozilla/Fira).\n\nThere is also a matching [UI theme](https://atom.io/themes/one-dark-ui).\n\n### Install\n\nThis theme is installed by default with Pulsar and can be activated by going to the __Settings > Themes__ section and selecting it from the __Syntax Themes__ drop-down menu.\n",
     "metadata": {
       "name": "one-dark-syntax",
       "theme": "syntax",
       "version": "1.8.4",
       "description": "A dark syntax theme",
-      "keywords": ["dark", "blue", "syntax"],
+      "keywords": [
+        "dark",
+        "blue",
+        "syntax"
+      ],
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
       "engines": {
@@ -2330,13 +2360,17 @@
     }
   },
   "one-dark-ui": {
-    "readme": "## One Dark UI theme\r\n\r\nA dark UI theme that adapts to most syntax themes.\r\n\r\n![One dark UI](https://cloud.githubusercontent.com/assets/378023/26246818/08255b76-3cd6-11e7-9f6d-6ae3e16a89a9.png)\r\n\r\n> The font used in the screenshot is [Fira Mono](https://github.com/mozilla/Fira).\r\n\r\n\r\n### Install\r\n\r\nThis theme comes bundled with Pulsar and can be activated by going to the __Settings > Themes__ section and selecting \"One Dark\" from the __UI Themes__ drop-down menu.\r\n\r\n\r\n### Settings\r\n\r\nIn the theme settings you can:\r\n\r\n- Change the __Font Size__ to scale the whole UI up or down.\r\n- Choose between 3 __Tab Sizing__ modes.\r\n- Hide the  __dock buttons__.\r\n\r\nTo make changes, go to `Settings > Themes > One Dark UI > Settings` or the cog icon next to the theme picker.\r\n\r\n\r\n### Customize\r\n\r\nIt's also possible to resize only certain areas by adding the following to your `styles.less` (Use DevTools to find the right selectors):\r\n\r\n```css\r\n.theme-one-dark-ui {\r\n  .tab-bar { font-size: 18px; }\r\n  .tree-view { font-size: 14px; }\r\n  .status-bar { font-size: 12px; }\r\n}\r\n```\r\n\r\n\r\n### FAQ\r\n\r\n__Why do the colors change when I switch Syntax themes?__\r\nThis UI theme uses the same background color as the chosen syntax theme. If that syntax theme has a light background color, it only uses its hue, but otherwise stays dark. This lets you use dark-light combos.\r\n",
+    "readme": "## One Dark UI theme\n\nA dark UI theme that adapts to most syntax themes.\n\n![One dark UI](https://cloud.githubusercontent.com/assets/378023/26246818/08255b76-3cd6-11e7-9f6d-6ae3e16a89a9.png)\n\n> The font used in the screenshot is [Fira Mono](https://github.com/mozilla/Fira).\n\n\n### Install\n\nThis theme comes bundled with Pulsar and can be activated by going to the __Settings > Themes__ section and selecting \"One Dark\" from the __UI Themes__ drop-down menu.\n\n\n### Settings\n\nIn the theme settings you can:\n\n- Change the __Font Size__ to scale the whole UI up or down.\n- Choose between 3 __Tab Sizing__ modes.\n- Hide the  __dock buttons__.\n\nTo make changes, go to `Settings > Themes > One Dark UI > Settings` or the cog icon next to the theme picker.\n\n\n### Customize\n\nIt's also possible to resize only certain areas by adding the following to your `styles.less` (Use DevTools to find the right selectors):\n\n```css\n.theme-one-dark-ui {\n  .tab-bar { font-size: 18px; }\n  .tree-view { font-size: 14px; }\n  .status-bar { font-size: 12px; }\n}\n```\n\n\n### FAQ\n\n__Why do the colors change when I switch Syntax themes?__\nThis UI theme uses the same background color as the chosen syntax theme. If that syntax theme has a light background color, it only uses its hue, but otherwise stays dark. This lets you use dark-light combos.\n",
     "metadata": {
       "name": "one-dark-ui",
       "theme": "ui",
       "version": "1.12.5",
       "description": "Pulsar One dark UI theme",
-      "keywords": ["dark", "adaptive", "ui"],
+      "keywords": [
+        "dark",
+        "adaptive",
+        "ui"
+      ],
       "license": "MIT",
       "repository": "https://github.com/pulsar-edit/pulsar",
       "main": "lib/main",
@@ -2349,7 +2383,19 @@
           "description": "Change the font size for the UI.",
           "type": "integer",
           "default": 12,
-          "enum": [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+          "enum": [
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20
+          ],
           "order": 1
         },
         "tabSizing": {
@@ -2357,7 +2403,11 @@
           "description": "In Even mode all tabs will be the same size. Great for quickly closing many tabs. In Maximum mode the tabs will expand to take up the full width. In Minimum mode the tabs will only take as little space as needed and also show longer file names.",
           "type": "string",
           "default": "Even",
-          "enum": ["Even", "Maximum", "Minimum"],
+          "enum": [
+            "Even",
+            "Maximum",
+            "Minimum"
+          ],
           "order": 2
         },
         "tabCloseButton": {
@@ -2365,7 +2415,10 @@
           "description": "Choose the position of the close button shown in tabs.",
           "type": "string",
           "default": "Right",
-          "enum": ["Left", "Right"],
+          "enum": [
+            "Left",
+            "Right"
+          ],
           "order": 3
         },
         "hideDockButtons": {
@@ -2385,13 +2438,16 @@
     }
   },
   "one-light-syntax": {
-    "readme": "## One Light Syntax theme\r\n\r\n![one-syntax-light](https://cloud.githubusercontent.com/assets/378023/7783214/c146b4e6-0174-11e5-8377-a57cf0274d5d.png)\r\n\r\n> The font used in the screenshot is [Fira Mono](https://github.com/mozilla/Fira).\r\n\r\nThere is also a matching [UI theme](../one-light-ui).\r\n\r\n### Install\r\n\r\nThis theme is installed by default with Pulsar and can be activated by going to the __Settings > Themes__ section and selecting it from the __Syntax Themes__ drop-down menu.\r\n",
+    "readme": "## One Light Syntax theme\n\n![one-syntax-light](https://cloud.githubusercontent.com/assets/378023/7783214/c146b4e6-0174-11e5-8377-a57cf0274d5d.png)\n\n> The font used in the screenshot is [Fira Mono](https://github.com/mozilla/Fira).\n\nThere is also a matching [UI theme](../one-light-ui).\n\n### Install\n\nThis theme is installed by default with Pulsar and can be activated by going to the __Settings > Themes__ section and selecting it from the __Syntax Themes__ drop-down menu.\n",
     "metadata": {
       "name": "one-light-syntax",
       "theme": "syntax",
       "version": "1.8.4",
       "description": "One light syntax theme developed for Atom, repurposed for Pulsar",
-      "keywords": ["light", "syntax"],
+      "keywords": [
+        "light",
+        "syntax"
+      ],
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
       "engines": {
@@ -2400,13 +2456,17 @@
     }
   },
   "one-light-ui": {
-    "readme": "## One Light UI theme\r\n\r\nA light UI theme that adapts to most syntax themes.\r\n\r\n![One light UI](https://cloud.githubusercontent.com/assets/378023/26246819/0826f04e-3cd6-11e7-98eb-cd94bc48b090.png)\r\n\r\n> The font used in the screenshot is [Fira Mono](https://github.com/mozilla/Fira).\r\n\r\n\r\n### Install\r\n\r\nThis theme comes bundled with Pulsar and can be activated by going to the __Settings > Themes__ section and selecting \"One Light\" from the __UI Themes__ drop-down menu.\r\n\r\n\r\n### Settings\r\n\r\nIn the theme settings you can:\r\n\r\n- Change the __Font Size__ to scale the whole UI up or down.\r\n- Choose between 3 __Tab Sizing__ modes.\r\n- Hide the  __dock buttons__.\r\n\r\nTo make changes, go to `Settings > Themes > One Light UI > Settings` or the cog icon next to the theme picker.\r\n\r\n\r\n### Customize\r\n\r\nIt's also possible to resize only certain areas by adding the following to your `styles.less` (Use DevTools to find the right selectors):\r\n\r\n```css\r\n.theme-one-light-ui {\r\n  .tab-bar { font-size: 18px; }\r\n  .tree-view { font-size: 14px; }\r\n  .status-bar { font-size: 12px; }\r\n}\r\n```\r\n\r\n\r\n### FAQ\r\n\r\n__Why do the colors change when I switch Syntax themes.__\r\nThis UI theme uses the same background color as the chosen syntax theme. If that syntax theme has a dark background color, it only uses its hue, but otherwise stays light. This lets you use light-dark combos.\r\n",
+    "readme": "## One Light UI theme\n\nA light UI theme that adapts to most syntax themes.\n\n![One light UI](https://cloud.githubusercontent.com/assets/378023/26246819/0826f04e-3cd6-11e7-98eb-cd94bc48b090.png)\n\n> The font used in the screenshot is [Fira Mono](https://github.com/mozilla/Fira).\n\n\n### Install\n\nThis theme comes bundled with Pulsar and can be activated by going to the __Settings > Themes__ section and selecting \"One Light\" from the __UI Themes__ drop-down menu.\n\n\n### Settings\n\nIn the theme settings you can:\n\n- Change the __Font Size__ to scale the whole UI up or down.\n- Choose between 3 __Tab Sizing__ modes.\n- Hide the  __dock buttons__.\n\nTo make changes, go to `Settings > Themes > One Light UI > Settings` or the cog icon next to the theme picker.\n\n\n### Customize\n\nIt's also possible to resize only certain areas by adding the following to your `styles.less` (Use DevTools to find the right selectors):\n\n```css\n.theme-one-light-ui {\n  .tab-bar { font-size: 18px; }\n  .tree-view { font-size: 14px; }\n  .status-bar { font-size: 12px; }\n}\n```\n\n\n### FAQ\n\n__Why do the colors change when I switch Syntax themes.__\nThis UI theme uses the same background color as the chosen syntax theme. If that syntax theme has a dark background color, it only uses its hue, but otherwise stays light. This lets you use light-dark combos.\n",
     "metadata": {
       "name": "one-light-ui",
       "theme": "ui",
       "version": "1.12.5",
       "description": "One light UI theme developed for Atom, repurposed for Pulsar",
-      "keywords": ["light", "adaptive", "ui"],
+      "keywords": [
+        "light",
+        "adaptive",
+        "ui"
+      ],
       "license": "MIT",
       "repository": "https://github.com/pulsar-edit/pulsar",
       "main": "lib/main",
@@ -2419,7 +2479,19 @@
           "description": "Change the font size for the UI.",
           "type": "integer",
           "default": 12,
-          "enum": [10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+          "enum": [
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20
+          ],
           "order": 1
         },
         "tabSizing": {
@@ -2427,7 +2499,11 @@
           "description": "In Even mode all tabs will be the same size. Great for quickly closing many tabs. In Maximum mode the tabs will expand to take up the full width. In Minimum mode the tabs will only take as little space as needed and also show longer file names.",
           "type": "string",
           "default": "Even",
-          "enum": ["Even", "Maximum", "Minimum"],
+          "enum": [
+            "Even",
+            "Maximum",
+            "Minimum"
+          ],
           "order": 2
         },
         "tabCloseButton": {
@@ -2435,7 +2511,10 @@
           "description": "Choose the position of the close button shown in tabs.",
           "type": "string",
           "default": "Right",
-          "enum": ["Left", "Right"],
+          "enum": [
+            "Left",
+            "Right"
+          ],
           "order": 3
         },
         "hideDockButtons": {
@@ -2455,7 +2534,7 @@
     }
   },
   "open-on-github": {
-    "readme": "# Open on GitHub package\r\n\r\nProvides commands to quickly view the current file on GitHub.com (The Website).\r\n\r\n## Usage\r\n\r\nWhen editing a file in Pulsar, use the command palette or keyboard shortcuts to:\r\n\r\n- Open the file on github.com <kbd>alt-g, o</kbd>\r\n- Open the blame view for the file on github.com <kbd>alt-g, b</kbd>\r\n- Open the history view for the file on github.com <kbd>alt-g, h</kbd>\r\n- Open the issues view for the repository the file belongs to on github.com <kbd>alt-g, i</kbd>\r\n- Open the pull requests view for the repository the file belongs to on github.com <kbd>alt-g, p</kbd>\r\n- Open the compare page for the current branch on github.com <kbd>alt-g, r</kbd>\r\n- Copy the github.com URL for the currently selected lines <kbd>alt-g, c</kbd>\r\n\r\n![Command Palette](https://f.cloud.github.com/assets/671378/2241755/23cb72f8-9ce2-11e3-9109-36c76a030f6a.png)\r\n\r\n## Remote URL detection\r\n\r\nThe GitHub repository URL is guessed from the current branch and Git remote information. To override the defaults, you can use `git config` to set the remote and branch name:\r\n\r\n```\r\ngit config atom.open-on-github.remote upstream\r\ngit config atom.open-on-github.branch some-branch\r\n```\r\n\r\n---\r\n\r\nInspired by the [GitHub Tools package][github-tools] for Sublime Text 2.\r\n\r\n[github-tools]: https://github.com/temochka/sublime-text-2-github-tools\r\n",
+    "readme": "# Open on GitHub package\n\nProvides commands to quickly view the current file on GitHub.com (The Website).\n\n## Usage\n\nWhen editing a file in Pulsar, use the command palette or keyboard shortcuts to:\n\n- Open the file on github.com <kbd>alt-g, o</kbd>\n- Open the blame view for the file on github.com <kbd>alt-g, b</kbd>\n- Open the history view for the file on github.com <kbd>alt-g, h</kbd>\n- Open the issues view for the repository the file belongs to on github.com <kbd>alt-g, i</kbd>\n- Open the pull requests view for the repository the file belongs to on github.com <kbd>alt-g, p</kbd>\n- Open the compare page for the current branch on github.com <kbd>alt-g, r</kbd>\n- Copy the github.com URL for the currently selected lines <kbd>alt-g, c</kbd>\n\n![Command Palette](https://f.cloud.github.com/assets/671378/2241755/23cb72f8-9ce2-11e3-9109-36c76a030f6a.png)\n\n## Remote URL detection\n\nThe GitHub repository URL is guessed from the current branch and Git remote information. To override the defaults, you can use `git config` to set the remote and branch name:\n\n```\ngit config atom.open-on-github.remote upstream\ngit config atom.open-on-github.branch some-branch\n```\n\n---\n\nInspired by the [GitHub Tools package][github-tools] for Sublime Text 2.\n\n[github-tools]: https://github.com/temochka/sublime-text-2-github-tools\n",
     "metadata": {
       "name": "open-on-github",
       "version": "1.3.2",
@@ -2481,7 +2560,7 @@
       },
       "devDependencies": {
         "fs-plus": "^3.0.1",
-        "temp": "^0.8.3"
+        "temp": "^0.9.0"
       },
       "configSchema": {
         "includeLineNumbersInUrls": {
@@ -2493,7 +2572,7 @@
     }
   },
   "package-generator": {
-    "readme": "# Package Generator package\r\n\r\nGenerates and opens a new sample package, language, or syntax theme in Pulsar.\r\n",
+    "readme": "# Package Generator package\n\nGenerates and opens a new sample package, language, or syntax theme in Pulsar.\n",
     "metadata": {
       "name": "package-generator",
       "version": "1.3.0",
@@ -2509,7 +2588,7 @@
       },
       "dependencies": {
         "fs-plus": "^3.0.0",
-        "temp": "^0.8.1",
+        "temp": "^0.9.0",
         "underscore-plus": "^1.0.0"
       },
       "repository": "https://github.com/pulsar-edit/pulsar",
@@ -2525,14 +2604,17 @@
         "packageSyntax": {
           "default": "javascript",
           "type": "string",
-          "enum": ["coffeescript", "javascript"],
+          "enum": [
+            "coffeescript",
+            "javascript"
+          ],
           "description": "The syntax to generate packages with."
         }
       }
     }
   },
   "pulsar-updater": {
-    "readme": "# Pulsar Updater\r\n\r\nUpdate utility for Pulsar. On launch of Pulsar, `pulsar-updater` will check for any new releases available via GitHub APIs. And if one is available will display a notification for the user to be able to install the new version.\r\n\r\nIf the user seems to have installed Pulsar manually, a link will be opened directly to the resource on GitHub, allowing the user to then download the correct file as needed, and install it. Otherwise if it seems the user has installed Pulsar via various recognized package managers, then Pulsar Updater will present a notification that an update is available, and provide the commands needed to preform the update themselves if they so wish.\r\n\r\nThis package is made to be minimally invasive, while still allowing users to be aware of new Pulsar versions without any manual effort.\r\n\r\nAdditionally, since the entire process of actually installation is done by the user, there is no need for complex Squirrel logic, or expensive certifications to allow Squirrel to work.\r\n\r\n## Command Palette\r\n\r\nIf a user would prefer to manually check for any updates available then the following commands are exposed from Pulsar Updater to do so:\r\n\r\n* `pulsar-updater:check-for-update`: Performs an update check and shows a notification if a newer version of Pulsar is available.\r\n* `pulsar-updater:clear-cache`: Clears the package's cache and forgets any requests to suppress update checking.\r\n\r\n## The Update Notification\r\n\r\nIf an update is available, the notification that is shown is intended to be as non-invasive as possible, providing a few possible options:\r\n\r\n* Dismiss this Version: This will remove the notification, and prevent an additional notification ever appearing for this version again. Bypassing any cache expirations.\r\n* Dismiss until next launch: This will remove the notification, but only until the next update check. Which happens automatically at launch, or otherwise can be invoked manually.\r\n* Download from GitHub: This option is only shown if the installation method was determined to be manually. And clicking it will open the GitHub page containing the specific version to update to.\r\n\r\n## Supported/Checked/Recognized for Installation Methods\r\n\r\nSince a major part of the functionality of this package is attempting to determine the installation method, it's important to list them all here:\r\n\r\n* Universal: Developer Mode\r\n* Universal: Safe Mode\r\n* Universal: Spec Mode\r\n* Universal: Developer Instance\r\n* Windows: Chocolatey Installation\r\n* Windows: winget Installation\r\n* Windows: User Installation\r\n* Windows: Machine Installation\r\n* Windows: Portable Installation\r\n* Linux: Flatpak Installation\r\n* Linux: Deb-Get Installation\r\n* Linux: Nix Installation\r\n* Linux: Homebrew Installation\r\n* Linux: Manual Installation\r\n* macOS: Homebrew Installation\r\n* macOS: Manual Installation\r\n\r\n## Known Issues\r\n\r\nIt's important to remember that this update system is in no way integrated with the rest of Pulsar. The toggles within Pulsar to update automatically are ignored. The About view will still be unable to alert of new versions, nor track progress on installation. Those systems should eventually be removed, or mothballed, in favour of this.\r\n",
+    "readme": "# Pulsar Updater\n\nUpdate utility for Pulsar. On launch of Pulsar, `pulsar-updater` will check for any new releases available via GitHub APIs. And if one is available will display a notification for the user to be able to install the new version.\n\nIf the user seems to have installed Pulsar manually, a link will be opened directly to the resource on GitHub, allowing the user to then download the correct file as needed, and install it. Otherwise if it seems the user has installed Pulsar via various recognized package managers, then Pulsar Updater will present a notification that an update is available, and provide the commands needed to preform the update themselves if they so wish.\n\nThis package is made to be minimally invasive, while still allowing users to be aware of new Pulsar versions without any manual effort.\n\nAdditionally, since the entire process of actually installation is done by the user, there is no need for complex Squirrel logic, or expensive certifications to allow Squirrel to work.\n\n## Command Palette\n\nIf a user would prefer to manually check for any updates available then the following commands are exposed from Pulsar Updater to do so:\n\n* `pulsar-updater:check-for-update`: Performs an update check and shows a notification if a newer version of Pulsar is available.\n* `pulsar-updater:clear-cache`: Clears the package's cache and forgets any requests to suppress update checking.\n\n## The Update Notification\n\nIf an update is available, the notification that is shown is intended to be as non-invasive as possible, providing a few possible options:\n\n* Dismiss this Version: This will remove the notification, and prevent an additional notification ever appearing for this version again. Bypassing any cache expirations.\n* Dismiss until next launch: This will remove the notification, but only until the next update check. Which happens automatically at launch, or otherwise can be invoked manually.\n* Download from GitHub: This option is only shown if the installation method was determined to be manually. And clicking it will open the GitHub page containing the specific version to update to.\n\n## Supported/Checked/Recognized for Installation Methods\n\nSince a major part of the functionality of this package is attempting to determine the installation method, it's important to list them all here:\n\n* Universal: Developer Mode\n* Universal: Safe Mode\n* Universal: Spec Mode\n* Universal: Custom Release Channel\n* Windows: Chocolatey Installation\n* Windows: winget Installation\n* Windows: User Installation\n* Windows: Machine Installation\n* Windows: Portable Installation\n* Linux: Flatpak Installation\n* Linux: Deb-Get Installation\n* Linux: Nix Installation\n* Linux: Homebrew Installation\n* Linux: Manual Installation\n* macOS: Homebrew Installation\n* macOS: Manual Installation\n\n## Known Issues\n\nIt's important to remember that this update system is in no way integrated with the rest of Pulsar. The toggles within Pulsar to update automatically are ignored. The About view will still be unable to alert of new versions, nor track progress on installation. Those systems should eventually be removed, or mothballed, in favour of this.\n",
     "metadata": {
       "name": "pulsar-updater",
       "version": "1.0.0",
@@ -2549,8 +2631,8 @@
       "repository": "https://github.com/pulsar-edit/pulsar",
       "dependencies": {
         "event-kit": "github:pulsar-edit/event-kit",
-        "shelljs": "^0.8.5",
-        "superagent": "^8.0.9",
+        "shelljs": "^0.10.0",
+        "superagent": "^10.0.0",
         "winreg": "^1.2.4"
       },
       "configSchema": {
@@ -2563,7 +2645,7 @@
     }
   },
   "settings-view": {
-    "readme": "# Settings View package\r\n\r\nEdit core configuration settings, install and configure packages, and change themes from within Pulsar.\r\n\r\n![Settings View](https://cloud.githubusercontent.com/assets/118951/16886698/b0ca5fae-4a8a-11e6-8afc-2c03fda4618c.PNG)\r\n\r\n## Usage\r\nYou can open the Settings View by navigating to\r\n***LNX***: _Edit > Preferences_ -\r\n***MAC***: _Atom > Preferences_ -\r\n***WIN***: _File > Settings_.\r\n\r\nIn order to install new packages and themes, click on the _Install_ section on the left-hand side.\r\nOnce installed, community packages/themes and their settings are housed within their respective section.\r\nAll packages/themes that have updates will be listed under the _Updates_ section. Finally, all keybindings (including ones that community packages have added) are available in the _Keybindings_ section.\r\n\r\nWant to learn more? Check out the [Getting Started: Pulsar Basics](https://pulsar-edit.dev/docs/launch-manual/sections/getting-started/#pulsar-basics) and [Using Pulsar: Pulsar Packages](https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#pulsar-packages) sections in the Pulsar Launch Manual.\r\n\r\n### Commands and Keybindings\r\nAll of the following commands are under the `atom-workspace` selector.\r\n\r\n|Command|Description|Keybinding (Linux)|Keybinding (macOS)|Keybinding (Windows)|\r\n|-------|-----------|------------------|-----------------|--------------------|\r\n|`settings-view:open`|Opens the Settings View|<kbd>ctrl-,</kbd>|<kbd>cmd-,</kbd>|<kbd>ctrl-,</kbd>|\r\n|`settings-view:core`|Opens the _Core_ section of the Settings View|\r\n|`settings-view:editor`|Opens the _Editor_ section of the Settings View|\r\n|`settings-view:system`|Opens the _System_ section of the Settings View (Windows)|\r\n|`settings-view:show-keybindings`|Opens the _Keybindings_ section of the Settings View|\r\n|`settings-view:uninstall-packages`|Opens the _Packages_ section of the Settings View|\r\n|`settings-view:change-themes`|Opens the _Themes_ section of the Settings View|\r\n|`settings-view:uninstall-themes`|Opens the _Themes_ section of the Settings View|\r\n|`settings-view:check-for-updates`|Opens the _Updates_ section of the Settings View|\r\n|`settings-view:install-packages-and-themes`|Opens the _Install_ section of the Settings View|\r\nCustom keybindings can be added by referencing the above commands.  To learn more, visit the [Using Pulsar: Basic Customization](https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#basic-customization) or [Behind Pulsar: Keymaps In-Depth](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar/#keymaps-in-depth) sections in the Pulsar Launch Manual.\r\n\r\n## Customize\r\nThe Settings View package uses the `ui-variables` to match a theme's color scheme. You can still customize the UI in your `styles.less` file. For example:\r\n\r\n```less\r\n// Change the color of the titles\r\n.settings-view .section .section-heading {\r\n  color: white;\r\n}\r\n\r\n// Change the font size of the setting descriptions\r\n.settings-view .setting-description {\r\n  font-size: 13px;\r\n}\r\n```\r\n\r\nUse the [developer tools](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#developer-tools) to find more selectors.\r\n\r\n## Contributing\r\nAlways feel free to help out!  Whether it's [filing bugs and feature requests](https://github.com/pulsar-edit/pulsar/issues/new) or working on some of the [open issues](https://github.com/pulsar-edit/pulsar/issues), Pulsar's [contributing guide](https://github.com/pulsar-edit/.github/blob/main/CONTRIBUTING.md) will help get you started while the [guide for contributing to packages](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#contributing-to-official-pulsar-packages) has some extra information.\r\n\r\n## License\r\nMIT License.  See [the license](https://github.com/pulsar-edit/pulsar/blob/master/LICENSE.md) for more details.\r\n",
+    "readme": "# Settings View package\n\nEdit core configuration settings, install and configure packages, and change themes from within Pulsar.\n\n![Settings View](https://cloud.githubusercontent.com/assets/118951/16886698/b0ca5fae-4a8a-11e6-8afc-2c03fda4618c.PNG)\n\n## Usage\nYou can open the Settings View by navigating to\n***LNX***: _Edit > Preferences_ -\n***MAC***: _Pulsar > Preferences_ -\n***WIN***: _File > Settings_.\n\nIn order to install new packages and themes, click on the _Install_ section on the left-hand side.\nOnce installed, community packages/themes and their settings are housed within their respective section.\nAll packages/themes that have updates will be listed under the _Updates_ section. Finally, all keybindings (including ones that community packages have added) are available in the _Keybindings_ section.\n\nWant to learn more? Check out the [Getting Started: Pulsar Basics](https://pulsar-edit.dev/docs/launch-manual/sections/getting-started/#pulsar-basics) and [Using Pulsar: Pulsar Packages](https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#pulsar-packages) sections in the Pulsar Launch Manual.\n\n### Commands and Keybindings\nAll of the following commands are under the `atom-workspace` selector.\n\n|Command|Description|Keybinding (Linux)|Keybinding (macOS)|Keybinding (Windows)|\n|-------|-----------|------------------|-----------------|--------------------|\n|`settings-view:open`|Opens the Settings View|<kbd>ctrl-,</kbd>|<kbd>cmd-,</kbd>|<kbd>ctrl-,</kbd>|\n|`settings-view:core`|Opens the _Core_ section of the Settings View|\n|`settings-view:editor`|Opens the _Editor_ section of the Settings View|\n|`settings-view:system`|Opens the _System_ section of the Settings View (Windows)|\n|`settings-view:show-keybindings`|Opens the _Keybindings_ section of the Settings View|\n|`settings-view:uninstall-packages`|Opens the _Packages_ section of the Settings View|\n|`settings-view:change-themes`|Opens the _Themes_ section of the Settings View|\n|`settings-view:uninstall-themes`|Opens the _Themes_ section of the Settings View|\n|`settings-view:check-for-updates`|Opens the _Updates_ section of the Settings View|\n|`settings-view:install-packages-and-themes`|Opens the _Install_ section of the Settings View|\nCustom keybindings can be added by referencing the above commands.  To learn more, visit the [Using Pulsar: Basic Customization](https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#basic-customization) or [Behind Pulsar: Keymaps In-Depth](https://pulsar-edit.dev/docs/launch-manual/sections/behind-pulsar/#keymaps-in-depth) sections in the Pulsar Launch Manual.\n\n## Customize\nThe Settings View package uses the `ui-variables` to match a theme's color scheme. You can still customize the UI in your `styles.less` file. For example:\n\n```less\n// Change the color of the titles\n.settings-view .section .section-heading {\n  color: white;\n}\n\n// Change the font size of the setting descriptions\n.settings-view .setting-description {\n  font-size: 13px;\n}\n```\n\nUse the [developer tools](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#developer-tools) to find more selectors.\n\n## Contributing\nAlways feel free to help out!  Whether it's [filing bugs and feature requests](https://github.com/pulsar-edit/pulsar/issues/new) or working on some of the [open issues](https://github.com/pulsar-edit/pulsar/issues), Pulsar's [contributing guide](https://github.com/pulsar-edit/.github/blob/main/CONTRIBUTING.md) will help get you started while the [guide for contributing to packages](https://pulsar-edit.dev/docs/launch-manual/sections/core-hacking/#contributing-to-official-pulsar-packages) has some extra information.\n\n## License\nMIT License.  See [the license](https://github.com/pulsar-edit/pulsar/blob/master/LICENSE.md) for more details.\n",
     "metadata": {
       "name": "settings-view",
       "version": "0.261.11",
@@ -2639,7 +2721,7 @@
     }
   },
   "snippets": {
-    "readme": "# Snippets package\r\n\r\nExpand snippets matching the current prefix with <kbd>tab</kbd> in Pulsar.\r\n\r\nTo add your own snippets, select the _Pulsar > Snippets..._ menu option if you're using macOS, or the _File > Snippets..._ menu option if you're using Windows, or the _Edit > Snippets..._ menu option if you are using Linux.\r\n\r\n## Snippet Format\r\n\r\nSnippets files are stored in a package's `snippets/` folder and also loaded from `~/.pulsar/snippets.cson`. They can be either `.json` or `.cson` file types.\r\n\r\n```coffee\r\n'.source.js':\r\n  'console.log':\r\n    'prefix': 'log'\r\n    'command': 'insert-console-log'\r\n    'body': 'console.log(${1:\"crash\"});$2'\r\n```\r\n\r\nThe outermost keys are the selectors where these snippets should be active, prefixed with a period (`.`) (details below).\r\n\r\nThe next level of keys are the snippet names. Because this is object notation, each snippet must have a different name.\r\n\r\nUnder each snippet name is a `body` to insert when the snippet is triggered.\r\n\r\n`$` followed by a number are the tabs stops which can be cycled between by pressing <kbd>Tab</kbd> once a snippet has been triggered.\r\n\r\nThe above example adds a `console.log` snippet to JavaScript files that would expand to:\r\n\r\n```js\r\nconsole.log(\"crash\");\r\n```\r\n\r\nThe string `\"crash\"` would be initially selected and pressing tab again would place the cursor after the `;`\r\n\r\nA snippet specifies how it can be triggered. Thus it must provide **at least one** of the following keys:\r\n\r\n### The ‘prefix’ key\r\n\r\nIf a `prefix` is defined, it specifies a string that can trigger the snippet. In the above example, typing `log` (as its own word) and then pressing <kbd>Tab</kbd> would replace `log` with the string `console.log(\"crash\")` as described above.\r\n\r\nPrefix completions can be suggested if partially typed thanks to the `autocomplete-snippets` package.\r\n\r\n### The ‘command’ key\r\n\r\nIf a `command` is defined, it specifies a command name that can trigger the snippet. That command can be invoked from the command palette or mapped to a keyboard shortcut via your `keymap.cson`.\r\n\r\nIf a package called `some-package` had defined that snippet, it would be available in the keymap as `some-package:insert-console-log`, or in the command palette as **Some Package: Insert Console Log**.\r\n\r\nIf you defined the `console.log` snippet described above in your own `snippets.cson`, it could be referenced in a keymap file as `snippets:insert-console-log`, or in the command palette as **Snippets: Insert Console Log**.\r\n\r\nInvoking the command would insert the snippet at the cursor, replacing any text that may be selected.\r\n\r\nSnippet command names must be unique. They can’t conflict with each other, nor can they conflict with any other commands that have been defined. If there is such a conflict, you’ll see an error notification describing the problem.\r\n\r\n### Optional parameters\r\n\r\nThese parameters are meant to provide extra information about your snippet to [autocomplete-plus](https://github.com/atom/autocomplete-plus/wiki/Provider-API).\r\n\r\n* `leftLabel` will add text to the left part of the autocomplete results box.\r\n* `leftLabelHTML` will overwrite what's in `leftLabel` and allow you to use a bit of CSS such as `color`.\r\n* `rightLabelHTML`. By default, in the right part of the results box you will see the name of the snippet. When using `rightLabelHTML` the name of the snippet will no longer be displayed, and you will be able to use a bit of CSS.\r\n* `description` will add text to a description box under the autocomplete results list.\r\n* `descriptionMoreURL` URL to the documentation of the snippet.\r\n\r\n![autocomplete-description](http://i.imgur.com/cvI2lOq.png)\r\n\r\nExample:\r\n```coffee\r\n'.source.js':\r\n  'console.log':\r\n    'prefix': 'log'\r\n    'body': 'console.log(${1:\"crash\"});$2'\r\n    'description': 'Output data to the console'\r\n    'rightLabelHTML': '<span style=\"color:#ff0\">JS</span>'\r\n```\r\n\r\n### Determining the correct scope for a snippet\r\n\r\nThe outmost key of a snippet is the “scope” that you want the descendent snippets to be available in. The key should be prefixed with a period (`text.html.basic` → `.text.html.basic`). You can find out the correct scope by opening the Settings (<kbd>cmd-,</kbd> on macOS) and selecting the corresponding *Language [xxx]* package. For example, here’s the settings page for `language-html`:\r\n\r\n![Screenshot of Language Html settings](https://cloud.githubusercontent.com/assets/1038121/5137632/126beb66-70f2-11e4-839b-bc7e84103f67.png)\r\n\r\nIf it's difficult to determine the package handling the file type in question (for example, for `.md`-documents), you can use another approach:\r\n\r\n1. Put your cursor in a file in which you want the snippet to be available.\r\n2. Open the [Command Palette](https://github.com/pulsar-edit/command-palette)\r\n(<kbd>cmd-shift-p</kbd> or <kbd>ctrl-shift-p</kbd>).\r\n3. Run the `Editor: Log Cursor Scope` command.\r\n\r\nThis will trigger a notification which will contain a list of scopes. The first scope that's listed is the scope for that language. Here are some examples: `source.coffee`, `text.plain`, `text.html.basic`.\r\n\r\n## Snippet syntax\r\n\r\nThis package supports a subset of the features of TextMate snippets, [documented here](http://manual.macromates.com/en/snippets), as well as most features described in the [LSP specification][lsp] and [supported by VSCode][vscode].\r\n\r\nThe following features from TextMate snippets are not yet supported:\r\n\r\n* Interpolated shell code can’t reliably be supported cross-platform, and is probably a bad idea anyway. No other editors that support snippets have adopted this feature, and Pulsar won’t either.\r\n\r\nThe following features from VSCode snippets are not yet supported:\r\n\r\n* “Choice” syntax like `${1|one,two,three|}` requires that the autocomplete engine pop up a menu to offer the user a choice between the available placeholder options. This may be supported in the future, but right now Pulsar effectively converts this to `${1:one}`, treating the first choice as a conventional placeholder.\r\n\r\n### Variables\r\n\r\nPulsar snippets support all of the variables mentioned in the [LSP specification][lsp], plus many of the variables [supported by VSCode][vscode].\r\n\r\nVariables can be referenced with `$`, either without braces (`$CLIPBOARD`) or with braces (`${CLIPBOARD}`). Variables can also have fallback values (`${CLIPBOARD:http://example.com}`), simple flag-based transformations (`${CLIPBOARD:/upcase}`), or `sed`-style transformations (`${CLIPBOARD/ /_/g}`).\r\n\r\nOne of the most useful is `TM_SELECTED_TEXT`, which represents whatever text was selected when the snippet was invoked. (Naturally, this can only happen when a snippet is invoked via command or key shortcut, rather than by typing in a <kbd>Tab</kbd> trigger.)\r\n\r\nOthers that can be useful:\r\n\r\n* `TM_FILENAME`: The name of the current file (`foo.rb`).\r\n* `TM_FILENAME_BASE`: The name of the current file, but without its extension (`foo`).\r\n* `TM_FILEPATH`: The entire path on disk to the current file.\r\n* `TM_CURRENT_LINE`: The entire current line that the cursor is sitting on.\r\n* `TM_CURRENT_WORD`: The entire word that the cursor is within or adjacent to, as interpreted by `cursor.getCurrentWordBufferRange`.\r\n* `CLIPBOARD`: The current contents of the clipboard.\r\n* `CURRENT_YEAR`, `CURRENT_MONTH`, et cetera: referneces to the current date and time in various formats.\r\n* `LINE_COMMENT`, `BLOCK_COMMENT_START`, `BLOCK_COMMENT_END`: uses the correct comment delimiters for whatever language you’re in.\r\n\r\nAny variable that has no value — for instance, `TM_FILENAME` on an untitled document, or `LINE_COMMENT` in a CSS file — will resolve to an empty string.\r\n\r\n#### Variable transformation flags\r\n\r\nPulsar supports the three flags defined in the [LSP snippets specification][lsp] and two other flags that are [implemented in VSCode][vscode]:\r\n\r\n* `/upcase` (`foo` → `FOO`)\r\n* `/downcase` (`BAR` → `bar`)\r\n* `/capitalize` (`lorem ipsum dolor` → `Lorem ipsum dolor`) *(first letter uppercased; rest of input left intact)*\r\n* `/camelcase` (`foo bar` → `fooBar`, `lorem-ipsum.dolor` → `loremIpsumDolor`)\r\n* `/pascalcase` (`foo bar` → `FooBar`, `lorem-ipsum.dolor` → `LoremIpsumDolor`)\r\n\r\nIt also supports two other common transformations:\r\n\r\n* `/snakecase` (`foo bar` → `foo_bar`, `lorem-ipsum.dolor` → `lorem_ipsum_dolor`)\r\n* `/kebabcase` (`foo bar` → `foo-bar`, `lorem-ipsum.dolor` → `lorem-ipsum-dolor`)\r\n\r\nThese transformation flags can also be applied on backreferences in `sed`-style replacements for transformed tab stops. Given the following example snippet body…\r\n\r\n```\r\n[$1] becomes [${1/(.*)/${1:/upcase}/}]\r\n```\r\n\r\n…invoking the snippet and typing `Lorem ipsum dolor` will produce:\r\n\r\n```\r\n[Lorem ipsum dolor] becomes [LOREM IPSUM DOLOR]\r\n```\r\n\r\n\r\n#### Variable caveats\r\n\r\n* `WORKSPACE_NAME`, `WORKSPACE_FOLDER`, and `RELATIVE_PATH` all rely on the presence of a root project folder, but a Pulsar project can technically have multiple root folders. While this is rare, it is handled by `snippets` as follows: whichever project path is an ancestor of the currently active file is treated as the project root — or the first one found if multiple roots are ancestors.\r\n* `WORKSPACE_NAME` in VSCode refers to “the name of the opened workspace or folder.” In the former case, this appears to mean bundled projects with a `.code-workspace` file extension — which have no Pulsar equivalent. Instead, `WORKSPACE_NAME` will always refer to the last path component of your project’s root directory as defined above.\r\n\r\n#### Variables that are not yet supported\r\n\r\nOf the variables supported by VSCode, Pulsar does not yet support:\r\n\r\n* `UUID` (Will automatically be supported when Pulsar uses a version of Electron that has native `crypto.randomUUID`.)\r\n\r\n## Multi-line Snippet Body\r\n\r\nYou can also use multi-line syntax using `\"\"\"` for larger templates:\r\n\r\n```coffee\r\n'.source.js':\r\n  'if, else if, else':\r\n    'prefix': 'ieie'\r\n    'body': \"\"\"\r\n      if (${1:true}) {\r\n        $2\r\n      } else if (${3:false}) {\r\n        $4\r\n      } else {\r\n        $5\r\n      }\r\n    \"\"\"\r\n```\r\n\r\n## Escaping Characters\r\n\r\nIncluding a literal closing brace inside the text provided by a snippet's tab stop will close that tab stop early. To prevent that, escape the brace with two backslashes, like so:\r\n\r\n```coffee\r\n'.source.js':\r\n  'function':\r\n    'prefix': 'funct'\r\n    'body': \"\"\"\r\n      ${1:function () {\r\n        statements;\r\n      \\\\}\r\n      this line is also included in the snippet tab;\r\n      }\r\n      \"\"\"\r\n```\r\n\r\nLikewise, if your snippet includes literal references to `$` or `{`, you may have to escape those with two backslashes as well, depending on the context.\r\n\r\n## Multiple snippets for the same scope\r\n\r\nSnippets for the same scope must be placed within the same key. See [this section of the Pulsar Flight Manual](https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#configuring-with-cson) for more information.\r\n\r\n\r\n[lsp]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#variables\r\n[vscode]: https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables\r\n",
+    "readme": "# Snippets package\n\nExpand snippets matching the current prefix with <kbd>tab</kbd> in Pulsar.\n\nTo add your own snippets, select the _Pulsar > Snippets..._ menu option if you're using macOS, or the _File > Snippets..._ menu option if you're using Windows, or the _Edit > Snippets..._ menu option if you are using Linux.\n\n## Snippet Format\n\nSnippets files are stored in a package's `snippets/` folder and also loaded from `~/.pulsar/snippets.cson`. They can be either `.json` or `.cson` file types.\n\n```coffee\n'.source.js':\n  'console.log':\n    'prefix': 'log'\n    'command': 'insert-console-log'\n    'body': 'console.log(${1:\"crash\"});$2'\n```\n\nThe outermost keys are the selectors where these snippets should be active, prefixed with a period (`.`) (details below).\n\nThe next level of keys are the snippet names. Because this is object notation, each snippet must have a different name.\n\nUnder each snippet name is a `body` to insert when the snippet is triggered.\n\n`$` followed by a number are the tabs stops which can be cycled between by pressing <kbd>Tab</kbd> once a snippet has been triggered.\n\nThe above example adds a `console.log` snippet to JavaScript files that would expand to:\n\n```js\nconsole.log(\"crash\");\n```\n\nThe string `\"crash\"` would be initially selected and pressing tab again would place the cursor after the `;`\n\nA snippet specifies how it can be triggered. Thus it must provide **at least one** of the following keys:\n\n### The ‘prefix’ key\n\nIf a `prefix` is defined, it specifies a string that can trigger the snippet. In the above example, typing `log` (as its own word) and then pressing <kbd>Tab</kbd> would replace `log` with the string `console.log(\"crash\")` as described above.\n\nPrefix completions can be suggested if partially typed thanks to the `autocomplete-snippets` package.\n\n### The ‘command’ key\n\nIf a `command` is defined, it specifies a command name that can trigger the snippet. That command can be invoked from the command palette or mapped to a keyboard shortcut via your `keymap.cson`.\n\nIf a package called `some-package` had defined that snippet, it would be available in the keymap as `some-package:insert-console-log`, or in the command palette as **Some Package: Insert Console Log**.\n\nIf you defined the `console.log` snippet described above in your own `snippets.cson`, it could be referenced in a keymap file as `snippets:insert-console-log`, or in the command palette as **Snippets: Insert Console Log**.\n\nInvoking the command would insert the snippet at the cursor, replacing any text that may be selected.\n\nSnippet command names must be unique. They can’t conflict with each other, nor can they conflict with any other commands that have been defined. If there is such a conflict, you’ll see an error notification describing the problem.\n\n### Optional parameters\n\nThese parameters are meant to provide extra information about your snippet to [autocomplete-plus](https://github.com/atom/autocomplete-plus/wiki/Provider-API).\n\n* `leftLabel` will add text to the left part of the autocomplete results box.\n* `leftLabelHTML` will overwrite what's in `leftLabel` and allow you to use a bit of CSS such as `color`.\n* `rightLabelHTML`. By default, in the right part of the results box you will see the name of the snippet. When using `rightLabelHTML` the name of the snippet will no longer be displayed, and you will be able to use a bit of CSS.\n* `description` will add text to a description box under the autocomplete results list.\n* `descriptionMoreURL` URL to the documentation of the snippet.\n\n![autocomplete-description](http://i.imgur.com/cvI2lOq.png)\n\nExample:\n```coffee\n'.source.js':\n  'console.log':\n    'prefix': 'log'\n    'body': 'console.log(${1:\"crash\"});$2'\n    'description': 'Output data to the console'\n    'rightLabelHTML': '<span style=\"color:#ff0\">JS</span>'\n```\n\n### Determining the correct scope for a snippet\n\nThe outmost key of a snippet is the “scope” that you want the descendent snippets to be available in. The key should be prefixed with a period (`text.html.basic` → `.text.html.basic`). You can find out the correct scope by opening the Settings (<kbd>cmd-,</kbd> on macOS) and selecting the corresponding *Language [xxx]* package. For example, here’s the settings page for `language-html`:\n\n![Screenshot of Language Html settings](https://cloud.githubusercontent.com/assets/1038121/5137632/126beb66-70f2-11e4-839b-bc7e84103f67.png)\n\nIf it's difficult to determine the package handling the file type in question (for example, for `.md`-documents), you can use another approach:\n\n1. Put your cursor in a file in which you want the snippet to be available.\n2. Open the [Command Palette](https://github.com/pulsar-edit/command-palette)\n(<kbd>cmd-shift-p</kbd> or <kbd>ctrl-shift-p</kbd>).\n3. Run the `Editor: Log Cursor Scope` command.\n\nThis will trigger a notification which will contain a list of scopes. The first scope that's listed is the scope for that language. Here are some examples: `source.coffee`, `text.plain`, `text.html.basic`.\n\n## Snippet syntax\n\nThis package supports a subset of the features of TextMate snippets, [documented here](http://manual.macromates.com/en/snippets), as well as most features described in the [LSP specification][lsp] and [supported by VSCode][vscode].\n\nThe following features from TextMate snippets are not yet supported:\n\n* Interpolated shell code can’t reliably be supported cross-platform, and is probably a bad idea anyway. No other editors that support snippets have adopted this feature, and Pulsar won’t either.\n\nThe following features from VSCode snippets are not yet supported:\n\n* “Choice” syntax like `${1|one,two,three|}` requires that the autocomplete engine pop up a menu to offer the user a choice between the available placeholder options. This may be supported in the future, but right now Pulsar effectively converts this to `${1:one}`, treating the first choice as a conventional placeholder.\n\n### Variables\n\nPulsar snippets support all of the variables mentioned in the [LSP specification][lsp], plus many of the variables [supported by VSCode][vscode].\n\nVariables can be referenced with `$`, either without braces (`$CLIPBOARD`) or with braces (`${CLIPBOARD}`). Variables can also have fallback values (`${CLIPBOARD:http://example.com}`), simple flag-based transformations (`${CLIPBOARD:/upcase}`), or `sed`-style transformations (`${CLIPBOARD/ /_/g}`).\n\nOne of the most useful is `TM_SELECTED_TEXT`, which represents whatever text was selected when the snippet was invoked. (Naturally, this can only happen when a snippet is invoked via command or key shortcut, rather than by typing in a <kbd>Tab</kbd> trigger.)\n\nOthers that can be useful:\n\n* `TM_FILENAME`: The name of the current file (`foo.rb`).\n* `TM_FILENAME_BASE`: The name of the current file, but without its extension (`foo`).\n* `TM_FILEPATH`: The entire path on disk to the current file.\n* `TM_CURRENT_LINE`: The entire current line that the cursor is sitting on.\n* `TM_CURRENT_WORD`: The entire word that the cursor is within or adjacent to, as interpreted by `cursor.getCurrentWordBufferRange`.\n* `CLIPBOARD`: The current contents of the clipboard.\n* `CURRENT_YEAR`, `CURRENT_MONTH`, et cetera: referneces to the current date and time in various formats.\n* `LINE_COMMENT`, `BLOCK_COMMENT_START`, `BLOCK_COMMENT_END`: uses the correct comment delimiters for whatever language you’re in.\n\nAny variable that has no value — for instance, `TM_FILENAME` on an untitled document, or `LINE_COMMENT` in a CSS file — will resolve to an empty string.\n\n#### Variable transformation flags\n\nPulsar supports the three flags defined in the [LSP snippets specification][lsp] and two other flags that are [implemented in VSCode][vscode]:\n\n* `/upcase` (`foo` → `FOO`)\n* `/downcase` (`BAR` → `bar`)\n* `/capitalize` (`lorem ipsum dolor` → `Lorem ipsum dolor`) *(first letter uppercased; rest of input left intact)*\n* `/camelcase` (`foo bar` → `fooBar`, `lorem-ipsum.dolor` → `loremIpsumDolor`)\n* `/pascalcase` (`foo bar` → `FooBar`, `lorem-ipsum.dolor` → `LoremIpsumDolor`)\n\nIt also supports two other common transformations:\n\n* `/snakecase` (`foo bar` → `foo_bar`, `lorem-ipsum.dolor` → `lorem_ipsum_dolor`)\n* `/kebabcase` (`foo bar` → `foo-bar`, `lorem-ipsum.dolor` → `lorem-ipsum-dolor`)\n\nThese transformation flags can also be applied on backreferences in `sed`-style replacements for transformed tab stops. Given the following example snippet body…\n\n```\n[$1] becomes [${1/(.*)/${1:/upcase}/}]\n```\n\n…invoking the snippet and typing `Lorem ipsum dolor` will produce:\n\n```\n[Lorem ipsum dolor] becomes [LOREM IPSUM DOLOR]\n```\n\n\n#### Variable caveats\n\n* `WORKSPACE_NAME`, `WORKSPACE_FOLDER`, and `RELATIVE_PATH` all rely on the presence of a root project folder, but a Pulsar project can technically have multiple root folders. While this is rare, it is handled by `snippets` as follows: whichever project path is an ancestor of the currently active file is treated as the project root — or the first one found if multiple roots are ancestors.\n* `WORKSPACE_NAME` in VSCode refers to “the name of the opened workspace or folder.” In the former case, this appears to mean bundled projects with a `.code-workspace` file extension — which have no Pulsar equivalent. Instead, `WORKSPACE_NAME` will always refer to the last path component of your project’s root directory as defined above.\n\n#### Variables that are not yet supported\n\nOf the variables supported by VSCode, Pulsar does not yet support:\n\n* `UUID` (Will automatically be supported when Pulsar uses a version of Electron that has native `crypto.randomUUID`.)\n\n## Multi-line Snippet Body\n\nYou can also use multi-line syntax using `\"\"\"` for larger templates:\n\n```coffee\n'.source.js':\n  'if, else if, else':\n    'prefix': 'ieie'\n    'body': \"\"\"\n      if (${1:true}) {\n        $2\n      } else if (${3:false}) {\n        $4\n      } else {\n        $5\n      }\n    \"\"\"\n```\n\n## Escaping Characters\n\nIncluding a literal closing brace inside the text provided by a snippet's tab stop will close that tab stop early. To prevent that, escape the brace with two backslashes, like so:\n\n```coffee\n'.source.js':\n  'function':\n    'prefix': 'funct'\n    'body': \"\"\"\n      ${1:function () {\n        statements;\n      \\\\}\n      this line is also included in the snippet tab;\n      }\n      \"\"\"\n```\n\nLikewise, if your snippet includes literal references to `$` or `{`, you may have to escape those with two backslashes as well, depending on the context.\n\n## Multiple snippets for the same scope\n\nSnippets for the same scope must be placed within the same key. See [this section of the Pulsar Flight Manual](https://pulsar-edit.dev/docs/launch-manual/sections/using-pulsar/#configuring-with-cson) for more information.\n\n\n[lsp]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#variables\n[vscode]: https://code.visualstudio.com/docs/editor/userdefinedsnippets#_variables\n",
     "metadata": {
       "name": "snippets",
       "version": "1.8.0",
@@ -2651,7 +2733,7 @@
         "atom": "*"
       },
       "dependencies": {
-        "async": "~0.2.6",
+        "async": "3.2.6",
         "atom-select-list": "^0.7.0",
         "pegjs": "^0.10.0",
         "scoped-property-store": "^0.17.0",
@@ -2673,7 +2755,7 @@
     }
   },
   "solarized-dark-syntax": {
-    "readme": "# Solarized Dark Syntax theme\r\n\r\nPulsar theme using the ever popular dark [solarized](http://ethanschoonover.com/solarized) colors.\r\n\r\n<img alt=\"screenshot\" src=\"https://cloud.githubusercontent.com/assets/378023/12602908/9c252b08-c4f0-11e5-8833-6aad91b8fa34.png\" srcset=\"https://cloud.githubusercontent.com/assets/378023/12602909/9c25b366-c4f0-11e5-9f5d-aa6a517f7d7e.png 2x\">\r\n\r\nThis theme is installed by default with Pulsar and can be activated by going to\r\nthe _Themes_ section in the Settings view (`cmd-,`) and selecting it from the\r\n_Syntax Themes_ dropdown menu.\r\n",
+    "readme": "# Solarized Dark Syntax theme\n\nPulsar theme using the ever popular dark [solarized](http://ethanschoonover.com/solarized) colors.\n\n<img alt=\"screenshot\" src=\"https://cloud.githubusercontent.com/assets/378023/12602908/9c252b08-c4f0-11e5-8833-6aad91b8fa34.png\" srcset=\"https://cloud.githubusercontent.com/assets/378023/12602909/9c25b366-c4f0-11e5-9f5d-aa6a517f7d7e.png 2x\">\n\nThis theme is installed by default with Pulsar and can be activated by going to\nthe _Themes_ section in the Settings view (`cmd-,`) and selecting it from the\n_Syntax Themes_ dropdown menu.\n",
     "metadata": {
       "name": "solarized-dark-syntax",
       "theme": "syntax",
@@ -2687,7 +2769,7 @@
     }
   },
   "solarized-light-syntax": {
-    "readme": "# Solarized Light Syntax theme\r\n\r\nPulsar theme using the ever popular light [solarized](http://ethanschoonover.com/solarized) colors.\r\n\r\n<img alt=\"screenshot\" src=\"https://cloud.githubusercontent.com/assets/378023/12602186/87edab3e-c4ea-11e5-8f4a-4b7defda283b.png\" srcset=\"https://cloud.githubusercontent.com/assets/378023/12602177/78d568da-c4ea-11e5-836d-e922ca5c850a.png 2x\">\r\n\r\nThis theme is installed by default with Pulsar and can be activated by going to\r\nthe _Themes_ section in the Settings view (`cmd-,`) and selecting it from the\r\n_Syntax Themes_ dropdown menu.\r\n",
+    "readme": "# Solarized Light Syntax theme\n\nPulsar theme using the ever popular light [solarized](http://ethanschoonover.com/solarized) colors.\n\n<img alt=\"screenshot\" src=\"https://cloud.githubusercontent.com/assets/378023/12602186/87edab3e-c4ea-11e5-8f4a-4b7defda283b.png\" srcset=\"https://cloud.githubusercontent.com/assets/378023/12602177/78d568da-c4ea-11e5-836d-e922ca5c850a.png 2x\">\n\nThis theme is installed by default with Pulsar and can be activated by going to\nthe _Themes_ section in the Settings view (`cmd-,`) and selecting it from the\n_Syntax Themes_ dropdown menu.\n",
     "metadata": {
       "name": "solarized-light-syntax",
       "theme": "syntax",
@@ -2701,19 +2783,18 @@
     }
   },
   "spell-check": {
-    "readme": "# Spell Check package\r\n\r\nHighlights misspelling in Pulsar and shows possible corrections.\r\n\r\nUse <kbd>cmd-shift-:</kbd> for Mac or <kbd>ctrl-shift-:</kbd> for Windows or Linux to bring up the list of corrections when your cursor is on a misspelled word.\r\n\r\nBy default spell check is enabled for the following files:\r\n\r\n* Plain Text\r\n* GitHub Markdown\r\n* Git Commit Message\r\n* AsciiDoc\r\n* reStructuredText\r\n\r\nYou can override this from the _Spell Check_ settings in the Settings View (<kbd>cmd-,</kbd>). The Grammars config option is a list of scopes for which the package will check for spelling errors.\r\n\r\nTo enable _Spell Check_ for your current file type: put your cursor in the file, open the [Command Palette](https://github.com/pulsar-edit/command-palette)\r\n(<kbd>cmd-shift-p</kbd> for Mac or <kbd>ctrl-shift-p</kbd> for Windows or Linux), and run the `Editor: Log Cursor Scope` command. This will trigger a notification which will contain a list of scopes. The first scope that's listed is the one you should add to the list of scopes in the settings for the _Spell Check_ package. Here are some examples: `source.coffee`, `text.plain`, `text.html.basic`.\r\n\r\n## Changing the dictionary\r\n\r\nExcept for Mac, Pulsar needs to know what language to use to perform spell-checking. To list these, set the \"Locales\" configuration option to the [IETF tag](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) (en-US, fr-FR, etc). More than one language can be used, simply separate them by commas.\r\n\r\nIf no locale is given, then Pulsar will attempt to infer the language based on environment variables and settings.\r\n\r\nIf any value is given for the \"Locales\", then Pulsar will not automatically add the browser language. So, if your browser is United States English (`en-US`), leaving this blank will still do US English checking. However, if it the \"Locales\" is set to French (`fr-FR`), then the checker will only check French. If the \"Locales\" is set to `en-US, fr-FR`, then both languages will be checked.\r\n\r\n### Missing Languages\r\n\r\nThis plugin uses the existing system dictionaries. If a locale is selected that is not installed, a warning will pop up when a document that would be spell-checked is loaded. To disable this, either remove the incorrect language from the \"Locales\" configuration or clear the check on \"Use Locales\" to disable it entirely.\r\n\r\nTo get the search paths used to look for a dictionary, make sure the \"Notices Mode\" is set to \"console\" or \"both\", then reload Atom. The developer's console will have the directory list.\r\n\r\n## Mac\r\n\r\nOn the Mac, checking \"Use System\" will use the operating system's spellchecking library. This uses all of the user's loaded dictionaries and doesn't require any customization within Pulsar.\r\n\r\nChecking \"Use Locales\" and providing locales would use Hunspell as additional dictionaries. Having \"Use Locales\" checked but no locales given will do nothing.\r\n\r\n## Windows 8 and Higher\r\n\r\nFor Windows 8 and 10, this package uses the Windows spell checker, so you must install the language using the regional settings before the language can be chosen inside Pulsar.\r\n\r\n![Add the language from the Language and Regions settings panel](docs/windows-10-language-settings.png)\r\n\r\nIf your Windows user does not have Administration privileges, you'll need to do an extra step once the language has been added to enable the spell checker. To do so, you need to install the \"Basic typing\" language option by following the next steps (you'll be asked for your administrator password):\r\n\r\n![Click on the \"Options\" button on the added language](docs/windows-10-language-settings-2.png)\r\n\r\n![Download the \"Basic Typing\" language option](docs/windows-10-language-settings-3.png)\r\n\r\nOnce the additional language is added, Pulsar will need to be restarted and configured to use it. Add the IEFT tag into the \"Locales\" setting for the language to be set.\r\n\r\nIf a Hunspell dictionary is found on a path (see below), it will be used in favor of the Windows API.\r\n\r\n## Linux\r\n\r\nFor all Linux-based operating systems, \"Use System\" does nothing. It can remained checked but has no impact. \"Use Locales\" is required for spell-checking.\r\n\r\n### Debian, Ubuntu, and Mint\r\n\r\nOn Ubuntu, installing \"Language Support\" may solve problems with the dictionaries. For other distributions (or if Language Support doesn't work), you may use `apt` to install the dictionaries.\r\n\r\n```\r\nsudo apt-get install hunspell-en-gb\r\nsudo apt-get install myspell-en-gb\r\n```\r\n\r\nOn RedHat, the following should work for Italian:\r\n\r\n```\r\nsudo dnf install hunspell\r\nsudo dnf install hunspell-it\r\n```\r\n\r\nYou can get a list of currently installed languages with:\r\n\r\n```\r\n/usr/bin/hunspell -D\r\n```\r\n\r\nPulsar may require a restart to pick up newly installed dictionaries.\r\n\r\n### Arch Linux\r\n\r\nA language may be installed by running:\r\n\r\n```\r\npacman -S hunspell-en_GB\r\n```\r\n\r\nFor the time being, a soft link may be required if the dictionary provided is \"large\".\r\n\r\n```\r\ncd /usr/share/hunspell\r\nsudo ln -s en_GB-large.dic en_GB.dic\r\nsudo ln -s en_GB-large.aff en_GB.aff\r\n```\r\n\r\n## Hunspell Dictionaries\r\n\r\nFor all platforms, a Hunspell-compatible dictionary is also supported. To use this, a `.dic` and `.aff` need to be located in one of the default search directories or in a directory entered into \"Locale paths\" (multiples may be entered with commas separating them). If the appropriate files are found for the locale and \"Use Locales\" is checked, then the dictionary will be used.\r\n\r\nFor example, if the following is set, then `/usr/share/hunspell/en_US.dic` will be used:\r\n\r\n- Use Locales: checked\r\n- Locales: `en-US`\r\n- Locale Paths: `/usr/share/hunspell`\r\n\r\nIf \"Locales\" is not provided, then the user's current language will be inferred from environmental settings.\r\n\r\nIn addition to what is provided, the following paths are checked:\r\n\r\n- `/usr/share/hunspell` (Linux only)\r\n- `/usr/share/myspell` (Linux only)\r\n- `/usr/share/myspell/dicts` (Linux only)\r\n- `/` (Mac only)\r\n- `/System/Library/Spelling` (Mac only)\r\n- `C:\\` (Windows only)\r\n\r\nDictionaries can be downloaded from various sites (such as [wooorm's repository](https://github.com/wooorm/dictionaries) or [LibreOffice's](https://github.com/LibreOffice/dictionaries)), but the file has to be renamed `locale.dic` and `locale.aff`.\r\n\r\n*Example locations to download are not an endorsement.*\r\n",
+    "readme": "# Spell Check package\n\nHighlights misspelling in Pulsar and shows possible corrections.\n\nUse <kbd>cmd-shift-:</kbd> for Mac or <kbd>ctrl-shift-:</kbd> for Windows or Linux to bring up the list of corrections when your cursor is on a misspelled word.\n\nBy default spell check is enabled for the following files:\n\n* Plain Text\n* GitHub Markdown\n* Git Commit Message\n* AsciiDoc\n* reStructuredText\n\nYou can override this from the _Spell Check_ settings in the Settings View (<kbd>cmd-,</kbd>). The Grammars config option is a list of scopes for which the package will check for spelling errors.\n\nTo enable _Spell Check_ for your current file type: put your cursor in the file, open the [Command Palette](https://github.com/pulsar-edit/command-palette)\n(<kbd>cmd-shift-p</kbd> for Mac or <kbd>ctrl-shift-p</kbd> for Windows or Linux), and run the `Editor: Log Cursor Scope` command. This will trigger a notification which will contain a list of scopes. The first scope that's listed is the one you should add to the list of scopes in the settings for the _Spell Check_ package. Here are some examples: `source.coffee`, `text.plain`, `text.html.basic`.\n\n## Changing the dictionary\n\nExcept for Mac, Pulsar needs to know what language to use to perform spell-checking. To list these, set the \"Locales\" configuration option to the [IETF tag](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry) (en-US, fr-FR, etc). More than one language can be used, simply separate them by commas.\n\nIf no locale is given, then Pulsar will attempt to infer the language based on environment variables and settings.\n\nIf any value is given for the \"Locales\", then Pulsar will not automatically add the browser language. So, if your browser is United States English (`en-US`), leaving this blank will still do US English checking. However, if it the \"Locales\" is set to French (`fr-FR`), then the checker will only check French. If the \"Locales\" is set to `en-US, fr-FR`, then both languages will be checked.\n\n### Missing Languages\n\nThis plugin uses the existing system dictionaries. If a locale is selected that is not installed, a warning will pop up when a document that would be spell-checked is loaded. To disable this, either remove the incorrect language from the \"Locales\" configuration or clear the check on \"Use Locales\" to disable it entirely.\n\nTo get the search paths used to look for a dictionary, make sure the \"Notices Mode\" is set to \"console\" or \"both\", then reload Atom. The developer's console will have the directory list.\n\n## Mac\n\nOn the Mac, checking \"Use System\" will use the operating system's spellchecking library. This uses all of the user's loaded dictionaries and doesn't require any customization within Pulsar.\n\nChecking \"Use Locales\" and providing locales would use Hunspell as additional dictionaries. Having \"Use Locales\" checked but no locales given will do nothing.\n\n## Windows 8 and Higher\n\nFor Windows 8 and 10, this package uses the Windows spell checker, so you must install the language using the regional settings before the language can be chosen inside Pulsar.\n\n![Add the language from the Language and Regions settings panel](docs/windows-10-language-settings.png)\n\nIf your Windows user does not have Administration privileges, you'll need to do an extra step once the language has been added to enable the spell checker. To do so, you need to install the \"Basic typing\" language option by following the next steps (you'll be asked for your administrator password):\n\n![Click on the \"Options\" button on the added language](docs/windows-10-language-settings-2.png)\n\n![Download the \"Basic Typing\" language option](docs/windows-10-language-settings-3.png)\n\nOnce the additional language is added, Pulsar will need to be restarted and configured to use it. Add the IEFT tag into the \"Locales\" setting for the language to be set.\n\nIf a Hunspell dictionary is found on a path (see below), it will be used in favor of the Windows API.\n\n## Linux\n\nFor all Linux-based operating systems, \"Use System\" does nothing. It can remained checked but has no impact. \"Use Locales\" is required for spell-checking.\n\n### Debian, Ubuntu, and Mint\n\nOn Ubuntu, installing \"Language Support\" may solve problems with the dictionaries. For other distributions (or if Language Support doesn't work), you may use `apt` to install the dictionaries.\n\n```\nsudo apt-get install hunspell-en-gb\nsudo apt-get install myspell-en-gb\n```\n\nOn RedHat, the following should work for Italian:\n\n```\nsudo dnf install hunspell\nsudo dnf install hunspell-it\n```\n\nYou can get a list of currently installed languages with:\n\n```\n/usr/bin/hunspell -D\n```\n\nPulsar may require a restart to pick up newly installed dictionaries.\n\n### Arch Linux\n\nA language may be installed by running:\n\n```\npacman -S hunspell-en_GB\n```\n\nFor the time being, a soft link may be required if the dictionary provided is \"large\".\n\n```\ncd /usr/share/hunspell\nsudo ln -s en_GB-large.dic en_GB.dic\nsudo ln -s en_GB-large.aff en_GB.aff\n```\n\n## Hunspell Dictionaries\n\nFor all platforms, a Hunspell-compatible dictionary is also supported. To use this, a `.dic` and `.aff` need to be located in one of the default search directories or in a directory entered into \"Locale paths\" (multiples may be entered with commas separating them). If the appropriate files are found for the locale and \"Use Locales\" is checked, then the dictionary will be used.\n\nFor example, if the following is set, then `/usr/share/hunspell/en_US.dic` will be used:\n\n- Use Locales: checked\n- Locales: `en-US`\n- Locale Paths: `/usr/share/hunspell`\n\nIf \"Locales\" is not provided, then the user's current language will be inferred from environmental settings.\n\nIn addition to what is provided, the following paths are checked:\n\n- `/usr/share/hunspell` (Linux only)\n- `/usr/share/myspell` (Linux only)\n- `/usr/share/myspell/dicts` (Linux only)\n- `/` (Mac only)\n- `/System/Library/Spelling` (Mac only)\n- `C:\\` (Windows only)\n\nDictionaries can be downloaded from various sites (such as [wooorm's repository](https://github.com/wooorm/dictionaries) or [LibreOffice's](https://github.com/LibreOffice/dictionaries)), but the file has to be renamed `locale.dic` and `locale.aff`.\n\n*Example locations to download are not an endorsement.*\n",
     "metadata": {
       "name": "spell-check",
       "version": "0.77.1",
       "main": "./lib/main",
       "description": "Highlights misspelled words and shows possible corrections.",
       "dependencies": {
-        "atom-pathspec": "^0.0.0",
         "atom-select-list": "^0.7.0",
         "debug": "^4.1.1",
         "multi-integer-range": "^2.0.0",
         "natural": "^0.4.0",
-        "spellchecker": "^3.7.1",
+        "spellchecker": "https://github.com/pulsar-edit/node-spellchecker.git#da32e897e74691b7f43b70ddc0d171bad2d38208",
         "spelling-manager": "^1.1.0",
         "underscore-plus": "^1"
       },
@@ -2724,7 +2805,8 @@
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
       "engines": {
-        "atom": "*"
+        "atom": "*",
+        "node": ">=14"
       },
       "scripts": {
         "format": "prettier --write \"spec/*.js\" \"lib/**/*.js\" \"script/*.js\" --loglevel warn"
@@ -2741,7 +2823,7 @@
             "source.rst",
             "text.restructuredtext"
           ],
-          "description": "List of scopes for languages which will be checked for misspellings. See [the README](https://github.com/pulsar-edit/pulsar/blob/master/packages/spell-check/README.md) for more information on finding the correct scope for a specific language.",
+          "description": "List of scopes for languages which will be checked for misspellings. See [the README](https://github.com/pulsar-edit/pulsar/blob/master/packages/spell-check/README.md) for more information on finding the correct scope for a specific language. If you want to spell-check only parts of some languages, you may specify a more detailed scope selector (like `source.js comment.block` or `source string`); but the first part of the selector must match the language scope.",
           "order": 1
         },
         "excludedScopes": {
@@ -2838,7 +2920,7 @@
     }
   },
   "status-bar": {
-    "readme": "# Status Bar package\r\n\r\nDisplay information about the current editor such as cursor position, file path, grammar, current branch, ahead/behind commit counts, and line diff count.\r\n\r\n![](https://f.cloud.github.com/assets/671378/2241819/f8418cb8-9ce5-11e3-87e5-109e965986d0.png)\r\n\r\n## Configuration\r\n\r\nThe status bar package accepts the following configuration values:\r\n\r\n* `status-bar.cursorPositionFormat` &mdash; A string that describes the format to use for the cursor position status bar tile. It defaults to `%L:%C`. In the format string, `%L` represents the 1-based line number and `%C` represents the 1-based column number.\r\n\r\n* `status-bar.selectionCountFormat` &mdash; A string that describes the format to use for the selection count status bar tile. It defaults to `(%L, %C)`. In the format string, `%L` represents the 1-based line count and `%C` represents the 1-based character count.\r\n\r\n## API\r\n\r\nThis package provides a service that you can use in other Pulsar packages. To use it, include `status-bar` in the `consumedServices` section of your `package.json`:\r\n\r\n```json\r\n{\r\n  \"name\": \"my-package\",\r\n  \"consumedServices\": {\r\n    \"status-bar\": {\r\n      \"versions\": {\r\n        \"^1.0.0\": \"consumeStatusBar\"\r\n      }\r\n    }\r\n  }\r\n}\r\n```\r\n\r\nThen, in your package's main module, call methods on the service:\r\n\r\n```coffee\r\nmodule.exports =\r\n  activate: -> # ...\r\n\r\n  consumeStatusBar: (statusBar) ->\r\n    @statusBarTile = statusBar.addLeftTile(item: myElement, priority: 100)\r\n\r\n  deactivate: ->\r\n    # ...\r\n    @statusBarTile?.destroy()\r\n    @statusBarTile = null\r\n```\r\n\r\nThe `status-bar` API has four methods:\r\n\r\n  * `addLeftTile({ item, priority })` - Add a tile to the left side of the status bar. Lower priority tiles are placed further to the left.\r\n  * `addRightTile({ item, priority })` - Add a tile to the right side of the status bar. Lower priority tiles are placed further to the right.\r\n\r\nThe `item` parameter to these methods can be a DOM element, a [jQuery object](http://jquery.com), or a model object for which a view provider has been registered in the [the view registry](https://atom.io/docs/api/latest/ViewRegistry).\r\n\r\n  * `getLeftTiles()` - Retrieve all of the tiles on the left side of the status bar.\r\n  * `getRightTiles()` - Retrieve all of the tiles on the right side of the status bar\r\n\r\nAll of these methods return `Tile` objects, which have the following methods:\r\n\r\n  * `getPriority()` - Retrieve the priority that was assigned to the `Tile` when it was created.\r\n  * `getItem()` - Retrieve the `Tile`'s item.\r\n  * `destroy()` - Remove the `Tile` from the status bar.\r\n",
+    "readme": "# Status Bar package\n\nDisplay information about the current editor such as cursor position, file path, grammar, current branch, ahead/behind commit counts, and line diff count.\n\n![](https://f.cloud.github.com/assets/671378/2241819/f8418cb8-9ce5-11e3-87e5-109e965986d0.png)\n\n## Configuration\n\nThe status bar package accepts the following configuration values:\n\n* `status-bar.cursorPositionFormat` &mdash; A string that describes the format to use for the cursor position status bar tile. It defaults to `%L:%C`. In the format string, `%L` represents the 1-based line number and `%C` represents the 1-based column number.\n\n* `status-bar.selectionCountFormat` &mdash; A string that describes the format to use for the selection count status bar tile. It defaults to `(%L, %C)`. In the format string, `%L` represents the 1-based line count and `%C` represents the 1-based character count.\n\n## API\n\nThis package provides a service that you can use in other Pulsar packages. To use it, include `status-bar` in the `consumedServices` section of your `package.json`:\n\n```json\n{\n  \"name\": \"my-package\",\n  \"consumedServices\": {\n    \"status-bar\": {\n      \"versions\": {\n        \"^1.0.0\": \"consumeStatusBar\"\n      }\n    }\n  }\n}\n```\n\nThen, in your package's main module, call methods on the service:\n\n```coffee\nmodule.exports =\n  activate: -> # ...\n\n  consumeStatusBar: (statusBar) ->\n    @statusBarTile = statusBar.addLeftTile(item: myElement, priority: 100)\n\n  deactivate: ->\n    # ...\n    @statusBarTile?.destroy()\n    @statusBarTile = null\n```\n\nThe `status-bar` API has four methods:\n\n  * `addLeftTile({ item, priority })` - Add a tile to the left side of the status bar. Lower priority tiles are placed further to the left.\n  * `addRightTile({ item, priority })` - Add a tile to the right side of the status bar. Lower priority tiles are placed further to the right.\n\nThe `item` parameter to these methods can be a DOM element, a [jQuery object](http://jquery.com), or a model object for which a view provider has been registered in the [the view registry](https://atom.io/docs/api/latest/ViewRegistry).\n\n  * `getLeftTiles()` - Retrieve all of the tiles on the left side of the status bar.\n  * `getRightTiles()` - Retrieve all of the tiles on the right side of the status bar\n\nAll of these methods return `Tile` objects, which have the following methods:\n\n  * `getPriority()` - Retrieve the priority that was assigned to the `Tile` when it was created.\n  * `getItem()` - Retrieve the `Tile`'s item.\n  * `destroy()` - Remove the `Tile` from the status bar.\n",
     "metadata": {
       "name": "status-bar",
       "version": "1.8.17",
@@ -2892,7 +2974,7 @@
     }
   },
   "styleguide": {
-    "readme": "# Styleguide package\r\n\r\nStyleguide will show you all the UI components used in Pulsar. It is useful as a reference when developing themes and packages.\r\n\r\n* <kbd>cmd-ctrl-shift-g</kbd> (macOS) and <kbd>ctrl-shift-g</kbd> (Windows and Linux) opens it in a new tab\r\n* You can click on the section headings to expand/collapse them\r\n\r\n![Demo](https://cloud.githubusercontent.com/assets/378023/15767543/ccecf9bc-2983-11e6-9c5e-d228d39f52b0.png)\r\n",
+    "readme": "# Styleguide package\n\nStyleguide will show you all the UI components used in Pulsar. It is useful as a reference when developing themes and packages.\n\n* <kbd>cmd-ctrl-shift-g</kbd> (macOS) and <kbd>ctrl-shift-g</kbd> (Windows and Linux) opens it in a new tab\n* You can click on the section headings to expand/collapse them\n\n![Demo](https://cloud.githubusercontent.com/assets/378023/15767543/ccecf9bc-2983-11e6-9c5e-d228d39f52b0.png)\n",
     "metadata": {
       "name": "styleguide",
       "main": "./lib/styleguide",
@@ -2914,7 +2996,7 @@
     }
   },
   "symbol-provider-ctags": {
-    "readme": "# symbol-provider-ctags package\r\n\r\nProvides symbols to `symbols-view` via `ctags`.\r\n\r\nThis is the approach historically used by `symbols-view` — now spun out into its own “provider” package among several.\r\n\r\nThis symbol provider will typically be used on non-Tree-sitter grammars, and possibly when performing a project-wide search. Symbol-based navigation on files with Tree-sitter grammars will typically be provided by `symbol-provider-tree-sitter`.\r\n\r\n## Language support\r\n\r\nThis provider supports any language that is present in its config file, and detects any symbols that match the specified patterns. If your language isn’t supported and you can help add support, we’ll happily accept a pull request.\r\n\r\n## Toggle file symbols\r\n\r\nFor the **Symbols View: Toggle File Symbols** command, `ctags` will scan the file on disk and emit its tag information to stdout, where it is read by this package. You don’t need a `TAGS` file to do a symbol search within a single file.\r\n\r\n## Toggle Project Symbols, Go To Declaration\r\n\r\nThese commands require a tags file, typically defined at `.tags`/`tags`/`.TAGS`/`TAGS` in the root of your project. This package cannot generate (or regenerate) your tags file, since it doesn’t know which files to include. You can run `ctags` regularly on your own to generate this file. Consult [the documentation for Exuberant Ctags](https://ctags.sourceforge.net/ctags.html) for more information.\r\n\r\nOnce your tags file is present, these commands can be fulfilled by `symbol-provider-ctags`…\r\n\r\n* The **Symbols View: Toggle Project Symbols** command works like **Symbols View: Toggle File Symbols** described above, except it’ll show you symbols from the entire project.\r\n* The **Symbols View: Go To Declaration** command works like **Symbols View: Toggle Project Symbols**, except the word under the cursor will be pre-filled in the search box, and a result will automatically be opened if it is the only result.\r\n",
+    "readme": "# symbol-provider-ctags package\n\nProvides symbols to `symbols-view` via `ctags`.\n\nThis is the approach historically used by `symbols-view` — now spun out into its own “provider” package among several.\n\nThis symbol provider will typically be used on non-Tree-sitter grammars, and possibly when performing a project-wide search. Symbol-based navigation on files with Tree-sitter grammars will typically be provided by `symbol-provider-tree-sitter`.\n\n## Language support\n\nThis provider supports any language that is present in its config file, and detects any symbols that match the specified patterns. If your language isn’t supported and you can help add support, we’ll happily accept a pull request.\n\n## Toggle file symbols\n\nFor the **Symbols View: Toggle File Symbols** command, `ctags` will scan the file on disk and emit its tag information to stdout, where it is read by this package. You don’t need a `TAGS` file to do a symbol search within a single file.\n\n## Toggle Project Symbols, Go To Declaration\n\nThese commands require a tags file, typically defined at `.tags`/`tags`/`.TAGS`/`TAGS` in the root of your project. This package cannot generate (or regenerate) your tags file, since it doesn’t know which files to include. You can run `ctags` regularly on your own to generate this file. Consult [the documentation for Exuberant Ctags](https://ctags.sourceforge.net/ctags.html) for more information.\n\nOnce your tags file is present, these commands can be fulfilled by `symbol-provider-ctags`…\n\n* The **Symbols View: Toggle Project Symbols** command works like **Symbols View: Toggle File Symbols** described above, except it’ll show you symbols from the entire project.\n* The **Symbols View: Go To Declaration** command works like **Symbols View: Toggle Project Symbols**, except the word under the cursor will be pre-filled in the search box, and a result will automatically be opened if it is the only result.\n",
     "metadata": {
       "name": "symbol-provider-ctags",
       "main": "./lib/main",
@@ -2942,7 +3024,7 @@
         }
       },
       "dependencies": {
-        "async": "^0.2.6",
+        "async": "3.2.6",
         "fs-plus": "^3.1.1",
         "ctags": "^3.1.0"
       },
@@ -2953,7 +3035,7 @@
     }
   },
   "symbol-provider-tree-sitter": {
-    "readme": "# symbol-provider-tree-sitter package\r\n\r\nProvides symbols to `symbols-view` via Tree-sitter queries.\r\n\r\nTree-sitter grammars [with tags queries](https://tree-sitter.github.io/tree-sitter/code-navigation-systems) can very easily give us a list of all the symbols in a file without the drawbacks of a `ctags`-based approach. For instance, they operate on the contents of the buffer, not the contents of the file on disk, so they work just fine in brand-new files and in files that have been modified since the last save.\r\n\r\nThis provider does not currently support project-wide symbol search, but possibly could do so in the future.\r\n\r\n## Tags queries\r\n\r\nThis provider expects for a grammar to have specified a tags query in its grammar definition file. All the built-in Tree-sitter grammars will have such a file. If you’re using a third-party Tree-sitter grammar that hasn’t defined one, file an issue on Pulsar and we’ll see what we can do.\r\n\r\nIf you’re writing your own grammar, or contributing a `tags.scm` to a grammar without one, keep reading.\r\n\r\n### Query syntax\r\n\r\nThe query syntax starts as a subset of what is described [on this page](https://tree-sitter.github.io/tree-sitter/code-navigation-systems). Here’s what this package can understand:\r\n\r\n* A query that consists of a `@definition.THING` capture with a `@name` capture inside will properly be understood as a symbol with a tag corresponding to `THING` and a name corresponding to the `@name` capture’s text.\r\n* A query that consists of a `@reference.THING` capture with a `@name` capture inside will be ignored by default. If the proper setting is enabled, each of these references will become a symbol with a tag corresponding to `THING` and a name corresponding to the `@name` capture’s text.\r\n* All other `@name` captures that are not within either a `@definition` or a `@reference` will be considered as a symbol in isolation. (These symbols can still specify a tag via a `#set!` predicate.)\r\n\r\nTo match the current behavior of the `symbols-view` package, you can usually take a `queries/tags.scm` file from a Tree-sitter repository — many parsers define them — and paste it straight into your grammar’s `tags.scm` file.\r\n\r\n#### Advanced features\r\n\r\nThe text of the captured node is what will be displayed as the symbol’s name, but a few predicates are available to alter that field and others. Symbol predicates use `#set!` and the `symbol` namespace.\r\n\r\n##### Node position descriptors\r\n\r\nSeveral predicates take a **node position descriptor** as an argument. It’s a string that resembles an object lookup chain in JavaScript:\r\n\r\n```scm\r\n(#set! symbol.prependTextForNode parent.parent.firstNamedChild)\r\n```\r\n\r\nStarting at the captured node, it describes a path to take within the tree in order to get to another meaningful node.\r\n\r\nIn all these examples, if the descriptor is invalid and does not return a node, the predicate will be ignored.\r\n\r\n##### Changing the symbol’s name\r\n\r\nThere are several ways to add text to the beginning or end of the symbol’s name:\r\n\r\n###### symbol.prepend\r\n\r\n```scm\r\n(class_declaration\r\n  name: (identifier) @name\r\n  (#set! symbol.prepend \"Class: \"))\r\n```\r\n\r\nThe `symbol.prepend` predicate adds a constant string to the beginning of a symbol name. For a class `Foo` in JavaScript, this predicate would result in a symbol called `Class: Foo`.\r\n\r\n###### symbol.append\r\n\r\n```scm\r\n(class_declaration\r\n  name: (identifier) @name\r\n  (#set! symbol.append \" (class)\"))\r\n```\r\n\r\nThe `symbol.append` predicate adds a constant string to the end of a symbol name. For a class `Foo`, this predicate would result in a symbol called `Foo (class)`.\r\n\r\n\r\n###### symbol.strip\r\n\r\n```scm\r\n(class_declaration\r\n  name: (identifier) @name\r\n  (#set! symbol.strip \"^\\\\s+|\\\\s+$\"))\r\n```\r\n\r\nThe `symbol.strip` predicate will replace everything matched by the regular expression with an empty string. The pattern given is compiled into a JavaScript `RegExp` with an implied `g` (global) flag.\r\n\r\nIn this example, _if_ the `identifier` node included whitespace on either side of the symbol, the symbol’s name would be stripped of that whitespace before being shown in the UI.\r\n\r\n###### symbol.prependTextForNode\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.prependTextForNode \"parent.parent.previousNamedSibling\")\r\n  (#set! symbol.joiner \"#\")\r\n))\r\n```\r\n\r\nThe `symbol.prependTextForNode` predicate will look up the text of the node referred to by the provided _node position descriptor_, then prepend that text to the symbol name. If `symbol.joiner` is provided, it will be inserted in between the two.\r\n\r\nIn this example, a `bar` method on a class named `Foo` would have a symbol name of `Foo#bar`.\r\n\r\n###### symbol.prependSymbolForNode\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.prependSymbolForNode \"parent.parent.previousNamedSibling\")\r\n  (#set! symbol.joiner \"#\")\r\n))\r\n```\r\n\r\nThe `symbol.prependSymbolForNode` predicate will look up the symbol name of the node referred to by the provided _node position descriptor_, then prepend that name to the symbol name. If `symbol.joiner` is provided, it will be inserted in between the two.\r\n\r\nUnlike `symbol.prependTextForNode`, the node referred to with the descriptor must have its own symbol name, and it must have been processed already — that is, it must be a symbol whose name was determined earlier than that of the current node.\r\n\r\nThis allows us to incorporate any transformations that were applied to the other node’s symbol name. We can use this to build “recursive” symbol names — for instance, JSON keys whose symbols consist of their entire key path from the root.\r\n\r\n##### Adding the `context` field\r\n\r\nThe `context` field of a symbol is a short piece of text meant to give context. For instance, a symbol that represents a class method could have a `context` field that contains the name of the class it belongs to. The `context` field is not filtered on.\r\n\r\n###### symbol.contextNode\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.contextNode \"parent.parent.previousNamedSibling\")\r\n))\r\n```\r\n\r\nThe `symbol.contextNode` predicate will set the value of a symbol’s `context` property to the text of a node based on the provided _node position descriptor_.\r\n\r\n###### symbol.context\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.context \"class\")\r\n))\r\n```\r\n\r\nThe `symbol.context` predicate will set the value of a symbol’s `context` property to a fixed string.\r\n\r\nThe point of `context` is to provide information to help you tell symbols apart, so you probably don’t want to set it to a fixed value. But this predicate is available just in case.\r\n\r\n##### Adding a tag\r\n\r\nThe `tag` field is a string that indicates a symbol’s kind or type. It should be a single word wherever possible. A `tag` for a class method’s symbol would typically be `method`, whereas the symbol for the class itself would typically have a `tag` of `class`. These tags will be indicated in the UI with a badge, an icon, or both.\r\n\r\nIf you’re not sure what to call something, consult [this list from the Language Server Protocol spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolKind). But some symbols may not fit any of those, so ultimately it’s up to the author. (For example, headings in Markdown files are assigned a kind of `heading`.)\r\n\r\nFor consistency, tags should be all lowercase. The interface will apply its own casing effect through CSS (`text-transform: capitalize` by default, but customizable in UI themes).\r\n\r\nThe preferred method of adding a tag is to leverage the `@definition.` captures that are typically present in a tags file. For instance, in this excerpt from the JavaScript grammar’s `tags.scm` file…\r\n\r\n```scm\r\n(assignment_expression\r\n  left: [\r\n    (identifier) @name\r\n    (member_expression\r\n      property: (property_identifier) @name)\r\n  ]\r\n  right: [(arrow_function) (function)]\r\n) @definition.function\r\n```\r\n\r\n…the resulting symbol will infer a `tag` value of `function`.\r\n\r\nIn cases where this is impractical, you can provide the tag explicitly with a predicate.\r\n\r\nNearly all the tags on [the aforementioned list](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolKind) will also apply an appropriate `icon` to their symbol when assigned. If you choose a tag name not on that list, or want to override the default, you can use the `symbol.icon` predicate described below.\r\n\r\n###### symbol.tag\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.tag \"class\")\r\n))\r\n```\r\n\r\nThe `symbol.tag` predicate will set the value of a symbol’s `tag` property to a fixed string.\r\n\r\nThe `tag` property is used to supply a word that represents the symbol in some way. For conventional symbols, this will often be something like `class` or `function`.\r\n\r\nThis provider will attempt to match certain common tag values to icons. This can be overridden by specifying an explicit `symbol.icon` value.\r\n\r\n###### symbol.icon\r\n\r\n```scm\r\n(class_body (method_definition\r\n  name: (property_identifier) @name\r\n  (#set! symbol.icon \"package\")\r\n))\r\n```\r\n\r\nThe icon to be shown alongside the symbol in a list. Will only be shown if the user has enabled the “Show Icons in Symbols View” option in the `symbols-view` settings. You can see the full list of available icons by invoking the **Styleguide: Show** command and browsing the “Icons” section. The value can include the preceding `icon-` or can omit it; e.g., `icon-package` and `package` are both valid values.\r\n\r\nIf this value is omitted, this provider will still attempt to match certain common tag values to icons. If `tag` is not present on the symbol, or is an uncommon value, there will be a blank space instead of an icon.\r\n",
+    "readme": "# symbol-provider-tree-sitter package\n\nProvides symbols to `symbols-view` via Tree-sitter queries.\n\nTree-sitter grammars [with tags queries](https://tree-sitter.github.io/tree-sitter/code-navigation-systems) can very easily give us a list of all the symbols in a file without the drawbacks of a `ctags`-based approach. For instance, they operate on the contents of the buffer, not the contents of the file on disk, so they work just fine in brand-new files and in files that have been modified since the last save.\n\nThis provider does not currently support project-wide symbol search, but possibly could do so in the future.\n\n## Tags queries\n\nThis provider expects for a grammar to have specified a tags query in its grammar definition file. All the built-in Tree-sitter grammars will have such a file. If you’re using a third-party Tree-sitter grammar that hasn’t defined one, file an issue on Pulsar and we’ll see what we can do.\n\nIf you’re writing your own grammar, or contributing a `tags.scm` to a grammar without one, keep reading.\n\n### Query syntax\n\nThe query syntax starts as a subset of what is described [on this page](https://tree-sitter.github.io/tree-sitter/code-navigation-systems). Here’s what this package can understand:\n\n* A query that consists of a `@definition.THING` capture with a `@name` capture inside will properly be understood as a symbol with a tag corresponding to `THING` and a name corresponding to the `@name` capture’s text.\n* A query that consists of a `@reference.THING` capture with a `@name` capture inside will be ignored by default. If the proper setting is enabled, each of these references will become a symbol with a tag corresponding to `THING` and a name corresponding to the `@name` capture’s text.\n* All other `@name` captures that are not within either a `@definition` or a `@reference` will be considered as a symbol in isolation. (These symbols can still specify a tag via a `#set!` predicate.)\n\nTo match the current behavior of the `symbols-view` package, you can usually take a `queries/tags.scm` file from a Tree-sitter repository — many parsers define them — and paste it straight into your grammar’s `tags.scm` file.\n\n#### Advanced features\n\nThe text of the captured node is what will be displayed as the symbol’s name, but a few predicates are available to alter that field and others. Symbol predicates use `#set!` and the `symbol` namespace.\n\n##### Node position descriptors\n\nSeveral predicates take a **node position descriptor** as an argument. It’s a string that resembles an object lookup chain in JavaScript:\n\n```scm\n(#set! symbol.prependTextForNode parent.parent.firstNamedChild)\n```\n\nStarting at the captured node, it describes a path to take within the tree in order to get to another meaningful node.\n\nIn all these examples, if the descriptor is invalid and does not return a node, the predicate will be ignored.\n\n##### Changing the symbol’s name\n\nThere are several ways to add text to the beginning or end of the symbol’s name:\n\n###### symbol.prepend\n\n```scm\n(class_declaration\n  name: (identifier) @name\n  (#set! symbol.prepend \"Class: \"))\n```\n\nThe `symbol.prepend` predicate adds a constant string to the beginning of a symbol name. For a class `Foo` in JavaScript, this predicate would result in a symbol called `Class: Foo`.\n\n###### symbol.append\n\n```scm\n(class_declaration\n  name: (identifier) @name\n  (#set! symbol.append \" (class)\"))\n```\n\nThe `symbol.append` predicate adds a constant string to the end of a symbol name. For a class `Foo`, this predicate would result in a symbol called `Foo (class)`.\n\n\n###### symbol.strip\n\n```scm\n(class_declaration\n  name: (identifier) @name\n  (#set! symbol.strip \"^\\\\s+|\\\\s+$\"))\n```\n\nThe `symbol.strip` predicate will replace everything matched by the regular expression with an empty string. The pattern given is compiled into a JavaScript `RegExp` with an implied `g` (global) flag.\n\nIn this example, _if_ the `identifier` node included whitespace on either side of the symbol, the symbol’s name would be stripped of that whitespace before being shown in the UI.\n\n###### symbol.prependTextForNode\n\n```scm\n(class_body (method_definition\n  name: (property_identifier) @name\n  (#set! symbol.prependTextForNode \"parent.parent.previousNamedSibling\")\n  (#set! symbol.joiner \"#\")\n))\n```\n\nThe `symbol.prependTextForNode` predicate will look up the text of the node referred to by the provided _node position descriptor_, then prepend that text to the symbol name. If `symbol.joiner` is provided, it will be inserted in between the two.\n\nIn this example, a `bar` method on a class named `Foo` would have a symbol name of `Foo#bar`.\n\n###### symbol.prependSymbolForNode\n\n```scm\n(class_body (method_definition\n  name: (property_identifier) @name\n  (#set! symbol.prependSymbolForNode \"parent.parent.previousNamedSibling\")\n  (#set! symbol.joiner \"#\")\n))\n```\n\nThe `symbol.prependSymbolForNode` predicate will look up the symbol name of the node referred to by the provided _node position descriptor_, then prepend that name to the symbol name. If `symbol.joiner` is provided, it will be inserted in between the two.\n\nUnlike `symbol.prependTextForNode`, the node referred to with the descriptor must have its own symbol name, and it must have been processed already — that is, it must be a symbol whose name was determined earlier than that of the current node.\n\nThis allows us to incorporate any transformations that were applied to the other node’s symbol name. We can use this to build “recursive” symbol names — for instance, JSON keys whose symbols consist of their entire key path from the root.\n\n##### Adding the `context` field\n\nThe `context` field of a symbol is a short piece of text meant to give context. For instance, a symbol that represents a class method could have a `context` field that contains the name of the class it belongs to. The `context` field is not filtered on.\n\n###### symbol.contextNode\n\n```scm\n(class_body (method_definition\n  name: (property_identifier) @name\n  (#set! symbol.contextNode \"parent.parent.previousNamedSibling\")\n))\n```\n\nThe `symbol.contextNode` predicate will set the value of a symbol’s `context` property to the text of a node based on the provided _node position descriptor_.\n\n###### symbol.context\n\n```scm\n(class_body (method_definition\n  name: (property_identifier) @name\n  (#set! symbol.context \"class\")\n))\n```\n\nThe `symbol.context` predicate will set the value of a symbol’s `context` property to a fixed string.\n\nThe point of `context` is to provide information to help you tell symbols apart, so you probably don’t want to set it to a fixed value. But this predicate is available just in case.\n\n##### Adding a tag\n\nThe `tag` field is a string that indicates a symbol’s kind or type. It should be a single word wherever possible. A `tag` for a class method’s symbol would typically be `method`, whereas the symbol for the class itself would typically have a `tag` of `class`. These tags will be indicated in the UI with a badge, an icon, or both.\n\nIf you’re not sure what to call something, consult [this list from the Language Server Protocol spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolKind). But some symbols may not fit any of those, so ultimately it’s up to the author. (For example, headings in Markdown files are assigned a kind of `heading`.)\n\nFor consistency, tags should be all lowercase. The interface will apply its own casing effect through CSS (`text-transform: capitalize` by default, but customizable in UI themes).\n\nThe preferred method of adding a tag is to leverage the `@definition.` captures that are typically present in a tags file. For instance, in this excerpt from the JavaScript grammar’s `tags.scm` file…\n\n```scm\n(assignment_expression\n  left: [\n    (identifier) @name\n    (member_expression\n      property: (property_identifier) @name)\n  ]\n  right: [(arrow_function) (function)]\n) @definition.function\n```\n\n…the resulting symbol will infer a `tag` value of `function`.\n\nIn cases where this is impractical, you can provide the tag explicitly with a predicate.\n\nNearly all the tags on [the aforementioned list](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolKind) will also apply an appropriate `icon` to their symbol when assigned. If you choose a tag name not on that list, or want to override the default, you can use the `symbol.icon` predicate described below.\n\n###### symbol.tag\n\n```scm\n(class_body (method_definition\n  name: (property_identifier) @name\n  (#set! symbol.tag \"class\")\n))\n```\n\nThe `symbol.tag` predicate will set the value of a symbol’s `tag` property to a fixed string.\n\nThe `tag` property is used to supply a word that represents the symbol in some way. For conventional symbols, this will often be something like `class` or `function`.\n\nThis provider will attempt to match certain common tag values to icons. This can be overridden by specifying an explicit `symbol.icon` value.\n\n###### symbol.icon\n\n```scm\n(class_body (method_definition\n  name: (property_identifier) @name\n  (#set! symbol.icon \"package\")\n))\n```\n\nThe icon to be shown alongside the symbol in a list. Will only be shown if the user has enabled the “Show Icons in Symbols View” option in the `symbols-view` settings. You can see the full list of available icons by invoking the **Styleguide: Show** command and browsing the “Icons” section. The value can include the preceding `icon-` or can omit it; e.g., `icon-package` and `package` are both valid values.\n\nIf this value is omitted, this provider will still attempt to match certain common tag values to icons. If `tag` is not present on the symbol, or is an uncommon value, there will be a blank space instead of an icon.\n",
     "metadata": {
       "name": "symbol-provider-tree-sitter",
       "main": "./lib/main",
@@ -2988,7 +3070,7 @@
     }
   },
   "symbols-view": {
-    "readme": "# symbols-view\r\n\r\nDisplay a list of symbols in the editor. Typically, a symbol will correspond to a meaningful part of a source code file (like a function definition) but can refer to other important parts of files depending on context.\r\n\r\n## Providers\r\n\r\n`symbols-view` uses a provider/subscriber model similar to that of `autocomplete-plus`. This package implements the UI, but it relies on other packages to suggest symbols.\r\n\r\n### Built-in providers\r\n\r\nThe original symbol provider, `ctags`, now lives in its own provider package called `symbol-provider-ctags`. Another package, `symbol-provider-tree-sitter`, is the preferred provider (by default) in buffers that use a Tree-sitter grammar.\r\n\r\n### Community package providers\r\n\r\nAny package can act as a symbol provider. [These are the packages on the Pulsar Package Repository that provide the `symbol.provider` service.](https://web.pulsar-edit.dev/packages?service=symbol.provider&serviceType=provided)\r\n\r\n## Commands\r\n\r\n|Command|Description|Keybinding (Linux/Windows)|Keybinding (macOS)|\r\n|-------|-----------|------------------|-----------------|\r\n|`symbols-view:toggle-file-symbols`|Show all symbols in current file|<kbd>ctrl-r</kbd>|<kbd>cmd-r</kbd>|\r\n|`symbols-view:toggle-project-symbols`|Show all symbols in the project|<kbd>ctrl-shift-r</kbd>|<kbd>cmd-shift-r</kbd>|\r\n|`symbols-view:go-to-declaration`|Jump to the symbol under the cursor|<kbd>ctrl-alt-down</kbd>|<kbd>cmd-alt-down</kbd>|\r\n|`symbols-view:return-from-declaration`|Return from the jump|<kbd>ctrl-alt-up</kbd>|<kbd>cmd-alt-up</kbd>|\r\n|`symbols-view:show-active-providers`|Display a list of all known symbol providers|||\r\n\r\nCommands relating to project-wide symbols may fail if no provider can satisfy a request for project-wide symbols. See `symbol-provider-ctags` for more information.\r\n",
+    "readme": "# symbols-view\n\nDisplay a list of symbols in the editor. Typically, a symbol will correspond to a meaningful part of a source code file (like a function definition) but can refer to other important parts of files depending on context.\n\n## Providers\n\n`symbols-view` uses a provider/subscriber model similar to that of `autocomplete-plus`. This package implements the UI, but it relies on other packages to suggest symbols.\n\n### Built-in providers\n\nThe original symbol provider, `ctags`, now lives in its own provider package called `symbol-provider-ctags`. Another package, `symbol-provider-tree-sitter`, is the preferred provider (by default) in buffers that use a Tree-sitter grammar.\n\n### Community package providers\n\nAny package can act as a symbol provider. [These are the packages on the Pulsar Package Repository that provide the `symbol.provider` service.](https://web.pulsar-edit.dev/packages?service=symbol.provider&serviceType=provided)\n\n## Commands\n\n|Command|Description|Keybinding (Linux/Windows)|Keybinding (macOS)|\n|-------|-----------|------------------|-----------------|\n|`symbols-view:toggle-file-symbols`|Show all symbols in current file|<kbd>ctrl-r</kbd>|<kbd>cmd-r</kbd>|\n|`symbols-view:toggle-project-symbols`|Show all symbols in the project|<kbd>ctrl-shift-r</kbd>|<kbd>cmd-shift-r</kbd>|\n|`symbols-view:go-to-declaration`|Jump to the symbol under the cursor|<kbd>ctrl-alt-down</kbd>|<kbd>cmd-alt-down</kbd>|\n|`symbols-view:return-from-declaration`|Return from the jump|<kbd>ctrl-alt-up</kbd>|<kbd>cmd-alt-up</kbd>|\n|`symbols-view:show-active-providers`|Display a list of all known symbol providers|||\n\nCommands relating to project-wide symbols may fail if no provider can satisfy a request for project-wide symbols. See `symbol-provider-ctags` for more information.\n",
     "metadata": {
       "name": "symbols-view",
       "version": "1.0.0",
@@ -3082,7 +3164,7 @@
     }
   },
   "tabs": {
-    "readme": "# Tabs package\r\n\r\nDisplay selectable tabs above the editor.\r\n\r\n![](https://cloud.githubusercontent.com/assets/18362/10862852/c6de2de0-800d-11e5-8158-284f30aaf5d2.png)\r\n\r\n## API\r\n\r\nTabs can display icons next to file names. These icons are customizable by installing a package that provides an `atom.file-icons` service.\r\n\r\nThe `atom.file-icons` service must provide the following methods:\r\n\r\n* `iconClassForPath(path)` - Returns a CSS class name to add to the tab view\r\n",
+    "readme": "# Tabs package\n\nDisplay selectable tabs above the editor.\n\n![](https://cloud.githubusercontent.com/assets/18362/10862852/c6de2de0-800d-11e5-8158-284f30aaf5d2.png)\n\n## API\n\nTabs can display icons next to file names. These icons are customizable by installing a package that provides an `atom.file-icons` service.\n\nThe `atom.file-icons` service must provide the following methods:\n\n* `iconClassForPath(path)` - Returns a CSS class name to add to the tab view\n",
     "metadata": {
       "name": "tabs",
       "version": "0.110.2",
@@ -3122,8 +3204,15 @@
           "description": "Show the tab bar even when only one tab is open."
         },
         "tabScrolling": {
-          "type": ["boolean", "string"],
-          "enum": [true, false, "platform"],
+          "type": [
+            "boolean",
+            "string"
+          ],
+          "enum": [
+            true,
+            false,
+            "platform"
+          ],
           "default": "platform",
           "description": "Jump to next or previous tab by scrolling on the tab bar."
         },
@@ -3159,7 +3248,7 @@
     }
   },
   "timecop": {
-    "readme": "# Timecop package\r\n\r\nDisplays information about where time is spent while Pulsar loads.\r\n\r\n  * Startup time\r\n  * Compile cache\r\n  * Package loading time\r\n  * Package activation time\r\n  * Theme loading time\r\n  * Theme activation time\r\n\r\n![](https://cloud.githubusercontent.com/assets/378023/20422582/9e5907f8-adae-11e6-8267-faa3514de896.png)\r\n\r\nInspired by [Timecop](http://www.imdb.com/title/tt0111438/) the movie. :watch: :rotating_light:\r\n",
+    "readme": "# Timecop package\n\nDisplays information about where time is spent while Pulsar loads.\n\n  * Startup time\n  * Compile cache\n  * Package loading time\n  * Package activation time\n  * Theme loading time\n  * Theme activation time\n\n![](https://cloud.githubusercontent.com/assets/378023/20422582/9e5907f8-adae-11e6-8267-faa3514de896.png)\n\nInspired by [Timecop](http://www.imdb.com/title/tt0111438/) the movie. :watch: :rotating_light:\n",
     "metadata": {
       "name": "timecop",
       "version": "0.36.2",
@@ -3181,7 +3270,7 @@
     }
   },
   "tree-view": {
-    "readme": "# Tree View package\r\n\r\nExplore and open files in the current project.\r\n\r\nPress <kbd>ctrl-\\\\</kbd> or <kbd>cmd-\\\\</kbd> to open/close the tree view and\r\n<kbd>alt-\\\\</kbd> or <kbd>ctrl-0</kbd> to focus it.\r\n\r\nWhen the tree view has focus you can press <kbd>a</kbd>, <kbd>shift-a</kbd>,\r\n<kbd>m</kbd>, or <kbd>delete</kbd> to add, move or delete files and folders.\r\n\r\nTo move the Tree view to the opposite side, select and drag the Tree view dock to the other side.\r\n\r\n![](https://f.cloud.github.com/assets/671378/2241932/6d9cface-9ceb-11e3-9026-31d5011d889d.png)\r\n\r\n## API\r\nThis package provides a service that you can use in other Pulsar packages.\r\nTo use it, include `tree-view` in the `consumedServices` section of your\r\n`package.json`:\r\n\r\n``` json\r\n{\r\n  \"name\": \"my-package\",\r\n  \"consumedServices\": {\r\n    \"tree-view\": {\r\n      \"versions\": {\r\n        \"^1.0.0\": \"consumeTreeView\"\r\n      }\r\n    }\r\n  }\r\n}\r\n```\r\n\r\nThen, in your package's main module, call methods on the service:\r\n\r\n``` coffee\r\nmodule.exports =\r\n  activate: -> # ...\r\n\r\n  consumeTreeView: (treeView) ->\r\n    selectedPaths = treeView.selectedPaths()\r\n    # Do something with the paths...\r\n```\r\n\r\nThe `tree-view` API has two methods:\r\n* `selectedPaths()` - Returns the paths to the selected tree view entries.\r\n* `entryForPath(entryPath)` - Returns a tree view entry for the given path.\r\n\r\n## Customization\r\nThe tree view displays icons next to files. These icons are customizable by\r\ninstalling a package that provides an `atom.file-icons` service.\r\n\r\nThe `atom.file-icons` service must provide the following methods:\r\n* `iconClassForPath(path)` - Returns a CSS class name to add to the file view.\r\n",
+    "readme": "# Tree View package\n\nExplore and open files in the current project.\n\nPress <kbd>ctrl-\\\\</kbd> or <kbd>cmd-\\\\</kbd> to open/close the tree view and\n<kbd>alt-\\\\</kbd> or <kbd>ctrl-0</kbd> to focus it.\n\nWhen the tree view has focus you can press <kbd>a</kbd>, <kbd>shift-a</kbd>,\n<kbd>m</kbd>, or <kbd>delete</kbd> to add, move or delete files and folders.\n\nTo move the Tree view to the opposite side, select and drag the Tree view dock to the other side.\n\n![](https://f.cloud.github.com/assets/671378/2241932/6d9cface-9ceb-11e3-9026-31d5011d889d.png)\n\n## API\nThis package provides a service that you can use in other Pulsar packages.\nTo use it, include `tree-view` in the `consumedServices` section of your\n`package.json`:\n\n``` json\n{\n  \"name\": \"my-package\",\n  \"consumedServices\": {\n    \"tree-view\": {\n      \"versions\": {\n        \"^1.0.0\": \"consumeTreeView\"\n      }\n    }\n  }\n}\n```\n\nThen, in your package's main module, call methods on the service:\n\n``` coffee\nmodule.exports =\n  activate: -> # ...\n\n  consumeTreeView: (treeView) ->\n    selectedPaths = treeView.selectedPaths()\n    # Do something with the paths...\n```\n\nThe `tree-view` API has two methods:\n* `selectedPaths()` - Returns the paths to the selected tree view entries.\n* `entryForPath(entryPath)` - Returns a tree view entry for the given path.\n\n## Customization\nThe tree view displays icons next to files. These icons are customizable by\ninstalling a package that provides an `atom.file-icons` service.\n\nThe `atom.file-icons` service must provide the following methods:\n* `iconClassForPath(path)` - Returns a CSS class name to add to the file view.\n",
     "metadata": {
       "name": "tree-view",
       "version": "0.229.1",
@@ -3190,13 +3279,13 @@
       "repository": "https://github.com/pulsar-edit/pulsar",
       "license": "MIT",
       "engines": {
-        "atom": "*"
+        "atom": "*",
+        "node": ">=14"
       },
       "private": true,
       "dependencies": {
         "fs-plus": "^3.0.0",
-        "minimatch": "~0.3.0",
-        "pathwatcher": "^8.1.0",
+        "minimatch": "~3.0.0",
         "temp": "~0.9.0",
         "underscore-plus": "^1.0.0"
       },
@@ -3270,7 +3359,7 @@
     }
   },
   "update-package-dependencies": {
-    "readme": "## Update Package Dependencies package\r\n\r\nRuns `puslar -p install` from the current project's directory. This will install all dependencies referenced in the `package.json` file to the `node_modules` folder.\r\n\r\nThis should only be used in projects that are Pulsar packages.\r\n",
+    "readme": "## Update Package Dependencies package\n\nRuns `puslar -p install` from the current project's directory. This will install all dependencies referenced in the `package.json` file to the `node_modules` folder.\n\nThis should only be used in projects that are Pulsar packages.\n",
     "metadata": {
       "name": "update-package-dependencies",
       "main": "./lib/update-package-dependencies",
@@ -3283,7 +3372,9 @@
         "atom": ">0.39.0"
       },
       "activationCommands": {
-        "atom-workspace": ["update-package-dependencies:update"]
+        "atom-workspace": [
+          "update-package-dependencies:update"
+        ]
       },
       "consumedServices": {
         "status-bar": {
@@ -3296,7 +3387,7 @@
     }
   },
   "welcome": {
-    "readme": "## Welcome package\r\n\r\nOpens a welcome editor with helpful information the very first time Pulsar is\r\nopened.\r\n",
+    "readme": "## Welcome package\n\nOpens a welcome editor with helpful information the very first time Pulsar is\nopened.\n",
     "metadata": {
       "name": "welcome",
       "version": "0.36.9",
@@ -3342,7 +3433,7 @@
     }
   },
   "whitespace": {
-    "readme": "# Whitespace package\r\n\r\nStrips trailing whitespace and adds a trailing newline when an editor is saved.\r\n\r\nTo disable/enable features for a certain language package, you can use syntax-scoped properties in your `config.cson`. E.g.\r\n\r\n```coffee\r\n'.slim.text':\r\n  whitespace:\r\n    removeTrailingWhitespace: false\r\n```\r\n\r\nYou find the `scope` on top of a grammar package's settings view.\r\n\r\nNote: for `.source.jade`, `.source.diff`, `.source.pug` and `.source.patch`, removing trailing whitespace is disabled by default.\r\n",
+    "readme": "# Whitespace package\n\nStrips trailing whitespace and adds a trailing newline when an editor is saved.\n\nTo disable/enable features for a certain language package, you can use syntax-scoped properties in your `config.cson`. E.g.\n\n```coffee\n'.slim.text':\n  whitespace:\n    removeTrailingWhitespace: false\n```\n\nYou find the `scope` on top of a grammar package's settings view.\n\nNote: for `.source.jade`, `.source.diff`, `.source.pug` and `.source.patch`, removing trailing whitespace is disabled by default.\n",
     "metadata": {
       "name": "whitespace",
       "version": "0.37.8",
@@ -3354,8 +3445,8 @@
         "atom": "*"
       },
       "devDependencies": {
-        "fs-plus": "2.x",
-        "temp": "~0.8.1"
+        "fs-plus": "3.x",
+        "temp": "~0.9.0"
       },
       "configSchema": {
         "removeTrailingWhitespace": {
@@ -3401,7 +3492,7 @@
     }
   },
   "wrap-guide": {
-    "readme": "# Wrap Guide package\r\n\r\nThe `wrap-guide` package places a vertical line in each editor at a certain column to guide your formatting, so lines do not exceed a certain width.\r\n\r\nBy default, the wrap-guide is placed at the value of `editor.preferredLineLength` config setting. The 80th column is used as the fallback if the config value is unset.\r\n\r\n![](https://f.cloud.github.com/assets/671378/2241976/dbf6a8f6-9ced-11e3-8fef-d8a226301530.png)\r\n\r\n## Configuration\r\n\r\nYou can customize where the column is placed for different file types by opening the Settings View and configuring the \"Preferred Line Length\" value. If you do not want the guide to show for a particular language, that can be set using scoped configuration. For example, to turn off the guide for GitHub-Flavored Markdown, you can add the following to your `config.cson`:\r\n\r\n```coffeescript\r\n'.source.gfm':\r\n  'wrap-guide':\r\n    'enabled': false\r\n```\r\n\r\nIt is possible to configure the color and/or width of the line by adding the following CSS/LESS to your `styles.less`:\r\n\r\n```css\r\natom-text-editor .wrap-guide {\r\n  width: 10px;\r\n  background-color: red;\r\n}\r\n```\r\n\r\nMultiple guide lines are also supported. For example, add the following to your `config.cson` to create four columns at the indicated positions:\r\n\r\n```coffeescript\r\n'wrap-guide':\r\n  'columns': [72, 80, 100, 120]\r\n```\r\n\r\n> Note: When using multiple guide lines, the right-most guide line functions as your `editor.preferredLineLength` setting.\r\n",
+    "readme": "# Wrap Guide package\n\nThe `wrap-guide` package places a vertical line in each editor at a certain column to guide your formatting, so lines do not exceed a certain width.\n\nBy default, the wrap-guide is placed at the value of `editor.preferredLineLength` config setting. The 80th column is used as the fallback if the config value is unset.\n\n![](https://f.cloud.github.com/assets/671378/2241976/dbf6a8f6-9ced-11e3-8fef-d8a226301530.png)\n\n## Configuration\n\nYou can customize where the column is placed for different file types by opening the Settings View and configuring the \"Preferred Line Length\" value. If you do not want the guide to show for a particular language, that can be set using scoped configuration. For example, to turn off the guide for GitHub-Flavored Markdown, you can add the following to your `config.cson`:\n\n```coffeescript\n'.source.gfm':\n  'wrap-guide':\n    'enabled': false\n```\n\nIt is possible to configure the color and/or width of the line by adding the following CSS/LESS to your `styles.less`:\n\n```css\natom-text-editor .wrap-guide {\n  width: 10px;\n  background-color: red;\n}\n```\n\nMultiple guide lines are also supported. For example, add the following to your `config.cson` to create four columns at the indicated positions:\n\n```coffeescript\n'wrap-guide':\n  'columns': [72, 80, 100, 120]\n```\n\n> Note: When using multiple guide lines, the right-most guide line functions as your `editor.preferredLineLength` setting.\n",
     "metadata": {
       "name": "wrap-guide",
       "version": "0.41.1",
@@ -3453,7 +3544,7 @@
     }
   },
   "github": {
-    "readme": "# Pulsar GitHub Package\r\n\r\nThe Pulsar GitHub package provides Git and GitHub integration for Pulsar.\r\n\r\n<img width=\"880\" alt=\"GitHub for Pulsar\" src=\"https://user-images.githubusercontent.com/378023/49062969-2e717a00-f259-11e8-8207-2ecbc6981cd6.png\">\r\n\r\n<img width=\"880\" alt=\"git-integration\" src=\"https://user-images.githubusercontent.com/378023/49062970-2f0a1080-f259-11e8-91e9-9402ec76cd66.png\">\r\n\r\n<img width=\"880\" alt=\"pull request view\" src=\"https://user-images.githubusercontent.com/6842965/55753896-7aa7a480-5a19-11e9-8540-a932a746fc29.png\">\r\n\r\n<img width=\"880\" alt=\"in-editor pull request comments\" src=\"https://user-images.githubusercontent.com/6842965/55753909-81ceb280-5a19-11e9-9762-2716b5e0f09f.png\">\r\n\r\n## Installation\r\n\r\nThis package is bundled with Pulsar starting in version 1.18, and does not need to be installed separately.\r\n\r\n## License\r\n\r\nThe MIT license grant is not for GitHub's trademarks, which include the logo designs. GitHub reserves all trademark and copyright rights in and to all GitHub trademarks.\r\n\r\nGitHub® and its stylized versions and the Invertocat mark are GitHub's Trademarks or registered Trademarks. When using GitHub's logos, be sure to follow the GitHub [logo guidelines](https://github.com/logos).\r\n",
+    "readme": "# Pulsar GitHub Package\n\nThe Pulsar GitHub package provides Git and GitHub integration for Pulsar.\n\n<img width=\"880\" alt=\"GitHub for Pulsar\" src=\"https://user-images.githubusercontent.com/378023/49062969-2e717a00-f259-11e8-8207-2ecbc6981cd6.png\">\n\n<img width=\"880\" alt=\"git-integration\" src=\"https://user-images.githubusercontent.com/378023/49062970-2f0a1080-f259-11e8-91e9-9402ec76cd66.png\">\n\n<img width=\"880\" alt=\"pull request view\" src=\"https://user-images.githubusercontent.com/6842965/55753896-7aa7a480-5a19-11e9-8540-a932a746fc29.png\">\n\n<img width=\"880\" alt=\"in-editor pull request comments\" src=\"https://user-images.githubusercontent.com/6842965/55753909-81ceb280-5a19-11e9-9762-2716b5e0f09f.png\">\n\n## Installation\n\nThis package is bundled with Pulsar starting in version 1.18, and does not need to be installed separately.\n\n## License\n\nThe MIT license grant is not for GitHub's trademarks, which include the logo designs. GitHub reserves all trademark and copyright rights in and to all GitHub trademarks.\n\nGitHub® and its stylized versions and the Invertocat mark are GitHub's Trademarks or registered Trademarks. When using GitHub's logos, be sure to follow the GitHub [logo guidelines](https://github.com/logos).\n",
     "metadata": {
       "name": "github",
       "main": "./lib/index",
@@ -3503,6 +3594,8 @@
         "@babel/plugin-proposal-object-rest-spread": "7.8.0",
         "@babel/preset-env": "7.12.1",
         "@babel/preset-react": "7.8.0",
+        "@pulsar-edit/whats-my-line": "0.3.0",
+        "@electron/remote": "^2.1.0",
         "babel-plugin-relay": "5.0.0",
         "bintrees": "1.0.2",
         "bytes": "3.1.0",
@@ -3513,7 +3606,7 @@
         "event-kit": "2.5.3",
         "fs-extra": "4.0.3",
         "graphql": "14.5.8",
-        "keytar": "4.13.0",
+        "keytar": "^7.9.0",
         "lodash.memoize": "4.1.2",
         "marked": "0.8.0",
         "moment": "2.28.0",
@@ -3531,7 +3624,6 @@
         "underscore-plus": "1.7.0",
         "what-the-diff": "0.6.0",
         "what-the-status": "1.0.3",
-        "whats-my-line": "https://github.com/pulsar-edit/whats-my-line/archive/4029ca9567a0bf0f12843890461fb13e758cfcbf.tar.gz",
         "yubikiri": "2.0.0"
       },
       "devDependencies": {
@@ -3547,7 +3639,6 @@
         "enzyme": "3.10.0",
         "enzyme-adapter-react-16": "1.7.1",
         "eslint": "6.8.0",
-        "eslint-config-fbjs-opensource": "1.0.0",
         "eslint-plugin-jsx-a11y": "6.2.3",
         "globby": "10.0.1",
         "hock": "1.4.1",
@@ -3586,7 +3677,11 @@
         "viewChangesForCurrentFileDiffPaneSplitDirection": {
           "type": "string",
           "default": "none",
-          "enum": ["none", "right", "down"],
+          "enum": [
+            "none",
+            "right",
+            "down"
+          ],
           "title": "Direction to open diff pane",
           "description": "Direction to split the active pane when showing diff associated with open file. If 'none', the results will be shown in the active pane."
         },
@@ -3602,7 +3697,9 @@
         },
         "performanceMask": {
           "type": "array",
-          "default": [".*"],
+          "default": [
+            ".*"
+          ],
           "items": {
             "type": "string"
           },
@@ -3656,7 +3753,10 @@
         "remoteFetchProtocol": {
           "type": "string",
           "default": "https",
-          "enum": ["https", "ssh"],
+          "enum": [
+            "https",
+            "ssh"
+          ],
           "description": "Transport protocol to prefer when creating a new git remote"
         }
       },
@@ -3672,7 +3772,90 @@
         "ReviewsStub": "createReviewsStub"
       },
       "greenkeeper": {
-        "ignore": ["electron-link", "electron-mksnapshot"]
+        "ignore": [
+          "electron-link",
+          "electron-mksnapshot"
+        ]
+      }
+    }
+  },
+  "terminal": {
+    "readme": "# terminal\n\nTerminal emulation in Pulsar.\n\n![screenshot of terminal package](https://raw.githubusercontent.com/pulsar-edit/terminal/main/images/terminal-package-screenshot.png)\n\nUses [XTerm](https://xtermjs.org/) and [`node-pty`](https://github.com/microsoft/node-pty).\n\nBased heavily on [`atomic-terminal`](https://github.com/atom-community/terminal), [`x-terminal-reloaded`](https://github.com/Spiker985/x-terminal-reloaded), and all their predecessors.\n\n## Commands\n\nThe simplest command is bound to <kbd>Ctrl-\\`</kbd> on all platforms: `terminal:focus`. This command will focus the last active terminal (if one exists), or else create a new terminal.\n\n> [!NOTE]\n> When focus is in a terminal, the terminal itself may handle some keystrokes _instead of_ Pulsar. If you notice that some of your keybindings don’t work inside the terminal, press <kbd>Ctrl-\\`</kbd> while the terminal is focused in order to _unfocus_ the terminal; at that point you’ll be able to press any key sequence and have it be interpreted by Pulsar instead of your terminal.\n\nMost of the package’s keybindings rely on a [key sequence](https://docs.pulsar-edit.dev/using-pulsar/basics/#key-sequence): first press the main shortcut (<kbd>Ctrl-~</kbd> on all platforms), then press a second key.\n\nIf you want to make any of these commands available via a simpler keybinding, you can [customize your keybindings](https://docs.pulsar-edit.dev/customizing-pulsar/customizing-keybindings/).\n\n### Workspace keybindings\n\n> [!NOTE]\n> In US QWERTY layouts, <kbd>\\`</kbd> and <kbd>\\~</kbd> are assigned to the key above <kbd>Tab</kbd>. Hence <kbd>Ctrl-\\~</kbd> in the table below can be read as <kbd>Ctrl-Shift-\\`</kbd> for US QWERTY users.\n>\n> In other locales with other keyboard layouts, however, these symbols will rarely share a key. If you’ve got such a layout, you can [rebind these commands](https://docs.pulsar-edit.dev/customizing-pulsar/customizing-keybindings/) to match the symbols assigned to the key above <kbd>Tab</kbd>.\n>\n> In time, we hope to make this unnecessary by making it possible for keymaps to bind directly to certain keyboard keys in layout-independent fashion.\n\n|Command|Description|Keybinding (Linux/Windows)|Keybinding (macOS)|\n|-------|-----------|------------------|-----------------|\n|`terminal:focus`|Focus the active terminal, or create one if needed|<kbd>Ctrl-\\`</kbd>|<kbd>Ctrl-\\`</kbd>|\n|`terminal:open`|Create a new terminal in the default location|<kbd>Ctrl-~</kbd> <kbd>N</kbd>|<kbd>Ctrl-~</kbd> <kbd>N</kbd>|\n|`terminal:open-left-dock`|Create a new terminal in the left dock|<kbd>Ctrl-~</kbd> <kbd>L</kbd>|<kbd>Ctrl-~</kbd> <kbd>L</kbd>|\n|`terminal:open-right-dock`|Create a new terminal in the right dock|<kbd>Ctrl-~</kbd> <kbd>R</kbd>|<kbd>Ctrl-~</kbd> <kbd>R</kbd>|\n|`terminal:open-bottom-dock`|Create a new terminal in the bottom dock|<kbd>Ctrl-~</kbd> <kbd>B</kbd>|<kbd>Ctrl-~</kbd> <kbd>B</kbd>|\n|`terminal:open-split-up`|Create a new terminal by splitting the current pane container upward|<kbd>Ctrl-~</kbd> <kbd>Up</kbd>|<kbd>Ctrl-~</kbd> <kbd>Up</kbd>|\n|`terminal:open-split-down`|Create a new terminal by splitting the current pane container downward|<kbd>Ctrl-~</kbd> <kbd>Down</kbd>|<kbd>Ctrl-~</kbd> <kbd>Down</kbd>|\n|`terminal:open-split-left`|Create a new terminal by splitting the current pane container leftward|<kbd>Ctrl-~</kbd> <kbd>Left</kbd>|<kbd>Ctrl-~</kbd> <kbd>Left</kbd>|\n|`terminal:open-split-right`|Create a new terminal by splitting the current pane container rightward|<kbd>Ctrl-~</kbd> <kbd>Right</kbd>|<kbd>Ctrl-~</kbd> <kbd>Right</kbd>|\n|`terminal:run-selected-text`|Run the selected text in the active terminal|<kbd>Ctrl-~</kbd> <kbd>X</kbd>|<kbd>Ctrl-~</kbd> <kbd>X</kbd>|\n|`terminal:insert-selected-text`|Insert the selected text into the active terminal|<kbd>Ctrl-~</kbd> <kbd>I</kbd>|<kbd>Ctrl-~</kbd> <kbd>I</kbd>|\n\n### Terminal keybindings\n\nThese commands and key bindings can be used when the terminal has focus.\n\n|Command|Description|Keybinding (Linux/Windows)|Keybinding (macOS)|\n|-------|-----------|------------------|-----------------|\n|`terminal:clear`|Clear the screen|<kbd>Ctrl-L</kbd>|<kbd>Ctrl-L</kbd> or <kbd>Cmd-alt-K</kbd>|\n|`terminal:find`|Open the find palette|<kbd>Ctrl-F</kbd>|<kbd>Cmd-F</kbd>|\n|`terminal:find-next`|Jump to the next match in the find palette|<kbd>F3</kbd>|<kbd>Cmd-G</kbd>|\n|`terminal:find-previous`|Jump to the previous match in the find palette|<kbd>Shift-F3</kbd>|<kbd>Cmd-Shift-G</kbd>|\n|`terminal:set-selection-as-find-pattern`|Use the selected terminal text as the search term in the find palette|<kbd>Ctrl-E</kbd>|<kbd>Cmd-E</kbd>|\n|`terminal:unfocus`|Unfocus the terminal, moving focus to the terminal’s pane container|<kbd>Ctrl-\\`</kbd> |<kbd>Ctrl-\\`</kbd>|\n\n## Theming\n\nThe colors and fonts used by the terminal can be customized. By default, your terminal will try to reuse many aspects of your editor’s theme, but you can change this behavior.\n\nThis package supports multiple approaches to theming:\n\n### Stylesheet variables\n\nThe ideal way to theme your terminal is via stylesheet variables, since this makes it possible for syntax themes to use terminal colors that harmonize with your editor theme.\n\nIf you use one of the eight built-in syntax themes, your terminal will **automatically** be styled to look like your editor, including theme-appropriate versions of the standard ANSI colors.\n\nIf you use a custom syntax theme that doesn’t define these variables, you can use the default fallbacks or define your own colors in your user stylesheet.\n\nYour theme can define terminal colors via [Less](https://lesscss.org/) variables like `@terminal-text-color`, `@terminal-background-color`, and so on. These values have defaults derived from similar color values in your theme, but any theme can customize them.\n\nIf you, as a user, want to tweak those values, you should not try to redefine (e.g.) `@terminal-text-color` in your user stylesheet. That won’t have the effect you want — the user stylesheet is purposefully evaluated last, so it won’t be able to change a value that another stylesheet uses.\n\nInstead, you can redefine the CSS custom property of the same name. Those custom properties are treated as the source of truth.\n\nThese are the default values as defined in `terminal-variables.less`:\n\n```less\n// This gives you access to Less variables from your syntax theme.\n@import \"syntax-variables\";\n\n// We use CSS custom properties as the source of truth instead of Less\n// variables — because CSS properties are late-binding and can more easily be\n// overridden via your stylesheet. But you can still use Less variables as the\n// values!\n//\n// For simplicity, this example CSS omits the intermediate step where\n// the value is assigned to a Less variable of the same name. For instance,\n// `--terminal-text-color` is actually assigned to `@terminal-text-color` —\n// which itself defaults to `@syntax-text-color` unless your theme specifies\n// otherwise.\n:root {\n  // The first block of variables below will by default use equivalent values\n  // from your syntax theme. You can still customize these, though, if you don't\n  // like the defaults.\n  // The ordinary text color of the terminal.\n  --terminal-text-color: @syntax-text-color;\n  // The background color of the terminal.\n  --terminal-background-color: @syntax-background-color;\n  // The background color of a selected text block.\n  --terminal-selection-background-color: @syntax-selection-color;\n  // The text color of selected text.\n  --terminal-selection-text-color: @syntax-text-color;\n  // The color of the cursor.\n  --terminal-cursor-color: @syntax-cursor-color;\n  // The color of the outline around a “find” result when it is inactive.\n  --terminal-result-marker-color: @syntax-result-marker-color;\n  // The color of the outline around a “find” result when it is active.\n  --terminal-result-marker-color-selected: @syntax-result-marker-color-selected;\n\n  // ANSI colors in regular and “bright” variants. If you use a built-in theme,\n  // these will be replaced with theme-appropriate color values! Otherwise, the\n  // values below will be used — but you can manually change them to match the\n  // colors of your custom syntax theme, if you like.\n  --terminal-color-black: #2e3436;\n  --terminal-color-red: #cc0000;\n  --terminal-color-green: #4e9a06;\n  --terminal-color-yellow: #c4a000;\n  --terminal-color-blue: #3465a4;\n  --terminal-color-magenta: #75507b;\n  --terminal-color-cyan: #06989a;\n  --terminal-color-white: #d3d7cf;\n  --terminal-color-bright-black: #555753;\n  --terminal-color-bright-red: #ef2929;\n  --terminal-color-bright-green: #8ae234;\n  --terminal-color-bright-yellow: #fce94f;\n  --terminal-color-bright-blue: #729fcf;\n  --terminal-color-bright-magenta: #ad7fa8;\n  --terminal-color-bright-cyan: #34e2e2;\n  --terminal-color-bright-white: #eeeeec;\n}\n```\n\nThis is an exhaustive list of what can be customized, but it’s more likely you’ll want to customize just a few values. For instance, if all you want to do is change the “bright cyan” color value, you can edit your `styles.less` like so:\n\n```less\n@import \"syntax-variables\";\n:root {\n  // Make your \"bright cyan\" match your ordinary editor text color.\n  // The Less `color` function is used here to ensure the value is set in a\n  // format that XTerm.js understands.\n  --terminal-color-bright-cyan: color(@syntax-text-color);\n}\n```\n\nYou could also hard-code a hex or `rgba` value, or use one of Less’s [color manipulation functions](https://lesscss.org/functions/#color-definition).\n\n### Configuration\n\nIf you prefer, you can eschew the stylesheet approach and define your terminal theme colors explicitly via configuration. The collapsed **Custom Theme Colors** section in the package settings lets you customize each individual color.\n\nBe sure to switch the **Color Theme** setting to **Config** in order for these colors to be used.\n\n> [!TIP]\n> As stated in the package settings, all color values support transparency and can accept `rgba()` CSS literal values, even though the color picker in the `settings-view` UI [doesn’t (yet) let you specify an alpha channel](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/color#html.elements.input.alpha).\n>\n> To add an alpha channel to any color value, first customize it in the `settings-view` UI (so that the appropriate key is placed in your `config.cson`); then [edit your `config.cson`](https://docs.pulsar-edit.dev/customizing-pulsar/global-configuration-settings/) and drill down from the top-level `terminal:key` to find the value you just customized. Change it to the value you want, then save your `config.cson`.\n\n### Legacy themes\n\nAll other values in the **Color Theme** list are specific terminal themes with hard-coded values. These themes are included because they were present in this package’s predecessors (`x-terminal`, etc.), but they are not comprehensive; most only define foreground and background text colors and otherwise will fall back onto colors specified in the **Custom Theme Colors** section.\n\n## Services\n\n### `terminal` (version 2.0.0)\n\nThis package defines a `terminal` service that is a streamlined version of the `terminal` version `1.0.0` service provided by `x-terminal` and `atomic-terminal`, among others.\n\nRather than serve as a direct copy of the `platformioIDETerminal` service described below, it aims to discard unneeded methods. It uses version `2.0.0` to signify a break in backward compatibility.\n\nIt may add methods in the future, but for now it provides an object with a few simple methods:\n\n#### `open(): Promise<void>`\n\nOpens a new terminal. The user’s configuration determines where that terminal opens in the workspace.\n\nReturns a promise that fulfills once the terminal is created and ready for input.\n\n#### `run(commands: string[]): Promise<boolean>`\n\nRuns the given command or commands in the active terminal. The “active” terminal is whichever one was most recently used. If no terminal is present, one will be created.\n\nBy default, the user will be shown the whole list of commands before the terminal spawns, and will be able to approve or reject the request to run the commands.\n\nAlso keep in mind that the consuming package isn’t allowed to inspect the output directly. In other words, this method is not a substitute for `child_process.spawn` in the Node standard library.\n\nReturns a promise that resolves to a boolean: `true` if the commands actually ran, and `false` if they did not.\n\n### `platformioIDETerminal` (version 1.1.0)\n\nThis service is supported for the sake of compatibility, since it’s arguably the most widely used terminal service. As the name implies, this service was originally created by the `platformio-ide-terminal` package.\n\nThe `platformioIDETerminal` service supports the `open` and `run` methods defined above, plus:\n\n#### `getTerminalViews(): TerminalModel`\n\nReturns each terminal view currently open in the workspace. Each terminal view is an instance of `TerminalModel` — but it functions like a _view_ model, and implements the [pane item interface](https://github.com/pulsar-edit/types/blob/0099e6b3004de4f94fcdee04b2d86f2910e3abfb/src/pane.d.ts#L88).\n\nBeware, though; this package makes no claim that these instances will share any properties or methods with whatever was returned by `platform-ide-terminal` for this method.\n\n#### `updateProcessEnv()`\n\nThis method is provided so that this package technically conforms to the `platformioIDETerminal` service contract, but it does nothing. (It’s not clear that its original implementation ever did anything useful that couldn’t have been done by setting `process.env` directly.)\n",
+    "metadata": {
+      "name": "terminal",
+      "main": "./lib/terminal",
+      "version": "0.3.2",
+      "description": "A terminal emulator built into Pulsar",
+      "keywords": [
+        "terminal",
+        "term",
+        "xterm",
+        "shell",
+        "tty",
+        "pty",
+        "bash",
+        "sh",
+        "powershell",
+        "cmd"
+      ],
+      "scripts": {
+        "build": "rollup -c rollup.config.mjs",
+        "watch": "rollup --watch -c rollup.config.mjs",
+        "prepare": "npm run build",
+        "prepublishOnly": "npm run build"
+      },
+      "repository": "https://github.com/pulsar-edit/terminal",
+      "license": "MIT",
+      "engines": {
+        "atom": ">=1.132.0 <2.0.0"
+      },
+      "activationHooks": [
+        "core:loaded-shell-environment"
+      ],
+      "deserializers": {
+        "TerminalModel": "deserializeTerminalModel"
+      },
+      "dependencies": {
+        "@electron/remote": "^2.1.2",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-ligatures": "^0.10.0",
+        "@xterm/addon-search": "^0.16.0",
+        "@xterm/addon-web-links": "^0.12.0",
+        "@xterm/addon-webgl": "^0.19.0",
+        "@xterm/xterm": "^6.0.0",
+        "etch": "^0.14.1",
+        "fs-extra": "^11.3.2",
+        "ndjson": "^2.0.0",
+        "node-pty": "npm:@pulsar-edit/node-pty@1.0.0-beta34-pulsar",
+        "tslib": "^2.8.1",
+        "which": "^5.0.0"
+      },
+      "devDependencies": {
+        "@rollup/plugin-commonjs": "^28.0.3",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.1",
+        "@rollup/plugin-typescript": "^12.1.2",
+        "@types/atom": "npm:@pulsar-edit/types@^1.128.1",
+        "@types/fs-extra": "^11.0.4",
+        "@types/ndjson": "^2.0.4",
+        "@types/which": "^3.0.4",
+        "rollup": "^4.40.0",
+        "temp": "^0.9.4",
+        "typescript": "^5.8.3"
+      },
+      "providedServices": {
+        "platformioIDETerminal": {
+          "description": "Run commands and open terminals.",
+          "versions": {
+            "1.1.0": "providePlatformioIDETerminalService"
+          }
+        },
+        "terminal": {
+          "description": "Run commands and open terminals.",
+          "versions": {
+            "2.0.0": "provideTerminalService"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [x] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

This updates the metadata we keep for bundled packages. In [this discussion](https://github.com/pulsar-edit/documentation/pull/53#discussion_r3230945588), we wondered aloud how to get the package registry to recognize that `terminal` was a built-in package, so I poked around a bit and found this!

I see that `update-bundled.js` has hard-coded the `github` repo since it's a core package that lives in its own repository. That also describes `terminal`, so I added another entry for `terminal` in the list. Then I ran `npm run tool:update-bundled` and committed the resulting JSON.

---

@confused-Techie, maybe give this a quick scan? Shouldn't take long to verify. Thanks!