### PR TITLE
Implement Trending Packages into Backend

### DIFF
--- a/scripts/migrations/0003-download-table.sql
+++ b/scripts/migrations/0003-download-table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE package_downloads_daily (
+  pointer UUID NOT NULL REFERENCES packages(pointer),
+  download_date DATE NOT NULL DEFAULT CURRENT_DATE,
+  downloads BIGINT NOT NULL DEFAULT 1,
+  PRIMARY KEY (pointer, download_date)
+);
+
+-- Improve performance of these scans by indexing the date
+CREATE INDEX idx_downloads_date ON package_downloads_daily(download_date);

--- a/src/database/getTrendingByRange.js
+++ b/src/database/getTrendingByRange.js
@@ -1,0 +1,33 @@
+/**
+ * @async
+ * @function getTrendingByRange
+ * @description Get trending packages, according to downloads, based on a specified range.
+ * @param {string} range
+ * @returns {object} A server status object
+*/
+
+const { paginated_amount } = require("../config.js").getConfig();
+
+module.exports = {
+  safe: true,
+  exec: async (sql, range = "7 days") => {
+    // TODO: Implement sanitizing of range here? Or should we trust endpoint APIs will do it well enough?
+
+    const command = await sql`
+      SELECT pointer, SUM(download_count) AS total_downloads
+      FROM package_downloads_daily
+      WHERE download_date >= CURRENT_DATE - INTERVAL ${range}
+      GROUP BY pointer
+      ORDER BY total_downloads DESC
+      LIMIT ${paginated_amount};
+    `;
+
+    return command.count !== 0
+      ? { ok: true, content: command[0] }
+      : {
+          ok: false,
+          content: `Unable to determine trending for '${range}'`,
+          short: "server_error"
+        };
+  },
+};

--- a/src/database/removePackageByName.js
+++ b/src/database/removePackageByName.js
@@ -39,11 +39,20 @@ module.exports = {
         }
 
         // Remove stars assigned to the package
+        // Don't expect results, as a package may have no stars
         await sqlTrans`
            DELETE FROM stars
            WHERE package = ${pointer}
            RETURNING userid;
          `;
+
+        // Remove download statistics for the package
+        // Don't expect results, as a package may have no downloads
+        await sqlTrans`
+          DELETE FROM package_downloads_daily
+          WHERE pointer = ${pointer}
+          RETURNING downloads;
+        `;
 
         const commandPack = await sqlTrans`
            DELETE FROM packages

--- a/src/database/updatePackageIncrementDownloadByName.js
+++ b/src/database/updatePackageIncrementDownloadByName.js
@@ -41,8 +41,9 @@ module.exports = {
           }
 
           dailyDwnCount = await sqlTrans`
-            INSERT INTO package_downloads_daily (pointer, download_date, downloads)
-            VALUES(${pack.content.pointer}, CURRENT_DATE, 1)
+            INSERT INTO package_downloads_daily
+            (pointer, download_date, downloads) VALUES
+            (${pack.content.pointer}, CURRENT_DATE, 1)
             ON CONFLICT (pointer, download_date)
             DO UPDATE SET download_count = package_downloads_daily.download_count + 1;
           `;

--- a/src/database/updatePackageIncrementDownloadByName.js
+++ b/src/database/updatePackageIncrementDownloadByName.js
@@ -6,23 +6,68 @@
  * @returns {object} The modified server status object.
  */
 
+const getPackageByName = require("./getPackageByName.js").exec;
+
 module.exports = {
   safe: false,
   exec: async (sql, name) => {
-    const command = await sql`
-      UPDATE packages AS p
-      SET downloads = p.downloads + 1
-      FROM names AS n
-      WHERE n.pointer = p.pointer AND n.name = ${name}
-      RETURNING p.name, p.downloads;
-    `;
 
-    return command.count !== 0
-      ? { ok: true, content: command[0] }
-      : {
-          ok: false,
-          content: "Unable to Update Package Download",
-          short: "Server Error",
+    return await sql
+      .begin(async (sqlTrans) => {
+        // Modify package global download count
+        let dwnCount = {};
+        try {
+          dwnCount = await sqlTrans`
+            UPDATE packages AS p
+            SET downloads = p.downloads + 1
+            FROM names AS n
+            WHERE n.pointer = p.pointer AND n.name = ${name}
+            RETURNING p.name, p.downloads;
+          `;
+        } catch(e) {
+          throw `A constraint has been violated while updating global download count of '${name}'`;
+        }
+
+        if (!dwnCount.count) {
+          throw `Cannot update global download count of '${name}'`;
+        }
+
+        let dailyDwnCount = {};
+        try {
+          const pack = await getPackageByName(sql, name);
+
+          if (!pack.ok) {
+            return pack;
+          }
+
+          dailyDwnCount = await sqlTrans`
+            INSERT INTO package_downloads_daily (pointer, download_date, downloads)
+            VALUES(${pack.content.pointer}, CURRENT_DATE, 1)
+            ON CONFLICT (pointer, download_date)
+            DO UPDATE SET download_count = package_downloads_daily.download_count + 1;
+          `;
+        } catch(e) {
+          throw `A constraint has been violated while updating daily download count of '${name}'`;
+        }
+
+        if (!dailyDwnCount.count) {
+          throw `Cannot update daily download count of '${name}'`;
+        }
+
+        return {
+          ok: true,
+          content: dwnCount[0]
         };
+      })
+      .catch((err) => {
+        return typeof err === "string"
+          ? { ok: false, content: err, short: "server_error" }
+          : {
+              ok: false,
+              content: `A generic error occurred while updating the download count for ${name}`,
+              short: "server_error",
+              error: err
+            };
+      });
   },
 };

--- a/src/database/updatePackageIncrementDownloadByName.js
+++ b/src/database/updatePackageIncrementDownloadByName.js
@@ -45,7 +45,7 @@ module.exports = {
             (pointer, download_date, downloads) VALUES
             (${pack.content.pointer}, CURRENT_DATE, 1)
             ON CONFLICT (pointer, download_date)
-            DO UPDATE SET download_count = package_downloads_daily.download_count + 1;
+            DO UPDATE SET downloads = package_downloads_daily.downloads + 1;
           `;
         } catch(e) {
           throw `A constraint has been violated while updating daily download count of '${name}'`;


### PR DESCRIPTION
Per popular request, this PR finally implements a "Trending" feature into the backend.

Since currently we only have a simple "download" count per package, there's never been any way to track when a package is downloaded (or even if those downloads happened pre-Pulsar). But this PR finally implements what we need to do just that.

This PR creates a new table, that tracks the download download of each package. Creating an entry for a package per day as it's download. Allowing us an aggregate count of how many times a day a package is downloaded.

Which we can then in turn use SQL to get the total download count over any arbitrary time interval.

Although, this PR just contains some of the first steps, a more complete look of what we need to do between this PR and having this feature live looks like:

* [ ] Add API endpoints to retrieve trending counts
* [ ] Add tests for new API endpoint, and new DB behavior
* [ ] Ideally, add caching mechanism for these counts, as a query per user can be expensive
* [ ] Add new microservice to automatically clean up this new DB over time, so we don't retain information forever.
* [ ] Implement this new API endpoint into the packages website
* [ ] Implement this new API endpoint into `settings-view`

Some key questions we may want to consider now that this is being worked on:
- Many services track trending across the download/uninstall ratio. We already have a no-op endpoint, inherited from Atom, of when a user uninstalls a package. Should that now update a packages download trend?
- With a proper trending implementation, should we discontinue the previous "Featured Packages"? We rarely updated it as is, and I'd imagine this would replace it's spot on the packages website, but what do we think?