### PR TITLE
Use built-in `node:crypto`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.0.0",
-        "crypto": "^1.0.1",
         "cson": "^7.20.0",
         "express": "^5.0.0",
         "express-rate-limit": "^6.7.0",
@@ -3017,12 +3016,6 @@
       "bin": {
         "semver": "bin/semver"
       }
-    },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
     "node_modules/cson": {
       "version": "7.20.0",
@@ -11837,11 +11830,6 @@
           "dev": true
         }
       }
-    },
-    "crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
     },
     "cson": {
       "version": "7.20.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^7.0.0",
-    "crypto": "^1.0.1",
     "cson": "^7.20.0",
     "express": "^5.0.0",
     "express-rate-limit": "^6.7.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,7 @@
  */
 const logger = require("./logger.js");
 const storage = require("./storage.js");
-const crypto = require("crypto");
+const crypto = require("node:crypto");
 
 /**
  * @async


### PR DESCRIPTION
This PR removes using the deprecated dependency `crypto` and switches instead to the built-in module `node:crypto`.
Which are identical, but the former is no longer recommended to install.