### PR TITLE
Search by `creationMethod`

### DIFF
--- a/src/controllers/getPackages.js
+++ b/src/controllers/getPackages.js
@@ -49,6 +49,9 @@ module.exports = {
     owner: (context, req) => {
       return context.query.owner(req);
     },
+    creationMethod: (context, req) => {
+      return context.query.creationMethod(req);
+    },
   },
 
   /**

--- a/src/controllers/getPackagesSearch.js
+++ b/src/controllers/getPackagesSearch.js
@@ -55,6 +55,9 @@ module.exports = {
     owner: (context, req) => {
       return context.query.owner(req);
     },
+    creationMethod: (context, req) => {
+      return context.query.creationMethod(req);
+    },
   },
 
   /**

--- a/src/database/_clause.js
+++ b/src/database/_clause.js
@@ -80,6 +80,24 @@ function fileExtensionClause(sql, opts) {
   return sql`AND ${opts.fileExtension}=ANY(v.supported_languages)`;
 }
 
+function creationMethodClause(sql, opts) {
+  console.log("BREAKPOINT");
+  console.log(`creationMethodClause: ${opts.creationMethod}`);
+  if (typeof opts.creationMethod !== "string") {
+    return getEmptyClause(sql);
+  }
+
+  switch(opts.creationMethod) {
+    case "pulsar":
+      return sql`AND p.creation_method = 'User Made Package'`;
+    case "atom":
+      return sql`AND p.creation_method = 'Migrated from Atom.io'`;
+    case "any":
+    default:
+      return getEmptyClause(sql);
+  }
+}
+
 module.exports = {
   getEmptyClause,
   queryClause,
@@ -88,4 +106,5 @@ module.exports = {
   ownerNameClause,
   serviceClause,
   fileExtensionClause,
+  creationMethodClause,
 };

--- a/src/database/_clause.js
+++ b/src/database/_clause.js
@@ -81,8 +81,6 @@ function fileExtensionClause(sql, opts) {
 }
 
 function creationMethodClause(sql, opts) {
-  console.log("BREAKPOINT");
-  console.log(`creationMethodClause: ${opts.creationMethod}`);
   if (typeof opts.creationMethod !== "string") {
     return getEmptyClause(sql);
   }

--- a/src/database/getSortedPackages.js
+++ b/src/database/getSortedPackages.js
@@ -60,6 +60,7 @@ module.exports = {
         ${clause.fileExtensionClause(sql, opts)}
         ${clause.ownerClause(sql, opts)}
         ${clause.ownerNameClause(sql, opts)}
+        ${clause.creationMethodClause(sql, opts)}
 
         ORDER BY p.name, v.semver_v1 DESC, v.semver_v2 DESC, v.semver_v3 DESC, v.created DESC
       )

--- a/src/query_parameters/creationMethod.js
+++ b/src/query_parameters/creationMethod.js
@@ -1,0 +1,25 @@
+/**
+ * @function creationMethod
+*/
+module.exports = {
+  schema: {
+    name: "creationMethod",
+    in: "query",
+    schema: {
+      type: "string",
+      enum: ["any", "pulsar", "atom"],
+      default: "any"
+    },
+    example: "pulsar",
+    allowEmptyValue: true,
+    description: "Return only packages with the specified creation method."
+  },
+  logic: (req) => {
+    const def = "any";
+    const valid = ["pulsar", "atom"];
+
+    const prov = req.query.creationMethod;
+
+    return valid.includes(prov) ? prov : def;
+  }
+};

--- a/src/query_parameters/index.js
+++ b/src/query_parameters/index.js
@@ -6,6 +6,7 @@
  */
 
 const auth = require("./auth.js");
+const creationMethod = require("./creationMethod.js");
 const direction = require("./direction.js");
 const engine = require("./engine.js");
 const fileExtension = require("./fileExtension.js");
@@ -28,6 +29,7 @@ const versionName = require("./versionName.js");
 module.exports = {
   logic: {
     auth: auth.logic,
+    creationMethod: creationMethod.logic,
     direction: direction.logic,
     engine: engine.logic,
     fileExtension: fileExtension.logic,
@@ -49,6 +51,7 @@ module.exports = {
   },
   schema: {
     auth: auth.schema,
+    creationMethod: creationMethod.schema,
     direction: direction.schema,
     engine: engine.schema,
     fileExtension: fileExtension.schema,

--- a/tests/full/getPackagesSearch.test.js
+++ b/tests/full/getPackagesSearch.test.js
@@ -28,6 +28,7 @@ describe("GET /api/packages/search", () => {
             extraVersionData: {
               theme: "syntax",
             },
+            creation_method: "User Made Package" // Pulsar package
           }
         )
       );
@@ -35,7 +36,10 @@ describe("GET /api/packages/search", () => {
 
       const addPkg2 = await database.insertNewPackage(
         genPackage(
-          "https://github.com/getPackagesSearch/get-packages-search-test"
+          "https://github.com/getPackagesSearch/get-packages-search-test",
+          {
+            creation_method: "Migrated from Atom.io" // Atom package
+          }
         )
       );
       expect(addPkg2.ok).toBe(true);
@@ -111,6 +115,41 @@ describe("GET /api/packages/search", () => {
       expect(res).toHaveHTTPCode(200);
       expect(res.body).toBeArray();
       expect(res.body.length).toBe(0);
+    });
+
+    test("By 'creationMethod' field: Include Pulsar packages", async () => {
+      const res = await supertest(app)
+        .get("/api/packages/search")
+        .query({ q: "get" })
+        .query({ creationMethod: "pulsar" });
+
+      expect(res).toHaveHTTPCode(200);
+      expect(res.body).toBeArray();
+      expect(res.body.length).toBe(1);
+      expect(res.body[0].name).toBe("get-packages-search-theme-test");
+    });
+
+    test("By 'creationMethod' field: Include Atom packages", async () => {
+      const res = await supertest(app)
+        .get("/api/packages/search")
+        .query({ q: "get" })
+        .query({ creationMethod: "atom" });
+
+      expect(res).toHaveHTTPCode(200);
+      expect(res.body).toBeArray();
+      expect(res.body.length).toBe(1);
+      expect(res.body[0].name).toBe("get-packages-search-test");
+    });
+
+    test("By 'creationMethod' field: Include all packages", async () => {
+      const res = await supertest(app)
+        .get("/api/packages/search")
+        .query({ q: "get" })
+        .query({ creationMethod: "any" });
+
+      expect(res).toHaveHTTPCode(200);
+      expect(res.body).toBeArray();
+      expect(res.body.length).toBe(2);
     });
   });
 });

--- a/tests/helpers/package.jest.js
+++ b/tests/helpers/package.jest.js
@@ -27,7 +27,7 @@ module.exports = function genPackage(repo, opts = {}) {
   pack.owner = parsedGH.owner;
 
   // Static Info
-  pack.creation_method = "Test Package";
+  pack.creation_method = opts.creation_method ?? "Test Package";
   pack.readme = "This is a readme!";
   pack.versions = {};
   pack.releases = {};


### PR DESCRIPTION
This PR introduces the ability to search & sort packages by the new query parameter `creationMethod`.

This parameter can be one of the following values:
* `any`: Behaves just like it does now, returning packages with any creation method.
* `atom`: Returns only packages that were originally migrated from Atom.
* `pulsar`: Returns only packages that have been created for Pulsar.
> The `pulsar` results will match packages that have the badge `Made for Pulsar`

The new query is supported on the following endpoints:
* `GET /api/packages`
* `GET /api/packages/search`

Tests are already included in the new framework to ensure they behave as we expect.

Relates to #231 (but does not close)
