### PR TITLE
Add endpoint `/api/packages/:packageName/availability`

### DIFF
--- a/src/controllers/endpoints.js
+++ b/src/controllers/endpoints.js
@@ -26,6 +26,7 @@ module.exports = [
   require("./getPackagesPackageNameVersionsVersionNameTarball.js"),
   require("./getPackagesPackageNameVersionsVersionName.js"),
   require("./getPackagesPackageNameStargazers.js"),
+  require("./getPackagesPackageNameAvailability.js"),
   require("./getPackagesPackageName.js"),
   require("./postPackagesPackageNameVersionsVersionNameEventsUninstall.js"),
   require("./postPackagesPackageNameVersions.js"),

--- a/src/controllers/getPackagesPackageNameAvailability.js
+++ b/src/controllers/getPackagesPackageNameAvailability.js
@@ -1,0 +1,109 @@
+/**
+ * @module getPackagesPackageNameAvailability
+*/
+
+module.exports = {
+  docs: {
+    summary: "Check if a package name is available.",
+    responses: {
+      204: {
+        description: "An empty response, indicating the package name is available for use."
+      },
+      409: {
+        description: "Indicates that the requested package name is taken, and is NOT available.",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object"
+            }
+          }
+        }
+      }
+    }
+  },
+  endpoint: {
+    method: "GET",
+    paths: ["/api/packages/:packageName/availability", "/api/themes/:packageName/availability"],
+    rateLimit: "generic",
+    successStatus: 204,
+    options: {
+      Allow: "GET",
+      "X-Content-Type-Options": "nosniff"
+    }
+  },
+  params: {
+    packageName: (context, req) => {
+      return context.query.packageName(req);
+    }
+  },
+
+  /**
+   * @async
+   * @memberOf getPackagesPackageNameAvailability
+   * @function logic
+   * @desc Informs the requester of the availability of a package name on the database.
+   * @param {object} params - The available query parameters.
+   * @param {object} context - The Endpoint Context
+   * @returns {sso}
+  */
+  async logic(params, context) {
+    const callStack = new context.callStack();
+
+    // Is the name banned?
+    const isBanned = await context.utils.isPackageNameBanned(params.packageName);
+
+    callStack.addCall("utils.isPackageNameBanned", isBanned);
+
+    if (isBanned.ok) {
+      // The package name is in fact banned
+      const sso = new context.sso();
+
+      return sso
+        .notOk()
+        .addShort("package_exists")
+        .assignCalls(callStack);
+    }
+
+    // Is the name of a bundled package?
+    const isBundled = context.bundled.isNameBundled(params.packageName);
+
+    callStack.addCall("bundled.isNameBundled", isBundled);
+
+    if (isBundled.ok && isBundled.content) {
+      // This is in fact a bundled package
+      const sso = new context.sso();
+
+      return sso
+        .notOk()
+        .addShort("package_exists")
+        .assignCalls(callStack);
+    }
+
+    // Is the name taken by another package?
+    const nameAvailable = await context.database.packageNameAvailability(params.packageName);
+
+    callStack.addCall("db.packageNameAvailability", nameAvailable);
+
+    if (!nameAvailable.ok) {
+      // We need to ensure the error is not found or otherwise
+      if (nameAvailable.short !== "not_found") {
+        // the server failed for some other reason
+        const sso = new context.sso();
+
+        return sso.notOk().addContent(nameAvailable).assignCalls(callStack);
+      }
+      // But if the short is "not_found" we can report the package as not being available
+      const sso = new context.sso();
+
+      return sso
+        .notOk()
+        .addShort("package_exists")
+        .assignCalls(callStack);
+    }
+
+    // Otherwise the package name is available
+    const sso = new context.sso();
+
+    return sso.isOk().addContent(false);
+  }
+};

--- a/tests/full/getPackagesPackageNameAvailability.test.js
+++ b/tests/full/getPackagesPackageNameAvailability.test.js
@@ -1,0 +1,74 @@
+const supertest = require("supertest");
+const nock = require("nock");
+const app = require("../../src/setupEndpoints.js");
+const database = require("../../src/database/_export.js");
+const genPackage = require("../helpers/package.jest.js");
+
+describe("GET /api/packages/:packageName/availability", () => {
+  beforeAll(() => {
+    nock.disableNetConnect();
+    nock.enableNetConnect("127.0.0.1");
+  });
+
+  afterAll(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test("Informs of an available name", async () => {
+    // == Test
+    const res = await supertest(app).get(
+      "/api/packages/a-package-name-that-will-likely-never-be-taken-ever-ever/availability"
+    );
+
+    expect(res).toHaveHTTPCode(204);
+    expect(Object.keys(res.body).length).toBe(0);
+  });
+
+  test("Informs of a banned name", async () => {
+    // == Test
+    const res = await supertest(app).get(
+      "/api/packages/test-package/availability"
+    );
+
+    expect(res).toHaveHTTPCode(409);
+    expect(res.body.message).toBe("A Package by that name already exists.");
+  });
+
+  test("Informs of a bundled name", async () => {
+    // == Test
+    const res = await supertest(app).get(
+      "/api/packages/autocomplete-plus/availability"
+    );
+
+    expect(res).toHaveHTTPCode(409);
+    expect(res.body.message).toBe("A Package by that name already exists.");
+  });
+
+  test("Informs of a taken name by a community package", async () => {
+    // == Setup
+    const addPkg = await database.insertNewPackage(
+      genPackage("https://github.com/confused-Techie/my-awesome-package")
+    );
+    expect(addPkg.ok).toBe(true);
+
+    // == Test
+    const res = await supertest(app).get(
+      "/api/packages/my-awesome-package/availability"
+    );
+
+    expect(res).toHaveHTTPCode(409);
+    expect(res.body.message).toBe("A Package by that name already exists.");
+
+    // == Cleanup
+    const removePkg = await database.removePackageByName(
+      "my-awesome-package",
+      true
+    );
+    expect(removePkg.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
It's occurred to me, that there's no easy way for a package author to check if the name they want is available.

They could search the package's website, but that won't tell them if a package has been deleted, is banned, or is otherwise unavailable.

Even when you publish a package, PPM just checks if there's a package currently published and healthy under that name, having no way to truly know.

So I thought it'd be a good idea to implement a new endpoint: `/api/packages/:packageName/availability`, which could allow API users to check if a package name is truly available.

Ideally, we'd implement this endpoint into PPMs own check, and maybe even add a way to check this online for authors. But in any case, this would be the first step into making that possible.
