### PR TITLE
Add new query packs for CodeQL Scanning

### DIFF
--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -5,7 +5,6 @@ queries:
   - uses: security-extended
   - uses: security-and-quality
   - uses: codeql/javascript-queries
-  - uses: codeql/javascript
 
 paths-ignore:
   - ./test

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -4,7 +4,7 @@ queries:
   - uses: default
   - uses: security-extended
   - uses: security-and-quality
-  - uses: codeql/javascript-queries
+  - uses: javascript-queries
 
 paths-ignore:
   - ./test

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,8 +1,11 @@
 name: "CodeQL Config"
 
 queries:
+  - uses: default
   - uses: security-extended
   - uses: security-and-quality
+  - uses: codeql/javascript-queries
+  - uses: codeql/javascript
 
 paths-ignore:
   - ./test


### PR DESCRIPTION
Was reading up on GitHub's advanced security tools, and discovered that there were some additional query packs we could take advantage of within this repository.

All this does is mean we are testing for even more rulesets to detect vulnerabilities.

EDIT

Apparently, I've misread.
The `default` query set is used to build the other two that are included. It cannot be required standalone. And the `javascript-queries` seems to be Something else more internal.
