### PR TITLE
Stop modifying `updated` field on package download

### DIFF
--- a/docs/reference/Admin_Actions.md
+++ b/docs/reference/Admin_Actions.md
@@ -4,6 +4,29 @@ When you consider that most backend services are a black box of code and decisio
 
 With that said this document will serve as the ongoing history of administrative actions that must be taken against the backend.
 
+## 2026 - May 31
+
+In the PR [`pulsar-edit/package-backend#307`](https://github.com/pulsar-edit/package-backend/pull/307)
+we fixed a long standing oversight, which could cause a package's `updated` time to be inaccurate.
+Where it may reflect the last time a user had downloaded the package, rather than the last time
+the author of the package actually updated it.
+
+This PR resolves this issue, and in it's wake a migration script was run on the backend to correct
+this date across all packages.
+
+The results of this migration script are below:
+- 11,327 Pointers handled
+- 10,421 Successes
+- 550 Deleted packages skipped
+- 356 Failures
+  - 354 Failures to determine the latest version
+  - 2 Failures to collect package version data
+
+Of the reported failures those will all have to be handled by hand to resolve.
+Of the reported successes, all this changes is to more accurately reflect the last time the
+author made any changes in the package, helping to ensure users of Pulsar can be more
+confident in finding and installing more recently maintained packages.
+
 ## 2025 - October 20
 
 While running some scripts to determine what community packages may struggle with the upcoming PulsarNext upgrade, we were able to automatically identify many package's whose associated GitHub repository has been deleted.

--- a/scripts/migrations/0002-replace-function.sql
+++ b/scripts/migrations/0002-replace-function.sql
@@ -1,6 +1,12 @@
 CREATE OR REPLACE FUNCTION now_on_updated_package()
 RETURNS TRIGGER AS $$
 BEGIN
+  IF TG_TABLE_NAME = 'versions' THEN
+    -- Since this function is also triggerred on the version table changes
+    -- and the version table does not contain a downloads column, we exclude
+    -- the check when operating on the versions table.
+    RETURN NEW;
+  END IF;
   IF (OLD.downloads = NEW.downloads) THEN
     -- Only change the updated column when the update is not triggerred
     -- by changing the download count.

--- a/scripts/migrations/0002-replace-function.sql
+++ b/scripts/migrations/0002-replace-function.sql
@@ -1,19 +1,13 @@
-CREATE OR REPLACE FUNCTION now_on_updated_package()
-RETURNS TRIGGER AS $$
-BEGIN
-  IF TG_TABLE_NAME = 'versions' THEN
-    -- Since this function is also triggerred on the version table changes
-    -- and the version table does not contain a downloads column, we exclude
-    -- the check when operating on the versions table.
-    RETURN NEW;
-  END IF;
-  IF (OLD.downloads = NEW.downloads) THEN
-    -- Only change the updated column when the update is not triggerred
-    -- by changing the download count.
-    NEW.updated = NOW();
-    RETURN NEW;
-  ELSE
-    RETURN NEW;
-  END IF;
-END;
-$$ language 'plpgsql';
+-- Replace the function that triggers modification of the updated column
+-- on packages, to only respond to changes made by package authors.
+CREATE OR REPLACE TRIGGER trigger_now_on_updated
+  BEFORE UPDATE
+  OF name, owner, data
+  ON packages
+  FOR EACH ROW
+EXECUTE PROCEDURE now_on_updated_package();
+
+-- Remove Version update trigger
+DROP TRIGGER IF EXISTS trigger_now_on_updated_versions ON versions;
+-- There is no package manager accessible way to update a deployed version.
+-- So we shouldn't need to account for this at this time.

--- a/scripts/migrations/0002-replace-function.sql
+++ b/scripts/migrations/0002-replace-function.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION now_on_updated_package()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF (OLD.downloads = NEW.downloads) THEN
+    -- Only change the updated column when the update is not triggerred
+    -- by changing the download count.
+    NEW.updated = NOW();
+    RETURN NEW;
+  ELSE
+    RETURN NEW;
+  END IF;
+END;
+$$ language 'plpgsql';

--- a/scripts/tools/.gitignore
+++ b/scripts/tools/.gitignore
@@ -1,3 +1,4 @@
 features_found.json
 archived_packages.json
 broken_packages.json
+fix-updated-column.results.json

--- a/scripts/tools/fix-updated-column.js
+++ b/scripts/tools/fix-updated-column.js
@@ -55,7 +55,7 @@ async function init(params) {
         continue;
       }
 
-      let latestVer = pack.content?.metadata?.version;
+      let latestVer = pack.content?.data?.metadata?.version;
 
       if (typeof latestVer !== "string") {
         results.push(`Failed to determine latest version for ${referenceStr}`);
@@ -73,7 +73,7 @@ async function init(params) {
       let verCreation = verData.content?.created;
       let originalCreation = pack.content?.updated;
 
-      if (typeof verCreation !== "string") {
+      if (!(verCreation instanceof Date)) {
         results.push(`Failed to collect created date of ${referenceStr} for version: '${latestVer}'`);
         continue;
       }

--- a/scripts/tools/fix-updated-column.js
+++ b/scripts/tools/fix-updated-column.js
@@ -1,0 +1,200 @@
+/**
+  This tool should only ever have to be run once, that is exactly after PR
+  https://github.com/pulsar-edit/package-backend/pull/307 is merged.
+
+  This PR fixes the behavior that would incorrectly modify the `updated` column
+  of all packages whenever any data about them has been modified. including
+  columns such as `downloads`, `stargazers_count`, etc.
+
+  So this tool will iterate all existing packages, and change the `updated` column
+  of the package to reflect that of the packages latest versions `creation` timestamp.
+*/
+
+const fs = require("fs");
+const postgres = require("postgres");
+const { DB_HOST, DB_USER, DB_PASS, DB_DB, DB_PORT, DB_SSL_CERT } =
+  require("../../src/config.js").getConfig();
+
+let sqlStorage;
+
+async function init(params) {
+  sqlStorage ??= setupSQL();
+
+  const allPointers = await getPointers();
+  const totalPointers = allPointers.length;
+  let pointerIdx = 0;
+  let results = [];
+
+  for await (const pointer of allPointers) {
+    const referenceStr = `'${pointer.name}::${pointer.pointer}'`;
+
+    try {
+      console.log(`Checking: ${referenceStr}`);
+      console.log(`\r[${pointerIdx}/${totalPointers}] Packages Checked...`);
+      pointerIdx++;
+
+      if (typeof pointer.name !== "string" || typeof pointer.pointer !== "string") {
+        let str = `The package '${referenceStr}' is missing a required value!`
+        console.log(str);
+        results.push(str);
+        continue;
+      }
+
+      /**
+        1. Find the latest version for this pacakge.
+        2. Collect that version from the DB
+        3. Find the `created` timestamp of that version
+        4. Update the DB for the packages `updated` column to match it's latest versions
+           `created` column.
+      */
+
+      let pack = await getPackageData(pointer.pointer);
+
+      if (!pack.ok) {
+        results.push(`Failed to collect package data for ${referenceStr}`);
+        continue;
+      }
+
+      let latestVer = pack.content?.metadata?.version;
+
+      if (typeof latestVer !== "string") {
+        results.push(`Failed to determine latest version for ${referenceStr}`);
+        continue;
+      }
+
+      // Get this latest version
+      let verData = await getVersionData(pointer.pointer, latestVer);
+
+      if (!verData.ok) {
+        results.push(`Failed to collect package version data for ${referenceStr}`);
+        continue;
+      }
+
+      let verCreation = verData.content?.created;
+      let originalCreation = pack.content?.updated;
+
+      if (typeof verCreation !== "string") {
+        results.push(`Failed to collect created date of ${referenceStr} for version: '${latestVer}'`);
+        continue;
+      }
+
+      let updatePack = await modifyPackUpdatedDate(pointer.pointer, verCreation);
+
+      if (!updatePack.ok) {
+        results.push(`Failed to update package 'updated' timestamp ${referenceStr}`);
+        continue;
+      }
+
+      results.push(`Successfully updated ${referenceStr}; from '${originalCreation}' to '${verCreation}'`);
+
+    } catch(err) {
+      console.error(err);
+      const str = `Critical error occured for '${pointer.pointer}': '${err.toString()}'`
+      console.error(str);
+      console.error("Waiting 5 seconds for manual intervention!");
+      await new Promise((r) => setTimeout(r, 5000));
+      // ^^ Allow a small timeout to ensure I can quite if something has gone
+      // TERRIBLY wrong.
+      console.log("Continuing run...");
+      results.push(str);
+    }
+  }
+
+  fs.writeFileSync(`${__dirname}/fix-updated-column.results.json`, JSON.stringify(results, null, 2));
+  console.log(results);
+  console.log("\n\nTask Completed!");
+  await sqlEnd();
+  process.exit(0);
+}
+
+function setupSQL() {
+  try {
+    sqlStorage = postgres({
+      host: DB_HOST,
+      username: DB_USER,
+      password: DB_PASS,
+      database: DB_DB,
+      port: DB_PORT,
+      ssl: {
+        rejectUnauthorized: true,
+        ca: fs.readFileSync(DB_SSL_CERT).toString(),
+      },
+    });
+    return sqlStorage;
+  } catch (err) {
+    console.log(err);
+    process.exit(100);
+  }
+}
+
+async function getPointers() {
+  sqlStorage ??= setupSQL();
+
+  const command = await sqlStorage`
+    SELECT * FROM names;
+  `;
+
+  if (command.count === 0) {
+    console.log("Failed to get all package pointers.");
+    await sqlEnd();
+    process.exit(1);
+  }
+  return command;
+}
+
+async function sqlEnd() {
+  if (sqlStorage !== undefined) {
+    await sqlStorage.end();
+    console.log("SQL Server Disconnected!");
+  }
+  return;
+}
+
+async function getPackageData(pointer) {
+  sqlStorage ??= setupSQL();
+
+  const command = await sqlStorage`
+    SELECT * from packages
+    WHERE pointer = ${pointer}
+  `;
+
+  if (command.count === 0) {
+    return { ok: false, content: `Failed to get package data of ${pointer}` };
+  }
+  return { ok: true, content: command[0] };
+}
+
+async function getVersionData(pointer, ver) {
+  sqlStorage ??= setupSQL();
+
+  const command = await sqlStorage`
+    SELECT * FROM versions
+    WHERE package = ${pointer} AND semver = ${ver}
+  `;
+
+  if (command.count === 0) {
+    return { ok: false, content: `Failed to get pacakge version data of ${pointer}` };
+  } else {
+    return { ok: true, content: command[0] };
+  }
+}
+
+async function modifyPackUpdatedDate(pointer, newDate) {
+  sqlStorage ??= setupSQL();
+
+  const command = await sqlStorage`
+    UPDATE packages
+    SET updated = ${newDate}
+    WHERE pointer = ${pointer};
+  `;
+
+  if (command.count === 0) {
+    return { ok: false, content: `Failed to update package '${pointer}' with new date: '${newDate}'` };
+  } else {
+    return { ok: true, content: command[0] };
+  }
+}
+
+(async () => {
+  await init();
+})();

--- a/scripts/tools/fix-updated-column.js
+++ b/scripts/tools/fix-updated-column.js
@@ -34,7 +34,7 @@ async function init(params) {
       pointerIdx++;
 
       if (typeof pointer.name !== "string" || typeof pointer.pointer !== "string") {
-        let str = `The package '${referenceStr}' is missing a required value!`
+        let str = `The package '${referenceStr}' is missing a required value!`;
         console.log(str);
         results.push(str);
         continue;
@@ -89,7 +89,7 @@ async function init(params) {
 
     } catch(err) {
       console.error(err);
-      const str = `Critical error occured for '${pointer.pointer}': '${err.toString()}'`
+      const str = `Critical error occured for '${pointer.pointer}': '${err.toString()}'`;
       console.error(str);
       console.error("Waiting 5 seconds for manual intervention!");
       await new Promise((r) => setTimeout(r, 5000));

--- a/src/controllers/getPackagesPackageNameVersionsVersionNameTarball.js
+++ b/src/controllers/getPackagesPackageNameVersionsVersionNameTarball.js
@@ -127,8 +127,7 @@ module.exports = {
     ];
 
     if (
-      !allowedHostnames.includes(hostname) &&
-      process.env.PULSAR_STATUS !== "dev"
+      !allowedHostnames.includes(hostname)
     ) {
       const sso = new context.sso();
 

--- a/tests/full/getPackagesPackageNameVersionsVersionNameTarball.test.js
+++ b/tests/full/getPackagesPackageNameVersionsVersionNameTarball.test.js
@@ -40,6 +40,52 @@ describe("GET /api/packages/:packageName/version/:versionName/tarball", () => {
     expect(removePkg.ok).toBe(true);
   });
 
+  test("Doesn't return tarball link to non-GitHub domain", async () => {
+    // == Setup
+    const addPkg = await database.insertNewPackage(
+      genPackage("https://github.com/confused-Techie/dwnld-pkg-bad-test", {
+        tarballUrl: "https://evil.malware/virus"
+      })
+    );
+    expect(addPkg.ok).toBe(true);
+
+    // == Test
+    const res = await supertest(app)
+      .get("/api/packages/dwnld-pkg-bad-test/versions/1.0.0/tarball");
+
+    expect(res).toHaveHTTPCode(500);
+    expect(res.body.message).toBe(
+      "Application Error: Invalid Domain for Download Redirect: evil.malware"
+    );
+
+    // == Cleanup
+    const removePkg = await database.removePackageByName("dwnld-pkg-bad-test", true);
+    expect(removePkg.ok).toBe(true);
+  });
+
+  test("Doesn't return tarball link to invalid domain", async () => {
+    // == Setup
+    const addPkg = await database.insertNewPackage(
+      genPackage("https://github.com/confused-Techie/dwnld-pkg-malformed-test", {
+        tarballUrl: "malformed-domain-data"
+      })
+    );
+    expect(addPkg.ok).toBe(true);
+
+    // == Test
+    const res = await supertest(app)
+      .get("/api/packages/dwnld-pkg-malformed-test/versions/1.0.0/tarball");
+
+    expect(res).toHaveHTTPCode(500);
+    expect(res.body.message).toBe(
+      "Application Error: The URL to download this package seems invalid: malformed-domain-data."
+    );
+
+    // == Cleanup
+    const removePkg = await database.removePackageByName("dwnld-pkg-malformed-test", true);
+    expect(removePkg.ok).toBe(true);
+  });
+
   test("Updates the download count of a package", async () => {
     // == Setup
     const addPkg = await database.insertNewPackage(

--- a/tests/full/getPackagesPackageNameVersionsVersionNameTarball.test.js
+++ b/tests/full/getPackagesPackageNameVersionsVersionNameTarball.test.js
@@ -1,0 +1,110 @@
+const supertest = require("supertest");
+const nock = require("nock");
+const app = require("../../src/setupEndpoints.js");
+const database = require("../../src/database/_export.js");
+const genPackage = require("../helpers/package.jest.js");
+
+describe("GET /api/packages/:packageName/version/:versionName/tarball", () => {
+  beforeAll(() => {
+    nock.disableNetConnect();
+    nock.enableNetConnect("127.0.0.1");
+  });
+
+  afterAll(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test("Returns valid GitHub Tarball Link", async () => {
+    // == Setup
+    const addPkg = await database.insertNewPackage(
+      genPackage("https://github.com/confused-Techie/dwnld-pkg-test", {
+        tarballUrl: "https://api.github.com/repos/confused-Techie/dwnld-pkg-test/tarball/refs/tags/v1.0.0"
+      })
+    );
+    expect(addPkg.ok).toBe(true);
+
+    // == Test
+    const res = await supertest(app)
+      .get("/api/packages/dwnld-pkg-test/versions/1.0.0/tarball");
+
+    expect(res).toHaveHTTPCode(302);
+    expect(res.headers["location"]).toBe("https://api.github.com/repos/confused-Techie/dwnld-pkg-test/tarball/refs/tags/v1.0.0");
+
+    // == Cleanup
+    const removePkg = await database.removePackageByName("dwnld-pkg-test", true);
+    expect(removePkg.ok).toBe(true);
+  });
+
+  test("Updates the download count of a package", async () => {
+    // == Setup
+    const addPkg = await database.insertNewPackage(
+      genPackage("https://github.com/confused-Techie/dwnld-pkg-update-test", {
+        tarballUrl: "https://api.github.com/repos/confused-Techie/dwnld-pkg-update-test/tarball/refs/tags/v1.0.0"
+      })
+    );
+
+    expect(addPkg.ok).toBe(true);
+
+    // == Tests
+    const pkgObj = await supertest(app)
+      .get("/api/packages/dwnld-pkg-update-test");
+    expect(pkgObj).toHaveHTTPCode(200);
+
+    const downloadsOriginal = pkgObj.body.downloads;
+
+    const res = await supertest(app)
+      .get("/api/packages/dwnld-pkg-update-test/versions/1.0.0/tarball");
+
+    expect(res).toHaveHTTPCode(302);
+
+    const pkgObjNew = await supertest(app)
+      .get("/api/packages/dwnld-pkg-update-test");
+    expect(pkgObjNew).toHaveHTTPCode(200);
+    const downloadsNew = pkgObjNew.body.downloads;
+
+    expect(parseInt(downloadsNew)).toBe(parseInt(downloadsOriginal) + 1);
+
+    // == Cleanup
+    const removePkg = await database.removePackageByName("dwnld-pkg-update-test", true);
+    expect(removePkg.ok).toBe(true);
+  });
+
+  test("Downloading a package doesn't modify the `updated` column", async () => {
+    // == Setup
+    const addPkg = await database.insertNewPackage(
+      genPackage("https://github.com/confused-Techie/dwnld-pkg-count-test", {
+        tarballUrl: "https://api.github.com/repos/confused-Techie/dwnld-pkg-count-test/tarball/refs/tags/v1.0.0"
+      })
+    );
+
+    expect(addPkg.ok).toBe(true);
+
+    // == Tests
+    const pkgObj = await database.getPackageByName("dwnld-pkg-count-test");
+    expect(pkgObj.ok).toBe(true);
+    const updatedOriginal = pkgObj.content.updated;
+
+    // Wait a second to ensure the time will be different
+    await new Promise((r) => setTimeout(r, 2000));
+
+    const res = await supertest(app)
+      .get("/api/packages/dwnld-pkg-count-test/versions/1.0.0/tarball");
+
+    expect(res).toHaveHTTPCode(302);
+
+    const pkgObjNew = await database.getPackageByName("dwnld-pkg-count-test");
+    expect(pkgObjNew.ok).toBe(true);
+    const updatedNew = pkgObjNew.content.updated;
+
+    expect(updatedOriginal).toEqual(updatedNew);
+
+    // == Cleanup
+    const removePkg = await database.removePackageByName("dwnld-pkg-count-test", true);
+    expect(removePkg.ok).toBe(true);
+  });
+});

--- a/tests/helpers/package.jest.js
+++ b/tests/helpers/package.jest.js
@@ -36,7 +36,7 @@ module.exports = function genPackage(repo, opts = {}) {
   let versionInfo = {
     name: pack.name,
     dist: {
-      tarball: "download-url",
+      tarball: opts.tarballUrl ?? "download-url",
       sha: "1234",
     },
   };


### PR DESCRIPTION
### Requirements 

* Filling out the template is required.
* All new code requires tests to ensure against regressions.
  - However, if your PR contains zero code changes, feel free to select the checkmark below to indicate so.

* [X] Have you ran tests against this code?
* [ ] This PR contains zero code changes.

### Description of the Change

Previously any change of a package would trigger a function that would modify the `updated` column of the package. But that meant that when the `download` count of a package was changed, this would also trigger the same function. Making the `updated` column worthless, since it's intended to track the last time a version was published or the name was changed, etc.

This PR resolves that, only changing the `updated` column if the new download count and previous download count match, indicated the function wasn't triggered because of a download count change.

I've also added some tests around the download behavior to verify this.

---

You'll notice I changed the database schema slightly differently. Previously, I've always just made the changes directly in `0001-initial-migrations.sql`, but I've since read up on best practices to discover that you're not supposed to do that. Instead you're supposed to add a new file for each change. So in this PR I'm now following that practice.

If this PR gets merged, I'll ensure to run those new migrations on the production database prior to deploying the new version.

Closes #263 
